### PR TITLE
Replaced usages of 'for in' loops for iterating arrays

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bids-validator",
-  "version": "0.18.14",
+  "version": "0.18.15",
   "description": "",
   "main": "index.js",
   "repository": {

--- a/utils/files.js
+++ b/utils/files.js
@@ -95,9 +95,9 @@ function readDir (dir, callback) {
 function getFiles (dir, files_){
     files_ = files_ || [];
     var files = fs.readdirSync(dir);
-    for (var i in files){
+    for (var i = 0; i < files.length; i++) {
         var name = dir + '/' + files[i];
-        if (fs.lstatSync(name).isDirectory()){
+        if (fs.lstatSync(name).isDirectory()) {
             getFiles(name, files_);
         } else {
             files_.push(name);

--- a/validators/bids.js
+++ b/validators/bids.js
@@ -289,7 +289,7 @@ var BIDS = {
                 if (summary.modalities.indexOf("fieldmap") < 0) {
                     var filteredWarnings = [];
                     var fieldmapRelatedCodes = ["6", "7", "8", "9"];
-                    for (var i in issues.warnings) {
+                    for (var i = 0; i < issues.warnings.length; i++) {
                         if (fieldmapRelatedCodes.indexOf(issues.warnings[i].code) < 0) {
                             filteredWarnings.push(issues.warnings[i]);
                         }
@@ -375,7 +375,7 @@ var BIDS = {
             [['epi'], "fieldmap"]
         ];
 
-        for (var groupTouple_i in modalityGroups) {
+        for (var groupTouple_i = 0; groupTouple_i < modalityGroups.length; groupTouple_i++) {
             var groupSet = modalityGroups[groupTouple_i][0];
             var groupName = modalityGroups[groupTouple_i][1];
             var match = true;

--- a/validators/headerFields.js
+++ b/validators/headerFields.js
@@ -17,8 +17,9 @@ var headerFields = function headerFields(headers) {
     var fields = ['dim', 'pixdim'];
 
     /* turn a list of dicts into a dict of lists */
-    for (var field in fields){
-        var issues = headerField(headers, fields[field]);
+    for (var i = 0; i < fields.length; i++) {
+        var field = fields[i];
+        var issues = headerField(headers, field);
         for (var file in issues) {
             if (issues[file].code == 39) {
                 if (allIssues39Dict.hasOwnProperty(file)) {
@@ -58,7 +59,7 @@ var headerFields = function headerFields(headers) {
 var headerField = function headerField(headers, field) {
     var nifti_types = {};
     var issues = {};
-    for (var header_index in headers) {
+    for (var header_index = 0; header_index < headers.length; header_index++) {
         var badField = false;
         var field_value;
         var file = headers[header_index][0];
@@ -129,7 +130,7 @@ var headerField = function headerField(headers, field) {
         if (match !== null) {
             filename = filename.replace(match[0], '<run>');
         }
-        
+
         if (!nifti_types.hasOwnProperty(filename)) {
             nifti_types[filename] = {};
             nifti_types[filename][field_value] = {'count': 1, 'files': [file]};
@@ -154,7 +155,7 @@ var headerField = function headerField(headers, field) {
         for (field_value_key in nifti_type) {
             field_value = nifti_type[field_value_key];
             if (max_field_value !== field_value_key && headerFieldCompare(max_field_value, field_value_key)) {
-                for (var nifti_file_index in field_value.files) {
+                for (var nifti_file_index = 0; nifti_file_index < field_value.files.length; nifti_file_index++) {
                     var nifti_file = field_value.files[nifti_file_index];
                     var evidence;
                     if (field === 'dim') {

--- a/validators/session.js
+++ b/validators/session.js
@@ -8,7 +8,7 @@ var utils  = require('../utils');
  * files from the set.
  */
 var session = function missingSessionFiles(fileList) {
-    var subjects = [];
+    var subjects = {};
     var issues = [];
     for (var key in fileList) {
         var file = fileList[key];
@@ -43,6 +43,7 @@ var session = function missingSessionFiles(fileList) {
     }
 
     var subject_files = [];
+
     for (var subjKey in subjects) {
         subject = subjects[subjKey];
         for (var i = 0; i < subject.length; i++) {
@@ -53,9 +54,10 @@ var session = function missingSessionFiles(fileList) {
         }
     }
 
-    subjects.sort();
-    for (subject in subjects) {
-        for (var set_file in subject_files) {
+    var subjectKeys = Object.keys(subjects).sort();
+    for (var j = 0; j < subjectKeys.length; j++) {
+        subject = subjectKeys[j];
+        for (var set_file = 0; set_file < subject_files.length; set_file++) {
             if (subjects[subject].indexOf(subject_files[set_file]) === -1) {
                 var fileThatsMissing = '/' + subject + subject_files[set_file].replace('<sub>', subject);
                 issues.push(new utils.Issue({


### PR DESCRIPTION
I ran into an issue where our usage of "for in" loops was conflicting when operating in the browser with [papaya.js](https://github.com/rii-mango/Papaya) loaded. Papaya adds a method "clone" to the array prototype that is enumerable so using "for in" to iterate an array will also end up iterating over "clone" and cause issues when we're not expecting to handle "clone".

After some brief research it looks like it's generally not recommend to use "for in" loops for arrays in javascript for a variety of reasons http://stackoverflow.com/questions/500504/why-is-using-for-in-with-array-iteration-a-bad-idea . 

Uses of "for in" for iterating objects should be fine and were left alone.
