### PR TITLE
Undefined Repetition Unit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bids-validator",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "",
   "main": "index.js",
   "repository": {

--- a/validators/nii.js
+++ b/validators/nii.js
@@ -71,7 +71,7 @@ module.exports = function NIFTI (header, file, jsonContentsDict, bContentsDict, 
     if (header) {
         // Define repetition time from header and coerce to seconds.
         var repetitionTime = header.pixdim[4];
-        var repetitionUnit = header.xyzt_units[3];
+        var repetitionUnit = header.xyzt_units && header.xyzt_units[3] ? header.xyzt_units[3] : null;
         if (repetitionUnit === 'ms') {repetitionTime = repetitionTime / 1000;    repetitionUnit = 's';}
         if (repetitionUnit === 'us') {repetitionTime = repetitionTime / 1000000; repetitionUnit = 's';}
     }


### PR DESCRIPTION
Small change to account for undefined repetition units as per issue #104 

This case will now return issue code 11 "Repetition time was not defined in seconds, milliseconds or microseconds in the scan's header."
