### PR TITLE
Exit code

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -24,7 +24,7 @@ module.exports = function (dir, options) {
         });
     } else {
         console.log(colors.red(dir + " does not exist"));
-        process.exit(1);
+        process.exit(2);
     }
 };
 

--- a/cli.js
+++ b/cli.js
@@ -20,9 +20,11 @@ module.exports = function (dir, options) {
                 console.log(colors.green("This dataset appears to be BIDS compatible."));
             }
             logSummary(summary);
+            if (errors.length >= 1) {process.exit(1);}
         });
     } else {
         console.log(colors.red(dir + " does not exist"));
+        process.exit(1);
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bids-validator",
-  "version": "0.18.7",
+  "version": "0.18.8",
   "description": "",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Added basic exit codes for #166 
- Any valid dataset (with our without warnings) will continue to exit with 0
- Any dataset with errors will exit with 1
- Passing an invalid dataset path will exit with 2

I'm open to changing the specific codes if there's a reason, but the thinking behind these two is. 1 is most often used as a general catch all for errors and 2 is listed (http://www-numi.fnal.gov/offline_software/srt_public_context/WebDocs/Errors/unix_system_errors.html) as "no file or directory".
