### PR TITLE
Browser header reading

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bids-validator",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "",
   "main": "index.js",
   "repository": {

--- a/utils/files.js
+++ b/utils/files.js
@@ -135,7 +135,7 @@ function readNiftiHeader (file, callback) {
             callback(nifti.parseNIfTIHeader(unzipped));
         };
 
-        fileReader.readAsArrayBuffer(blobSlice.call(file, 0, 3480));
+        fileReader.readAsArrayBuffer(blobSlice.call(file, 0, 500));
     }
 }
 

--- a/utils/files.js
+++ b/utils/files.js
@@ -126,6 +126,13 @@ function readNiftiHeader (file, callback) {
             });
         });
     } else {
+
+        // file size is smaller than nifti header size
+        if (file.size < 348) {
+            callback({error: "Unable to read " + file.path});
+            return;
+        }
+
         var blobSlice = File.prototype.slice || File.prototype.mozSlice || File.prototype.webkitSlice,
         fileReader = new FileReader();
 


### PR DESCRIPTION
Fixed issue #50 by adding error in browser for scans too small to be read. Additionally reduced the number of scan bytes read in browser to match the server side header reading.
