### PR TITLE
add support for multiple intendedFor files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bids-validator",
-  "version": "0.18.18",
+  "version": "0.18.19",
   "description": "",
   "main": "index.js",
   "repository": {

--- a/validators/nii.js
+++ b/validators/nii.js
@@ -204,7 +204,7 @@ module.exports = function NIFTI (header, file, jsonContentsDict, bContentsDict, 
         if (path.includes("_phasediff.nii") || path.includes("_phase1.nii") ||
             path.includes("_phase2.nii") || path.includes("_fieldmap.nii") || path.includes("_epi.nii")){
             if (mergedDictionary.hasOwnProperty('IntendedFor')) {
-              var intendedFor = typeof mergedDictionary['IntendedFor'] == "string" ? {1:mergedDictionary['IntendedFor']} : mergedDictionary['IntendedFor'];
+              var intendedFor = typeof mergedDictionary['IntendedFor'] == "string" ? [mergedDictionary['IntendedFor']] : mergedDictionary['IntendedFor'];
 
               for(var key = 0; key<intendedFor.length; key++){
                 var intendedForFile = "/" + path.split("/")[1] + "/" + intendedFor[key];

--- a/validators/nii.js
+++ b/validators/nii.js
@@ -204,12 +204,7 @@ module.exports = function NIFTI (header, file, jsonContentsDict, bContentsDict, 
         if (path.includes("_phasediff.nii") || path.includes("_phase1.nii") ||
             path.includes("_phase2.nii") || path.includes("_fieldmap.nii") || path.includes("_epi.nii")){
             if (mergedDictionary.hasOwnProperty('IntendedFor')) {
-
-              if (typeof mergedDictionary['IntendedFor'] == "string"){
-                var intendedFor = {1:mergedDictionary['IntendedFor']};
-              } else {
-                var intendedFor = mergedDictionary['IntendedFor'];
-              }
+              var intendedFor = typeof mergedDictionary['IntendedFor'] == "string" ? {1:mergedDictionary['IntendedFor']} : mergedDictionary['IntendedFor'];
 
               for(var key = 0; key<intendedFor.length; key++){
                 var intendedForFile = "/" + path.split("/")[1] + "/" + intendedFor[key];

--- a/validators/nii.js
+++ b/validators/nii.js
@@ -204,7 +204,10 @@ module.exports = function NIFTI (header, file, jsonContentsDict, bContentsDict, 
         if (path.includes("_phasediff.nii") || path.includes("_phase1.nii") ||
             path.includes("_phase2.nii") || path.includes("_fieldmap.nii") || path.includes("_epi.nii")){
             if (mergedDictionary.hasOwnProperty('IntendedFor')) {
-                var intendedForFile = "/" + path.split("/")[1] + "/" + mergedDictionary['IntendedFor'];
+              var intendedFor = mergedDictionary['IntendedFor'];
+              for(var key in intendedFor){
+                var onTheList = false;
+                var intendedForFile = "/" + path.split("/")[1] + "/" + intendedFor[key];
                 var onTheList = false;
                 async.forEachOf(fileList, function (file, key, cb) {
                     var filePath = file.path ? file.path : file.webkitRelativePath;
@@ -224,6 +227,7 @@ module.exports = function NIFTI (header, file, jsonContentsDict, bContentsDict, 
                     }
                 });
             }
+          }
         }
     }
 

--- a/validators/nii.js
+++ b/validators/nii.js
@@ -204,9 +204,14 @@ module.exports = function NIFTI (header, file, jsonContentsDict, bContentsDict, 
         if (path.includes("_phasediff.nii") || path.includes("_phase1.nii") ||
             path.includes("_phase2.nii") || path.includes("_fieldmap.nii") || path.includes("_epi.nii")){
             if (mergedDictionary.hasOwnProperty('IntendedFor')) {
-              var intendedFor = mergedDictionary['IntendedFor'];
-              for(var key in intendedFor){
-                var onTheList = false;
+
+              if (typeof mergedDictionary['IntendedFor'] == "string"){
+                var intendedFor = {1:mergedDictionary['IntendedFor']};
+              } else {
+                var intendedFor = mergedDictionary['IntendedFor'];
+              }
+
+              for(var key = 0; key<intendedFor.length; key++){
                 var intendedForFile = "/" + path.split("/")[1] + "/" + intendedFor[key];
                 var onTheList = false;
                 async.forEachOf(fileList, function (file, key, cb) {


### PR DESCRIPTION
**intendedFor** key in fmap json file only accepted 1 entry.  With this patch, the validator loops over all entries.
