### PR TITLE
Issue 106

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bids-validator",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "",
   "main": "index.js",
   "repository": {

--- a/validators/session.js
+++ b/validators/session.js
@@ -4,7 +4,7 @@ var utils  = require('../utils');
  * session
  *
  * Takes a list of files and creates a set of file names that occur in subject
- * directories. Then generates a warning if a given subject is missing any 
+ * directories. Then generates a warning if a given subject is missing any
  * files from the set.
  */
 var session = function missingSessionFiles(fileList) {
@@ -13,11 +13,11 @@ var session = function missingSessionFiles(fileList) {
     for (var key in fileList) {
         var file = fileList[key];
         var filename;
-        
+
         if (!file || (typeof window != 'undefined' && !file.webkitRelativePath)) {
             continue;
         }
-         
+
         var path = utils.files.relativePath(file);
         if (!utils.type.isBIDS(path)) {
             continue;
@@ -34,34 +34,35 @@ var session = function missingSessionFiles(fileList) {
         if (typeof(subjects[subject]) === 'undefined') {
             subjects[subject] = [];
         }
-        // files are prepended with subject name, the following two commands 
+        // files are prepended with subject name, the following two commands
         // remove the subject from the file name to allow filenames to be more
         // easily compared
         filename = path.substring(path.match(subject).index + subject.length);
         filename = filename.replace(subject, '<sub>');
         subjects[subject].push(filename);
     }
-      
-    var subject_files = [];
-    for (var subject in subjects) {
-        subject_files = subject_files.concat(subjects[subject])
-    }
-    // Converting to a Set removes all duplicates
-    all_files = new Set(subject_files);
 
-    // Converting it back to an array for easy iteration
-    all_files = Array.from(all_files);
+    var subject_files = [];
+    for (var key in subjects) {
+        var subject = subjects[key];
+        for (var file of subject) {
+            if (subject_files.indexOf(file) < 0) {
+                subject_files.push(file);
+            }
+        }
+    }
+
     for (var subject in subjects) {
-        for (var set_file in all_files) {
-            if (subjects[subject].indexOf(all_files[set_file]) === -1) {
-                filename = all_files[set_file].replace('<sub>', subject);
+        for (var set_file in subject_files) {
+            if (subjects[subject].indexOf(subject_files[set_file]) === -1) {
+                filename = subject_files[set_file].replace('<sub>', subject);
                 file.relativePath = '/' + subject + filename;
                 issues.push(new utils.Issue({
                     file: file,
                     evidence: "Subject: " + subject + "; Missing file: " + filename,
                     code: 38
                 }));
-            } 
+            }
         }
     }
     return issues;

--- a/validators/tsv.js
+++ b/validators/tsv.js
@@ -1,4 +1,3 @@
-var async = require('async');
 var Issue = require('../utils').Issue;
 
 /**
@@ -38,6 +37,7 @@ module.exports = function TSV (file, contents, isEvents, callback) {
     }
 
     var emptyCells = 0;
+    var NACells    = 0;
     // iterate rows
     for (var i = 0; i < rows.length; i++) {
         var row = rows[i];
@@ -71,7 +71,8 @@ module.exports = function TSV (file, contents, isEvents, callback) {
                     character: "at column # " + (j+1),
                     code: 23
                 }));
-            } else if (column === "NA" || column === "na" || column === "nan") {
+            } else if ((column === "NA" || column === "na" || column === "nan") && NACells < 5) {
+                NACells++;
                 // check if missing value is properly labeled as 'n/a'
                 issues.push(new Issue({
                     file: file,

--- a/validators/tsv.js
+++ b/validators/tsv.js
@@ -37,54 +37,52 @@ module.exports = function TSV (file, contents, isEvents, callback) {
         }
     }
 
-    // iterate through rows
-    async.each(rows, function (row, cb) {
+    var emptyCells = 0;
+    // iterate rows
+    for (var i = 0; i < rows.length; i++) {
+        var row = rows[i];
 
-        //skip empty rows
-        if (!row || /^\s*$/.test(row)){
-            cb();
-            return
-        }
-        var columnsInRow = row.split('\t');
+        // skip empty rows
+        if (!row || /^\s*$/.test(row)) {continue;}
+
+        var columns = row.split('\t');
 
         // check for different length rows
-        if (columnsInRow.length !== headers.length) {
+        if (columns.length !== headers.length) {
             issues.push(new Issue({
                 file: file,
                 evidence: row,
-                line: rows.indexOf(row) + 1,
+                line: i + 1,
                 code: 22
             }));
         }
 
-        // iterate through columns
-        column_num = 1
-        async.each(columnsInRow, function (column, cb1) {
+        // iterate columns
+        for (var j = 0; j < columns.length; j++) {
+            var column = columns[j];
 
-            // check if missing value is properly labeled as 'n/a'
-            if (column === "") {
+            if (column === "" && emptyCells < 5) {
+                emptyCells++;
                 // empty cell should raise an error
                 issues.push(new Issue({
                     file: file,
                     evidence: row,
-                    line: rows.indexOf(row) + 1,
-                    character: "at column # "+column_num,
+                    line: i + 1,
+                    character: "at column # " + (j+1),
                     code: 23
                 }));
             } else if (column === "NA" || column === "na" || column === "nan") {
-                // these cases should raise warning
+                // check if missing value is properly labeled as 'n/a'
                 issues.push(new Issue({
                     file: file,
                     evidence: row,
-                    line: rows.indexOf(row) + 1,
-                    character: "at column # "+column_num,
+                    line: i + 1,
+                    character: "at column # " + (j+1),
                     code: 24
                 }));
             }
-            column_num++
-	        cb1();
-        }, function () {cb();});
-    }, function () {
-        callback(issues);
-    });
+        }
+    }
+
+    callback(issues);
 };


### PR DESCRIPTION
Fixes issue #106 by limiting how often tsv issues can be thrown per file. Current limit if 5 instances. We can change this limit. 

If this is not a preferred strategy we also have the option to address this in the browser by truncating to the display to a maximum number of files per issue.

I also replaced the use of javascript 'set' and 'Array.from' to avoid issues with somewhat limited support I was running into locally. 
