### PR TITLE
Check for empty or blank header fields in headerFields.js for #128

### DIFF
--- a/utils/issues.js
+++ b/utils/issues.js
@@ -160,5 +160,17 @@ module.exports = {
         severity: 'warning',
         reason: "Not all subjects/sessions/runs have the same scanning parameters"
     }
+    40: {
+        severity: 'warning',
+        reason: "Nifti file's header field for dimension information blank or too short."
+    },
+    41: {
+        severity: 'warning',
+        reason: "Nifti file's header field for unit information for x, y, z, and t dimensions empty or too short"
+    },
+    42: {
+        severity: 'warning',
+        reason: "Nifti file's header field for pixel dimension information empty or too short."
+    }
 
 };

--- a/utils/issues.js
+++ b/utils/issues.js
@@ -159,7 +159,7 @@ module.exports = {
     39: {
         severity: 'warning',
         reason: "Not all subjects/sessions/runs have the same scanning parameters"
-    }
+    },
     40: {
         severity: 'warning',
         reason: "Nifti file's header field for dimension information blank or too short."

--- a/validators/bids.js
+++ b/validators/bids.js
@@ -94,7 +94,7 @@ var BIDS = {
         var jsonContentsDict = {},
             bContentsDict    = {},
             events           = [],
-            niftis           = [];
+            niftis           = [],
             headers          = [];
 
         // validate individual files

--- a/validators/headerFields.js
+++ b/validators/headerFields.js
@@ -124,7 +124,7 @@ var headerField = function headerField(headers, field) {
         }
     }
     for (var nifti_key in nifti_types) {
-        nifti_type = nifti_types[nifti_key];
+        var nifti_type = nifti_types[nifti_key];
         var max_field_value = Object.keys(nifti_type)[0];
         for (var field_value_key in nifti_type) {
             var field_value = nifti_type[field_value_key];
@@ -166,8 +166,8 @@ var headerField = function headerField(headers, field) {
  * the two headers are signifigantly different
  */
 function headerFieldCompare(header1, header2) {
-    hdr1 = header1.split(',');
-    hdr2 = header2.split(',');
+    var hdr1 = header1.split(',');
+    var hdr2 = header2.split(',');
     for (var i = 0; i < hdr1.length; i++) {
         var hdr1_val = Number(hdr1[i].match(/-?\d*\.?\d*/));
         var hdr2_val  = Number(hdr2[i].match(/-?\d*\.?\d*/));

--- a/validators/headerFields.js
+++ b/validators/headerFields.js
@@ -59,14 +59,12 @@ var headerField = function headerField(headers, field) {
                 badField = true;
             } 
             if ((typeof header['pixdim']) === 'undefined' || header['pixdim'] === null || header['pixdim'].length < 4) {
-                console.log(header['pixdim']);
                 issues.push(new utils.Issue({
                         file: file,
                         code: 42
                 }));
                 badField = true;
             }
-            console.log(header['xyzt_units']);
             if (badField === true) {
                 continue;
             }

--- a/validators/headerFields.js
+++ b/validators/headerFields.js
@@ -14,6 +14,7 @@ var utils  = require('../utils');
 var headerFields = function headerFields(headers) {
     var issues = [];
     issues = issues.concat(headerField(headers, 'dim'));
+
     issues = issues.concat(headerField(headers, 'pixdim'));
     return issues;
 }
@@ -31,6 +32,7 @@ var headerField = function headerField(headers, field) {
     var nifti_types = {};
     var issues = [];
     for (var header_index in headers) {
+        var badField = false;
         var field_value;
         var file = headers[header_index][0];
         var filename;
@@ -41,8 +43,31 @@ var headerField = function headerField(headers, field) {
         var subject;
         
         if (field === 'dim') {
+            if ((typeof header[field]) === 'undefined' || header[field] === null || header[field].length < header[field][0]) {
+                issues.push(new utils.Issue({
+                        file: nifti_file,
+                        code: 40
+                }));
+                continue;
+            }
             field_value = header[field].slice(1, header[field][0]+1).toString();
         } else if (field === 'pixdim') {
+            if ((typeof header['xyzt_units']) === 'undefined' || header['xyzt_units'] === null || header['xyzt_units'].length < 4) {
+                issues.push(new utils.Issue({
+                        file: nifti_file,
+                        code: 41
+                }));
+                badField = true;
+            } else if ((typeof header['pix_dim']) === 'undefined' || header['pix_dim'] === null || header['pix_dim'].length < 5) {
+                issues.push(new utils.Issue({
+                        file: nifti_file,
+                        code: 42
+                }));
+                badField = true;
+            }
+            if (badField === true) {
+                continue;
+            }
             field_value = [];
             var pix_dim = header[field].slice(1,5);
             var units = header['xyzt_units'].slice(0,4);

--- a/validators/headerFields.js
+++ b/validators/headerFields.js
@@ -14,7 +14,6 @@ var utils  = require('../utils');
 var headerFields = function headerFields(headers) {
     var issues = [];
     issues = issues.concat(headerField(headers, 'dim'));
-
     issues = issues.concat(headerField(headers, 'pixdim'));
     return issues;
 }
@@ -45,7 +44,7 @@ var headerField = function headerField(headers, field) {
         if (field === 'dim') {
             if ((typeof header[field]) === 'undefined' || header[field] === null || header[field].length < header[field][0]) {
                 issues.push(new utils.Issue({
-                        file: nifti_file,
+                        file: file,
                         code: 40
                 }));
                 continue;
@@ -54,17 +53,20 @@ var headerField = function headerField(headers, field) {
         } else if (field === 'pixdim') {
             if ((typeof header['xyzt_units']) === 'undefined' || header['xyzt_units'] === null || header['xyzt_units'].length < 4) {
                 issues.push(new utils.Issue({
-                        file: nifti_file,
+                        file: file,
                         code: 41
                 }));
                 badField = true;
-            } else if ((typeof header['pix_dim']) === 'undefined' || header['pix_dim'] === null || header['pix_dim'].length < 5) {
+            } 
+            if ((typeof header['pixdim']) === 'undefined' || header['pixdim'] === null || header['pixdim'].length < 4) {
+                console.log(header['pixdim']);
                 issues.push(new utils.Issue({
-                        file: nifti_file,
+                        file: file,
                         code: 42
                 }));
                 badField = true;
             }
+            console.log(header['xyzt_units']);
             if (badField === true) {
                 continue;
             }


### PR DESCRIPTION
In reference to #128 
Created three new warnings for each of the headers being tested. This causes a bit of overlap for error code 11 and the new warning code 41:

```

    1: Repetition time was not defined in seconds, milliseconds or microseconds in the scan's header. (code: 11)
        /sub-01/func/sub-01_task-Emotionregulation_run-01_bold.nii.gz

    6: Nifti file's header field for unit information for x, y, z, and t dimensions empty or too short (code: 41)
        /sub-01/func/sub-01_task-Emotionregulation_run-01_bold.nii.gz
```

@chrisfilo Is this redundancy in warning messages ok? 
