### PR TITLE
issue-272: Shouldn't _rec- be excluded from "functional run/task identity"?  

### DIFF
--- a/tests/nii.spec.js
+++ b/tests/nii.spec.js
@@ -98,9 +98,7 @@ describe('NIFTI', function(){
             '/sub-15/run-01_events.tsv'
         ];
         jsonContentsDict[file.relativePath.replace('.nii.gz', '.json')] = jsonContentsDict['/sub-15/func/sub-15_task-mixedeventrelatedproberest_run-01_bold.json'];
-        console.log(events);
         validate.NIFTI(null, file, jsonContentsDict, {}, [], events, function (issues) {
-          console.log(issues);
             assert.deepEqual(issues, []);
         });
     });

--- a/tests/nii.spec.js
+++ b/tests/nii.spec.js
@@ -88,21 +88,6 @@ describe('NIFTI', function(){
         });
     });
 
-    it('should ignore missing task name definitions on reconstructed(rec-) task scans', function() {
-        var file = {
-            name: 'sub-15_task-mixedeventrelatedprobe_rec-LR_run-01_bold.nii.gz',
-            relativePath: '/sub-15/func/sub-15_task-mixedeventrelatedprobe_rec-LR_run-01_bold.nii.gz'
-        };
-        var events = [
-            '/sub-15/func/sub-15_task-mixedeventrelatedprobe_run-01_events.tsv',
-            '/sub-15/run-01_events.tsv'
-        ];
-        jsonContentsDict[file.relativePath.replace('.nii.gz', '.json')] = jsonContentsDict['/sub-15/func/sub-15_task-mixedeventrelatedproberest_run-01_bold.json'];
-        validate.NIFTI(null, file, jsonContentsDict, {}, [], events, function (issues) {
-            assert.deepEqual(issues, []);
-        });
-    });
-
     it('should generate warning if files listed in IntendedFor of fieldmap json doesnot exist', function() {
       var file = {
           name: 'sub-09_ses-test_run-01_fieldmap.nii.gz',
@@ -150,4 +135,18 @@ describe('NIFTI', function(){
       });
     });
 
+    it('should ignore missing task name definitions on reconstructed(rec-) task scans', function() {
+        var file = {
+            name: 'sub-15_task-mixedeventrelatedprobe_rec-LR_run-01_bold.nii.gz',
+            relativePath: '/sub-15/func/sub-15_task-mixedeventrelatedprobe_rec-LR_run-01_bold.nii.gz'
+        };
+        var events = [
+            '/sub-15/func/sub-15_task-mixedeventrelatedprobe_run-01_events.tsv',
+            '/sub-15/run-01_events.tsv'
+        ];
+        jsonContentsDict[file.relativePath.replace('.nii.gz', '.json')] = jsonContentsDict['/sub-15/func/sub-15_task-mixedeventrelatedproberest_run-01_bold.json'];
+        validate.NIFTI(null, file, jsonContentsDict, {}, [], events, function (issues) {
+            assert.deepEqual(issues, []);
+        });
+    });
 });

--- a/tests/nii.spec.js
+++ b/tests/nii.spec.js
@@ -103,4 +103,51 @@ describe('NIFTI', function(){
         });
     });
 
