### PR TITLE
Sidecars

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -13,7 +13,8 @@ if (typeof window === 'undefined') {
 var fileUtils = {
 	readFile: readFile,
     readDir: readDir,
-	generateTree: generateTree
+	generateTree: generateTree,
+    relativePath: relativePath
 };
 
 // implementations ----------------------------------------------------------------
@@ -53,18 +54,19 @@ function readFile (file, callback) {
 /**
  * Read Directory
  *
- * Takes a path to a directory and returns an
- * array containing all of the files to a callback.
+ * In node it takes a path to a directory and returns
+ * an array containing all of the files to a callback.
  * Used to input and organize files in node, in a
- * similar structure to how chrome reads a
- * directory.
+ * similar structure to how chrome reads a directory.
+ * In the browser it simply passes the file dir
+ * object to the callback.
  */
-function readDir (path, callback) {
+function readDir (dir, callback) {
     if (fs) {
-        files = getFiles(path);
+        files = getFiles(dir);
         filesObj = {};
-        var str = path.substr(path.lastIndexOf('/') + 1) + '$';
-        var subpath = path.replace(new RegExp(str), '');
+        var str = dir.substr(dir.lastIndexOf('/') + 1) + '$';
+        var subpath = dir.replace(new RegExp(str), '');
         for (var i = 0; i < files.length; i++) {
             filesObj[i] = {
                 name: files[i].substr(files[i].lastIndexOf('/') + 1),
@@ -73,6 +75,8 @@ function readDir (path, callback) {
             };
         }
         callback(filesObj);
+    } else {
+        callback(dir);
     }
 }
 
@@ -140,6 +144,16 @@ function generateTree (files) {
 
     // return tree
     return dirTree;
+}
+
+/**
+ * Relative Path
+ *
+ * Takes a file and returns the correct relative path property
+ * base on the environment.
+ */
+function relativePath (file) {
+    return typeof window != 'undefined' ? file.webkitRelativePath : file.relativePath;
 }
 
 module.exports = fileUtils;

--- a/validators/bids.js
+++ b/validators/bids.js
@@ -5,6 +5,173 @@ var TSV    = require('./tsv');
 var JSON   = require('./json');
 var NIFTI  = require('./nii');
 
+var myObj = {
+
+    errors:   [],
+    warnings: [],
+    sidecars: [],
+
+    /**
+     * Start
+     *
+     */
+    start: function (fileList, callback) {
+        var self = this;
+        self.quickTest(fileList, function (couldBeBIDS) {
+            if (couldBeBIDS) {
+                self.fullTest(fileList, callback);
+            } else {
+                callback('Invalid');
+            }
+        });
+    },
+
+    /**
+     * Quick Test
+     *
+     * A quick test to see if it could be a BIDS
+     * dataset based on structure/naming. If it
+     * could be it will trigger the full validation
+     * otherwise it will throw a callback with a
+     * generic error.
+     */
+    quickTest: function (fileList, callback) {
+        var couldBeBIDS = false;
+        for (var key in fileList) {
+            var file = fileList[key];
+            var path = typeof window != 'undefined' ? file.webkitRelativePath : file.relativePath;
+            if (path) {
+                path = path.split('/');
+                if (path.length > 5) {couldBeBIDS = false; break;}
+                path = path.reverse();
+
+                if (
+                    path[0].indexOf('.nii.gz') > -1 &&
+                    (path[1].indexOf('anatomy') > -1 ||
+                     path[1].indexOf('functional') > -1 ||
+                     path[1].indexOf('diffusion') > -1) &&
+                    (
+                        (path[2] && path[2].indexOf('ses') > -1) ||
+                        (path[2] && path[2].indexOf('sub') > -1)
+                    )
+                ) {
+                    couldBeBIDS = true;
+                    break;
+                }
+            }
+        }
+        callback(couldBeBIDS);
+    },
+
+    /**
+     * Full Test
+     *
+     * Takes on an array of files and starts
+     * the validation process for a BIDS
+     * package.
+     */
+    fullTest: function (fileList, callback) {
+        var self = this;
+        var NifTiFIles = [];
+        var JSONFiles  = [];
+
+        // validate individual files
+        async.forEachOf(fileList, function (file, key, cb) {
+            var path = typeof window != 'undefined' ? file.webkitRelativePath : file.relativePath;
+
+            // validate NifTi
+            if (file.name && file.name.indexOf('.nii') > -1) {
+                NifTiFIles.push(path);
+                // check if NifTi is gzipped
+                if (file.name.indexOf('.gz') === -1) {
+                    var newError = {
+                        evidence: file.name,
+                        line: null,
+                        character: null,
+                        reason: 'NifTi files should be compressed using gzip.',
+                        severity: 'error'
+                    }
+                    
+                    self.errors.push({file: file, errors: [newError]});
+                }
+                cb();
+                return;
+            }
+
+            // validate tsv
+            if (file.name && file.name.indexOf('.tsv') > -1) {
+                utils.readFile(file, function (contents) {
+                    TSV(contents, function (errs, warns) {
+                        if (errs && errs.length > 0) {
+                            self.errors.push({file: file, errors: errs})
+                        }
+                        if (warns && warns.length > 0) {
+                            self.warnings.push({file: file, errors: warns});
+                        }
+                        cb();
+                    });
+                });
+                return;
+            }
+
+            // validate json
+            if (file.name && file.name.indexOf('.json') > -1) {
+                JSONFiles.push(path);
+                utils.readFile(file, function (contents) {
+                    JSON(contents, function (errs) {
+                        if (errs) {
+                            self.errors.push({file: file, errors: errs})
+                        }
+                        cb();
+                    });
+                });
+            } else {
+                cb();
+            }
+        
+        }, function () {
+            self.checkSidecars(NifTiFIles, JSONFiles);
+            callback(self.errors, self.warnings);
+        });
+    },
+
+    /**
+     * Check Sidecars
+     *
+     * Takes an array of all NifTi files and an array
+     * of all JSON files and returns errors for scans
+     * without a corresponding sidecar metadata file.
+     */
+    checkSidecars: function (scans, JSONFiles, callback) {
+
+        var sidecars = [];
+
+        // remove files from the lists that are perfect
+        // matches or scan that do not require sidecars
+        for (var i = scans.length -1; i > -1; i--) {
+            var scan = scans[i];
+
+            // remove perfect matches
+            var scan = scan.replace('.nii.gz', '');
+            var sidecarIndex = JSONFiles.indexOf(scan + '.json');
+            if (sidecarIndex > -1) {
+                scans.splice(i, 1);
+                var sidecar = JSONFiles.splice(sidecarIndex, 1);
+                sidecars.push(sidecar[0]);
+            }
+
+            // remove sbref scans
+            if (scan.indexOf('sbref') > -1) {
+                scans.splice(i, 1);
+            }
+        }
+
+        console.log(scans);
+        console.log(JSONFiles);
+        console.log(sidecars);
+    }
+};
+
 /**
  * BIDS
  *
@@ -16,170 +183,10 @@ var NIFTI  = require('./nii');
  */
 module.exports = function (fileList, callback) {
     if (typeof fileList === 'object') {
-        start(fileList, callback);
+        myObj.start(fileList, callback);
     } else if (typeof fileList === 'string') {
         utils.readDir(fileList, function (files) {
-            start(files, callback);
+            myObj.start(files, callback);
         });
     }
 };
-
-/**
- * Start
- *
- */
-function start (fileList, callback) {
-    quickTest(fileList, function (couldBeBIDS) {
-        if (couldBeBIDS) {
-            fullTest(fileList, callback);
-        } else {
-            callback('Invalid');
-        }
-    });
-}
-
-/**
- * Quick Test
- *
- * A quick test to see if it could be a BIDS
- * dataset based on structure/naming. If it
- * could be it will trigger the full validation
- * otherwise it will throw a callback with a
- * generic error.
- */
-function quickTest (fileList, callback) {
-    var couldBeBIDS = false;
-    for (var key in fileList) {
-        var file = fileList[key];
-        var path = typeof window != 'undefined' ? file.webkitRelativePath : file.relativePath;
-        if (path) {
-            path = path.split('/');
-            if (path.length > 5) {couldBeBIDS = false; break;}
-            path = path.reverse();
-
-            if (
-                path[0].indexOf('.nii.gz') > -1 &&
-                (path[1].indexOf('anatomy') > -1 ||
-                 path[1].indexOf('functional') > -1 ||
-                 path[1].indexOf('diffusion') > -1) &&
-                (
-                    (path[2] && path[2].indexOf('ses') > -1) ||
-                    (path[2] && path[2].indexOf('sub') > -1)
-                )
-            ) {
-                couldBeBIDS = true;
-                break;
-            }
-        }
-    }
-    callback(couldBeBIDS);
-}
-
-/**
- * Full Test
- *
- * Takes on an array of files and starts
- * the validation process for a BIDS
- * package.
- */
-function fullTest (fileList, callback) {
-    var errors     = [];
-    var warnings   = [];
-    var NifTiFIles = [];
-    var JSONFiles  = [];
-
-    // validate individual files
-    async.forEachOf(fileList, function (file, key, cb) {
-        var path = typeof window != 'undefined' ? file.webkitRelativePath : file.relativePath;
-
-        // validate NifTi
-        if (file.name && file.name.indexOf('.nii') > -1) {
-            NifTiFIles.push(path);
-            // check if NifTi is gzipped
-            if (file.name.indexOf('.gz') === -1) {
-                var newError = {
-                    evidence: file.name,
-                    line: null,
-                    character: null,
-                    reason: 'NifTi files should be compressed using gzip.',
-                    severity: 'error'
-                }
-                
-                errors.push({file: file, errors: [newError]});
-            }
-            cb();
-            return;
-        }
-
-        // validate tsv
-        if (file.name && file.name.indexOf('.tsv') > -1) {
-            utils.readFile(file, function (contents) {
-                TSV(contents, function (errs, warns) {
-                    if (errs && errs.length > 0) {
-                        errors.push({file: file, errors: errs})
-                    }
-                    if (warns && warns.length > 0) {
-                        warnings.push({file: file, errors: warns});
-                    }
-                    cb();
-                });
-            });
-            return;
-        }
-
-        // validate json
-        if (file.name && file.name.indexOf('.json') > -1) {
-            JSONFiles.push(path);
-            utils.readFile(file, function (contents) {
-                JSON(contents, function (errs) {
-                    if (errs) {
-                        errors.push({file: file, errors: errs})
-                    }
-                    cb();
-                });
-            });
-        } else {
-            cb();
-        }
-    
-    }, function () {
-        checkSidecars(NifTiFIles, JSONFiles);
-        callback(errors, warnings);
-    });
-}
-
-/**
- * Check Sidecars
- *
- * Takes an array of all NifTi files and an array
- * of all JSON files and returns errors for scans
- * without a corresponding sidecar metadata file.
- */
-function checkSidecars (scans, JSONFiles) {
-
-    var sidecars = [];
-
-    // remove files from the lists that are perfect
-    // matches or scan that do not require sidecars
-    for (var i = scans.length -1; i > -1; i--) {
-        var scan = scans[i];
-
-        // remove perfect matches
-        var scan = scan.replace('.nii.gz', '');
-        var sidecarIndex = JSONFiles.indexOf(scan + '.json');
-        if (sidecarIndex > -1) {
-            scans.splice(i, 1);
-            var sidecar = JSONFiles.splice(sidecarIndex, 1);
-            sidecars.push(sidecar[0]);
-        }
-
-        // remove sbref scans
-        if (scan.indexOf('sbref') > -1) {
-            scans.splice(i, 1);
-        }
-    }
-
-    console.log(scans);
-    console.log(JSONFiles);
-    console.log(sidecars);
-}

--- a/validators/bids.js
+++ b/validators/bids.js
@@ -41,7 +41,7 @@ var BIDS = {
         var couldBeBIDS = false;
         for (var key in fileList) {
             var file = fileList[key];
-            var path = typeof window != 'undefined' ? file.webkitRelativePath : file.relativePath;
+            var path = utils.relativePath(file);
             if (path) {
                 path = path.split('/');
                 if (path.length > 5) {couldBeBIDS = false; break;}
@@ -80,7 +80,7 @@ var BIDS = {
         // collect nifti and json files
         for (var key in fileList) {
             var file = fileList[key];
-            var path = typeof window != 'undefined' ? file.webkitRelativePath : file.relativePath;
+            var path = utils.relativePath(file);
             if (file.name && file.name.indexOf('.nii.gz') > -1) {scans.push(path);}
             if (file.name && file.name.indexOf('.json') > -1)   {JSONFiles.push(path);}
         }
@@ -119,7 +119,7 @@ var BIDS = {
 
         // validate individual files
         async.forEachOf(fileList, function (file, key, cb) {
-            var path = typeof window != 'undefined' ? file.webkitRelativePath : file.relativePath;
+            var path = utils.relativePath(file);
 
             // validate NifTi
             if (file.name && file.name.indexOf('.nii') > -1) {
@@ -157,6 +157,7 @@ var BIDS = {
 
             // validate json
             if (file.name && file.name.indexOf('.json') > -1) {
+                console.log(file);
                 utils.readFile(file, function (contents) {
                     JSON(contents, function (errs) {
                         if (errs) {
@@ -182,15 +183,11 @@ var BIDS = {
  * Takes either a filelist array or
  * a path to a BIDS directory and
  * starts the validation process and
- * returns the errors as an argument
- * to the callback.
+ * returns the errors and warnings as 
+ * arguments to the callback.
  */
-module.exports = function (fileList, callback) {
-    if (typeof fileList === 'object') {
-        BIDS.start(fileList, callback);
-    } else if (typeof fileList === 'string') {
-        utils.readDir(fileList, function (files) {
-            BIDS.start(files, callback);
-        });
-    }
+module.exports = function (dir, callback) {
+    utils.readDir(dir, function (files) {
+        BIDS.start(files, callback);
+    });
 };

--- a/validators/bids.js
+++ b/validators/bids.js
@@ -116,8 +116,6 @@ var BIDS = {
      */
     fullTest: function (fileList, callback) {
         var self = this;
-        var NifTiFIles = [];
-        var JSONFiles  = [];
 
         // validate individual files
         async.forEachOf(fileList, function (file, key, cb) {
@@ -125,7 +123,6 @@ var BIDS = {
 
             // validate NifTi
             if (file.name && file.name.indexOf('.nii') > -1) {
-                NifTiFIles.push(path);
                 // check if NifTi is gzipped
                 if (file.name.indexOf('.gz') === -1) {
                     var newError = {
@@ -160,7 +157,6 @@ var BIDS = {
 
             // validate json
             if (file.name && file.name.indexOf('.json') > -1) {
-                JSONFiles.push(path);
                 utils.readFile(file, function (contents) {
                     JSON(contents, function (errs) {
                         if (errs) {

--- a/validators/bids.js
+++ b/validators/bids.js
@@ -157,9 +157,9 @@ var BIDS = {
 
             // validate json
             if (file.name && file.name.indexOf('.json') > -1) {
-                console.log(file);
+                var isSidecar = self.isSidecar(file);
                 utils.readFile(file, function (contents) {
-                    JSON(contents, function (errs) {
+                    JSON(contents, isSidecar, function (errs) {
                         if (errs) {
                             self.errors.push({file: file, errors: errs})
                         }
@@ -173,8 +173,28 @@ var BIDS = {
         }, function () {
             callback(self.errors, self.warnings);
         });
-    }
+    },
 
+    /**
+     * Is Sidecar
+     *
+     * Takes a file object and returns a boolean value
+     * of whether or not it is a sidecar.
+     */
+    isSidecar: function (file) {
+        return this.sidecars.indexOf(utils.relativePath(file)) > -1;
+    },
+
+    /**
+     * Reset
+     *
+     * Resets the in object data back to original values.
+     */
+    reset: function () {
+        this.errors = [];
+        this.warnings = [];
+        this.sidecars = [];
+    }
 };
 
 /**
@@ -187,6 +207,7 @@ var BIDS = {
  * arguments to the callback.
  */
 module.exports = function (dir, callback) {
+    BIDS.reset();
     utils.readDir(dir, function (files) {
         BIDS.start(files, callback);
     });

--- a/validators/json.js
+++ b/validators/json.js
@@ -8,7 +8,7 @@ var JSHINT = require('jshint').JSHINT;
  * it finds while validating against the BIDS
  * specification.
  */
-module.exports = function (contents, callback) {
+module.exports = function (contents, isSidecar, callback) {
 
 // primary flow --------------------------------------------------------------------
 
@@ -23,8 +23,7 @@ module.exports = function (contents, callback) {
     }
     finally {
 
-        // TODO figure out how to filter sidecar only files
-        if (jsObj) {
+        if (isSidecar) {
             repetitionTime(jsObj);
         }
 


### PR DESCRIPTION
Added in the basic structure for determining which JSON files are sidecars. So far it only captures perfect name matches and does not throw errors when a scan is missing a sidecar. It does however check in the JSON validation if a file is a sidecar.
