### PR TITLE
Raise an error if empty cell is detected in TSV file

### DIFF
--- a/utils/issues.js
+++ b/utils/issues.js
@@ -94,6 +94,10 @@ module.exports = {
 		severity: 'error',
 		reason:   'All rows must have the same number of columns as there are headers.'
 	},
+	23: {
+		severity: 'error',
+		reason:   'Empty cell in TSV file detected: The proper way of labeling missing values is "n/a".'
+	},
 	24: {
 		severity: 'warning',
 		reason:   'A proper way of labeling missing values is "n/a".'

--- a/validators/tsv.js
+++ b/validators/tsv.js
@@ -62,7 +62,17 @@ module.exports = function TSV (file, contents, isEvents, callback) {
         async.each(columnsInRow, function (column, cb1) {
 
             // check if missing value is properly labeled as 'n/a'
-            if (column === "" || column === "NA" || column === "na" || column === "nan") {
+            if (column === "") {
+                // empty cell should raise an error
+                issues.push(new Issue({
+                    file: file,
+                    evidence: row,
+                    line: rows.indexOf(row) + 1,
+                    character: "at column # "+column_num,
+                    code: 23
+                }));
+            } else if (column === "NA" || column === "na" || column === "nan") {
+                // these cases should raise warning
                 issues.push(new Issue({
                     file: file,
                     evidence: row,


### PR DESCRIPTION
Leaving “NA”, “na”, and “nan” as warnings in the off chance that they
represent actual factors or values other than empty cell in the context
of the dataset being validated.

Potentially resolves #74