+    it('should generate warning if files listed in IntendedFor of fieldmap json doesnot exist', function() {
+      var file = {
+          name: 'sub-09_ses-test_run-01_fieldmap.nii.gz',
+          path: '/ds114/sub-09/ses-test/dwi/sub-09_ses-test_run-01_fieldmap.nii.gz',
+          relativePath: '/sub-09/ses-test/dwi/sub-09_ses-test_run-01_fieldmap.nii.gz'
+      };
+
+      var jsonContentsDict = {
+          '/sub-09/ses-test/dwi/sub-09_ses-test_run-01_fieldmap.json': {
+              TaskName: 'Mixed Event Related Probe',
+              IntendedFor: ['func/sub-15_task-mixedeventrelatedprobe_run-05_bold.nii.gz','func/sub-15_task-mixedeventrelatedprobe_run-02_bold.nii.gz'
+            ]
+          }
+        };
+      var fileList = [];
+      fileList.push({ name:'sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz',
+        path: 'sub-15/func/sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz',
+        relativePath: '/func/sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz'});
+      validate.NIFTI(null, file, jsonContentsDict, {}, [], [], function (issues) {
+          assert(issues.length = 2 && issues[0].code == 17  && issues[1].code == 37);
+      });
+    });
+
+    it('should not generate warning if files listed in IntendedFor of fieldmap json exist', function() {
+      var file = {
+          name: 'sub-15_ses-test_run-01_fieldmap.nii.gz',
+          path: '/ds114/sub-15/ses-test/dwi/sub-15_ses-test_run-01_fieldmap.nii.gz',
+          relativePath: '/sub-15/ses-test/dwi/sub-15_ses-test_run-01_fieldmap.nii.gz'
+      };
+
+      var jsonContentsDict = {
+          '/sub-15/ses-test/dwi/sub-15_ses-test_run-01_fieldmap.json': {
+              TaskName: 'Mixed Event Related Probe',
+              Units: 'rad/s',
+              IntendedFor: ['func/sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz'
+            ]
+          }
+        };
+
+      var fileList = [{ name:'sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz',
+        path: 'sub-15/func/sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz',
+        relativePath: '/func/sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz'}];
+      validate.NIFTI(null, file, jsonContentsDict, {}, fileList, [], function (issues) {
+          assert.deepEqual(issues, []);
+      });
+    });
+
 });

--- a/tests/nii.spec.js
+++ b/tests/nii.spec.js
@@ -88,4 +88,21 @@ describe('NIFTI', function(){
         });
     });
 
+    it('should ignore missing task name definitions on reconstructed(rec-) task scans', function() {
+        var file = {
+            name: 'sub-15_task-mixedeventrelatedprobe_rec-LR_run-01_bold.nii.gz',
+            relativePath: '/sub-15/func/sub-15_task-mixedeventrelatedprobe_rec-LR_run-01_bold.nii.gz'
+        };
+        var events = [
+            '/sub-15/func/sub-15_task-mixedeventrelatedprobe_run-01_events.tsv',
+            '/sub-15/run-01_events.tsv'
+        ];
+        jsonContentsDict[file.relativePath.replace('.nii.gz', '.json')] = jsonContentsDict['/sub-15/func/sub-15_task-mixedeventrelatedproberest_run-01_bold.json'];
+        console.log(events);
+        validate.NIFTI(null, file, jsonContentsDict, {}, [], events, function (issues) {
+          console.log(issues);
+            assert.deepEqual(issues, []);
+        });
+    });
+
 });

