### PR TITLE
Events bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bids-validator",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "",
   "main": "index.js",
   "repository": {

--- a/validators/nii.js
+++ b/validators/nii.js
@@ -135,8 +135,8 @@ module.exports = function NIFTI (header, path, jsonContentsDict, events, callbac
 };
 
 function missingEvents(path, potentialEvents, events) {
-    var missingEvent = false,
-        isRest       = false;
+    var hasEvent = false,
+        isRest   = false;
 
     // check if is a rest file
     var pathParts = path.split('/');
@@ -148,14 +148,15 @@ function missingEvents(path, potentialEvents, events) {
         }
     }
 
-    // check for missing event
+    // check for event file
     for (var i = 0; i < potentialEvents.length; i++) {
         var event = potentialEvents[i];
-        if (!isRest && path.endsWith('_bold.nii.gz') && events.indexOf(event) === -1) {
-            missingEvent = true;
+        if (events.indexOf(event) > -1) {
+            hasEvent = true;
         }
     }
-    return missingEvent;
+
+    return !isRest && path.endsWith('_bold.nii.gz') && !hasEvent;
 }
 
 


### PR DESCRIPTION
Fixed a bug with missing event file determination. Original bug was caused by trying to check if a file didn't exist while iterating. This meant that in order for the file not to be flagged as missing, the correct file path had to be the only iteration. Fixed by flagging for "found file" with the same strategy.
