### PR TITLE
Ignored top level 'derivatives' directories in quick test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bids-validator",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "",
   "main": "index.js",
   "repository": {

--- a/validators/bids.js
+++ b/validators/bids.js
@@ -54,6 +54,7 @@ var BIDS = {
                 var path = utils.files.relativePath(file);
                 if (path) {
                     path = path.split('/');
+                    if (path[1] === 'derivatives') {continue;}
                     if (path.length > 5) {couldBeBIDS = false; break;}
                     path = path.reverse();
 


### PR DESCRIPTION
Fix for issue #61. I'm assuming here that the "derivatives" directory must be named all lowercase.