--- a/validators/nii.js
+++ b/validators/nii.js
@@ -271,17 +271,14 @@ function missingEvents(path, potentialEvents, events) {
  */
 function potentialLocations(path) {
     var potentialPaths = [path];
-    // console.log('1. POtential Paths ' + potentialPaths);
     var pathComponents = path.split('/');
-    // console.log('path_Components- '+ pathComponents);
     var filenameComponents = pathComponents[pathComponents.length - 1].split("_");
-    // console.log('filename_componenets - '+ filenameComponents)
     var sessionLevelComponentList = [],
         subjectLevelComponentList = [],
         topLevelComponentList = [],
         ses = null,
         sub = null;
-        rec = null;
+    var rec = null;
 
     filenameComponents.forEach(function (filenameComponent) {
         if (filenameComponent.substring(0, 3) != "run") {
@@ -304,17 +301,17 @@ function potentialLocations(path) {
           file and event.tsv file.
         */
         if (filenameComponent.substring(0, 3) === "rec"){
-          rec = filenameComponent
+          rec = filenameComponent;
           var rec_path = path.replace((rec + '_'), '');
-          potentialPaths.push(rec_path)
-        };
+          potentialPaths.push(rec_path);
+        }
     });
 
 
     if (ses) {
         var sessionLevelPath= "/" + sub + "/" + ses + "/" + sessionLevelComponentList.join("_");
         potentialPaths.push(sessionLevelPath);
-    };
+    }
 
     var subjectLevelPath = "/" + sub + "/" + subjectLevelComponentList.join("_");
     potentialPaths.push(subjectLevelPath);

--- a/validators/nii.js
+++ b/validators/nii.js
@@ -300,8 +300,6 @@ function potentialLocations(path) {
         }
         if (filenameComponent.substring(0, 3) === "rec"){
           rec = filenameComponent
-          console.log("subjectLevelComponentList " + subjectLevelComponentList);
-          console.log("sessionLevelComponentList " + sessionLevelComponentList);
           var rec_path = path.replace((rec + '_'), '');
           potentialPaths.push(rec_path)
         };
@@ -315,30 +313,26 @@ function potentialLocations(path) {
         var rec_index = subjectLevelComponentList.indexOf(rec);
         subjectLevelComponentList.splice(rec_index);
 
-        // if (rec){
-        // var rec_path = "/" + sub + "/" + ses + "/" + sessionLevelComponentList.join("_");
-        // potentialPaths.push(rec_path);
-        // };
+        if (rec){
+        var rec_path = "/" + sub + "/" + ses + "/" + sessionLevelComponentList.join("_");
+        potentialPaths.push(rec_path);
+        };
 
     }
 
     var subjectLevelPath = "/" + sub + "/" + subjectLevelComponentList.join("_");
 
-    // if (rec){
-    // var rec_index = subjectLevelComponentList.indexOf(rec);
-    // subjectLevelComponentList.splice(rec_index,1);
-    // var rec_path = "/" + sub + "/" + subjectLevelComponentList.join("_");
-    // potentialPaths.push(rec_path);
-    // console.log(potentialPaths)
-    // };
-    // console.log('Second topLevelComponentList - ' + topLevelComponentList);
+    if (rec){
+    var rec_index = subjectLevelComponentList.indexOf(rec);
+    subjectLevelComponentList.splice(rec_index,1);
+    var rec_path = "/" + sub + "/" + subjectLevelComponentList.join("_");
+    potentialPaths.push(rec_path);
+    console.log(potentialPaths)
+    };
+    
     potentialPaths.push(subjectLevelPath);
-    // console.log('3. POtential Paths ' + potentialPaths);
-
     var topLevelPath = "/" + topLevelComponentList.join("_");
     potentialPaths.push(topLevelPath);
-    // console.log('4. POtential Paths ' + potentialPaths);
-
     potentialPaths.reverse();
     console.log('potentialPaths - ' + potentialPaths)
     return potentialPaths;

--- a/validators/nii.js
+++ b/validators/nii.js
@@ -298,6 +298,11 @@ function potentialLocations(path) {
                 }
             }
         }
