### PR TITLE
Compare header field length before individual values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bids-validator",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "",
   "main": "index.js",
   "repository": {

--- a/utils/issues/list.js
+++ b/utils/issues/list.js
@@ -266,5 +266,10 @@ module.exports = {
         key: 'NO_T1W',
         severity: 'ignore',
         reason: "Dataset does not contain any T1w scans."
+    },
+    54: {
+        key: 'BOLD_NOT_4D',
+        severity: 'error',
+        reason: 'Bold scans must be 4 dimensional.'
     }
 };

--- a/validators/headerFields.js
+++ b/validators/headerFields.js
@@ -77,6 +77,13 @@ var headerField = function headerField(headers, field) {
                         code: 40
                 });
                 continue;
+            } else if (file.name.indexOf('_bold') > -1 && (header[field][0] !== 4 || header[field].length !== 5)) {
+                issues[file.relativePath] = new Issue({
+                    file: file,
+                    code: 54,
+                    evidence: 'header field "dim" = ' + header[field]
+                });
+                continue;
             }
             field_value = header[field].slice(1, header[field][0]+1).toString();
         } else if (field === 'pixdim') {

--- a/validators/headerFields.js
+++ b/validators/headerFields.js
@@ -189,6 +189,7 @@ var headerField = function headerField(headers, field) {
 function headerFieldCompare(header1, header2) {
     var hdr1 = header1.split(',');
     var hdr2 = header2.split(',');
+    if (hdr1.length !== hdr2.length) {return true;}
     for (var i = 0; i < hdr1.length; i++) {
         var hdr1_val = Number(hdr1[i].match(/-?\d*\.?\d*/));
         var hdr2_val  = Number(hdr2[i].match(/-?\d*\.?\d*/));


### PR DESCRIPTION
Fix for issue #227. I was unable to directly duplicate the bug with the file attached to the issue. Because the issue happens while comparing header values it relies on the context of multiple scan headers.

However it looks pretty straight forward what happened and I was able to mock some data locally to force this issue. The issue is caused when comparing values that are comma separated lists (dim and pixdim). This validation wasn't accounting for lists of different lengths and only checked the individual values.

So I updated this to consider lists of different lengths to be different dimensions. So 

`[ '3.13mm', '3.13mm', '4.00mm', '1.00s' ]`

is not the same as 

`[ '3.13mm', '3.13mm', '4.00mm']`

I believe the existing issue (below) still explains this well but let me know if you think we need any changes.

```
39: {
    key: 'INCONSISTENT_PARAMETERS',
    severity: 'warning',
    reason: "Not all subjects/sessions/runs have the same scanning parameters."
}
```

Verbose mode will also show

`The most common resolution is: 3.13mm x 3.13mm x 4.00mm x 1.00s, This file has the resolution: 3.13mm x 3.13mm x 4.00m.`
