### PR TITLE
Gulp failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bids-validator",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "",
   "main": "index.js",
   "repository": {

--- a/validators/session.js
+++ b/validators/session.js
@@ -45,7 +45,8 @@ var session = function missingSessionFiles(fileList) {
     var subject_files = [];
     for (var key in subjects) {
         var subject = subjects[key];
-        for (var file of subject) {
+        for (var i = 0; i < subject.length; i++) {
+            var file = subject[i];
             if (subject_files.indexOf(file) < 0) {
                 subject_files.push(file);
             }

--- a/validators/session.js
+++ b/validators/session.js
@@ -59,7 +59,7 @@ var session = function missingSessionFiles(fileList) {
                 filename = subject_files[set_file].replace('<sub>', subject);
                 file.relativePath = '/' + subject + filename;
                 issues.push(new utils.Issue({
-                    file: file,
+                    file: {relativePath: file},
                     evidence: "Subject: " + subject + "; Missing file: " + filename,
                     code: 38
                 }));

--- a/validators/session.js
+++ b/validators/session.js
@@ -56,10 +56,9 @@ var session = function missingSessionFiles(fileList) {
     for (var subject in subjects) {
         for (var set_file in subject_files) {
             if (subjects[subject].indexOf(subject_files[set_file]) === -1) {
-                filename = subject_files[set_file].replace('<sub>', subject);
-                file.relativePath = '/' + subject + filename;
+                var relativePath = '/' + subject + subject_files[set_file].replace('<sub>', subject);
                 issues.push(new utils.Issue({
-                    file: {relativePath: file},
+                    file: {relativePath: relativePath},
                     evidence: "Subject: " + subject + "; Missing file: " + filename,
                     code: 38
                 }));


### PR DESCRIPTION
I replaced a "for of" loop that was causing minification failures during the gulp build. If need be we can fix the build process for "for of" loops and other newer language features, but I think we should figure out what browsers and node versions we're targeting first.

I also noticed I wasn't getting relativePaths back correctly with issues for this validation. I likely broke that in my last PR and fixed it here.