+        /*
+          // this filter will remove rec key value pair from potentialPaths. Thus,
+          for reconstructed(with rec- k:v) task runs validator wont ask for json
+          file and event.tsv file.
+        */
         if (filenameComponent.substring(0, 3) === "rec"){
           rec = filenameComponent
           var rec_path = path.replace((rec + '_'), '');
@@ -309,32 +314,14 @@ function potentialLocations(path) {
     if (ses) {
         var sessionLevelPath= "/" + sub + "/" + ses + "/" + sessionLevelComponentList.join("_");
         potentialPaths.push(sessionLevelPath);
-
-        var rec_index = subjectLevelComponentList.indexOf(rec);
-        subjectLevelComponentList.splice(rec_index);
-
-        if (rec){
-        var rec_path = "/" + sub + "/" + ses + "/" + sessionLevelComponentList.join("_");
-        potentialPaths.push(rec_path);
-        };
-
-    }
+    };
 
     var subjectLevelPath = "/" + sub + "/" + subjectLevelComponentList.join("_");
-
-    if (rec){
-    var rec_index = subjectLevelComponentList.indexOf(rec);
-    subjectLevelComponentList.splice(rec_index,1);
-    var rec_path = "/" + sub + "/" + subjectLevelComponentList.join("_");
-    potentialPaths.push(rec_path);
-    console.log(potentialPaths)
-    };
-    
     potentialPaths.push(subjectLevelPath);
     var topLevelPath = "/" + topLevelComponentList.join("_");
     potentialPaths.push(topLevelPath);
     potentialPaths.reverse();
-    console.log('potentialPaths - ' + potentialPaths)
+
     return potentialPaths;
 }
 

--- a/validators/nii.js
+++ b/validators/nii.js
@@ -15,6 +15,7 @@ module.exports = function NIFTI (header, file, jsonContentsDict, bContentsDict, 
     var issues = [];
     var potentialSidecars = potentialLocations(path.replace(".gz", "").replace(".nii", ".json"));
     var potentialEvents   = potentialLocations(path.replace(".gz", "").replace("bold.nii", "events.tsv"));
+    // console.log('potential Events - ' + potentialEvents);
     var mergedDictionary  = generateMergedSidecarDict(potentialSidecars, jsonContentsDict);
     var sidecarMessage    = "It can be included one of the following locations: " + potentialSidecars.join(", ");
     var eventsMessage     = "It can be included one of the following locations: " + potentialEvents.join(", ");
@@ -270,14 +271,17 @@ function missingEvents(path, potentialEvents, events) {
  */
 function potentialLocations(path) {
     var potentialPaths = [path];
+    // console.log('1. POtential Paths ' + potentialPaths);
     var pathComponents = path.split('/');
+    // console.log('path_Components- '+ pathComponents);
     var filenameComponents = pathComponents[pathComponents.length - 1].split("_");
-
+    // console.log('filename_componenets - '+ filenameComponents)
     var sessionLevelComponentList = [],
         subjectLevelComponentList = [],
         topLevelComponentList = [],
         ses = null,
         sub = null;
+        rec = null;
 
     filenameComponents.forEach(function (filenameComponent) {
         if (filenameComponent.substring(0, 3) != "run") {
@@ -294,21 +298,49 @@ function potentialLocations(path) {
                 }
             }
         }
+        if (filenameComponent.substring(0, 3) === "rec"){
+          rec = filenameComponent
+          console.log("subjectLevelComponentList " + subjectLevelComponentList);
+          console.log("sessionLevelComponentList " + sessionLevelComponentList);
+          var rec_path = path.replace((rec + '_'), '');
+          potentialPaths.push(rec_path)
+        };
     });
+
 
     if (ses) {
         var sessionLevelPath= "/" + sub + "/" + ses + "/" + sessionLevelComponentList.join("_");
         potentialPaths.push(sessionLevelPath);
+
+        var rec_index = subjectLevelComponentList.indexOf(rec);
+        subjectLevelComponentList.splice(rec_index);
+
+        // if (rec){
+        // var rec_path = "/" + sub + "/" + ses + "/" + sessionLevelComponentList.join("_");
+        // potentialPaths.push(rec_path);
+        // };
+
     }
 
     var subjectLevelPath = "/" + sub + "/" + subjectLevelComponentList.join("_");
+
+    // if (rec){
+    // var rec_index = subjectLevelComponentList.indexOf(rec);
+    // subjectLevelComponentList.splice(rec_index,1);
+    // var rec_path = "/" + sub + "/" + subjectLevelComponentList.join("_");
+    // potentialPaths.push(rec_path);
+    // console.log(potentialPaths)
+    // };
+    // console.log('Second topLevelComponentList - ' + topLevelComponentList);
     potentialPaths.push(subjectLevelPath);
+    // console.log('3. POtential Paths ' + potentialPaths);
 
     var topLevelPath = "/" + topLevelComponentList.join("_");
     potentialPaths.push(topLevelPath);
+    // console.log('4. POtential Paths ' + potentialPaths);
 
     potentialPaths.reverse();
-
+    console.log('potentialPaths - ' + potentialPaths)
     return potentialPaths;
 }
 

--- a/validators/nii.js
+++ b/validators/nii.js
@@ -79,7 +79,7 @@ module.exports = function NIFTI (header, file, jsonContentsDict, bContentsDict, 
     if (!mergedDictionary.invalid) {
 
         // task scan checks
-        if (path.includes('_task-') && !path.includes('_defacemask.nii') && !path.includes('_sbref.nii')) {
+        if (path.includes('_task-') && !path.includes('_defacemask.nii') && !path.includes('_sbref.nii') && !path.includes('_rec-')) {
             if (!mergedDictionary.hasOwnProperty('TaskName')) {
                 issues.push(new Issue({
                     file: file,
@@ -90,7 +90,7 @@ module.exports = function NIFTI (header, file, jsonContentsDict, bContentsDict, 
         }
 
         // field map checks
-        if (path.includes("_bold.nii") || path.includes("_sbref.nii") || path.includes("_dwi.nii")) {
+        if ((path.includes("_bold.nii") || path.includes("_sbref.nii") || path.includes("_dwi.nii")) && !path.includes('_rec-')) {
             if (!mergedDictionary.hasOwnProperty('EchoTime')) {
                 issues.push(new Issue({
                     file: file,
@@ -124,7 +124,7 @@ module.exports = function NIFTI (header, file, jsonContentsDict, bContentsDict, 
         }
 
         // we don't need slice timing or repetition time for SBref
-        if (path.includes("_bold.nii")) {
+        if (path.includes("_bold.nii") && !path.includes('_rec-')) {
             if (!mergedDictionary.hasOwnProperty('RepetitionTime')) {
                 issues.push(new Issue({
                     file: file,


### PR DESCRIPTION
After adding `rec-` to the list where it shouldn't check for task name, there are other **warnings** as generated below:

`2: You should define 'EchoTime' for this file. If you don't provide this information field map correction will not be possible. (code: 6 - ECHO_TIME_NOT_DEFINED)
		/sub-Exp1s03/func/sub-Exp1s03_task-routelearning_rec-retest_run-02_bold.nii.gz

	3: You should define 'PhaseEncodingDirection' for this file. If you don't provide this information field map correction will not be possible. (code: 7 - PHASE_ENCODING_DIRECTION_NOT_DEFINED)
		/sub-Exp1s03/func/sub-Exp1s03_task-routelearning_rec-retest_run-02_bold.nii.gz

	4: You should define 'EffectiveEchoSpacing' for this file. If you don't provide this information field map correction will not be possible. (code: 8 - EFFECTIVE_ECHO_SPACING_NOT_DEFINED)
		/sub-Exp1s03/func/sub-Exp1s03_task-routelearning_rec-retest_run-02_bold.nii.gz

	5: You should define 'SliceTiming' for this file. If you don't provide this information slice time correction will not be possible. (code: 13 - SLICE_TIMING_NOT_DEFINED)
		/sub-Exp1s03/func/sub-Exp1s03_task-routelearning_rec-retest_run-02_bold.nii.gz

	6: Task scans should have a corresponding events.tsv file. If this is a resting state scan you can ignore this warning or rename the task to include the word "rest". (code: 25 - EVENTS_TSV_MISSING)
		/sub-Exp1s03/func/sub-Exp1s03_task-routelearning_rec-retest_run-02_bold.nii.gz`


I have added filter to exclude files with 'rec-' for above checks. 