### PR TITLE
Fix out of array bounds issue with illegal character checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ tests/data/BIDS-examples-1.0.0-rc2
 tests/data/BIDS-examples-1.0.0-rc3u2
 tests/data/BIDS-examples-1.0.0-rc3u3
 tests/data/BIDS-examples-1.0.0-rc3u4
+tests/data/BIDS-examples-1.0.0-rc3u5
 tests/data/examples.zip
 npm-debug.log

--- a/tests/bids.spec.js
+++ b/tests/bids.spec.js
@@ -106,4 +106,25 @@ var suite = describe('BIDS example datasets ', function() {
             isdone();
         });
     });
+
+    // Catch some browser specific iteration issues with for .. in loops
+    describe('with enumerable array prototype methods', function() {
+        before(function () {
+            // Patch in a potentially iterable prototype
+            Array.prototype.broken = function () { /* custom extension */ }
+        });
+        after(function () {
+            // Unpatch the above
+            delete Array.prototype.broken;
+        });
+        it('validates dataset with illegal characters in task name', function (isdone) {
+
+            var options = {ignoreNiftiHeaders: false};
+            validate.BIDS("tests/data/valid_filenames", options, function (issues) {
+                var errors = issues.errors;
+                assert(errors[0].code === '58');
+                isdone();
+            });
+        });
+    });
 });

--- a/tests/bids.spec.js
+++ b/tests/bids.spec.js
@@ -1,6 +1,7 @@
 /*eslint no-console: ["error", { allow: ["log"] }] */
 
 var assert = require('chai').assert;
+var after = require('mocha').after;
 var validate = require('../index.js');
 var request = require('sync-request');
 var fs = require('fs');
@@ -111,7 +112,7 @@ var suite = describe('BIDS example datasets ', function() {
     describe('with enumerable array prototype methods', function() {
         before(function () {
             // Patch in a potentially iterable prototype
-            Array.prototype.broken = function () { /* custom extension */ }
+            Array.prototype.broken = function () { /* custom extension */ };
         });
         after(function () {
             // Unpatch the above

--- a/validators/bids.js
+++ b/validators/bids.js
@@ -131,10 +131,10 @@ BIDS = {
         for (var f in fileList) {
             var completename = fileList[f].relativePath;
 
-            for (var err in illegalchar_regex_list) {
-                var err_regex = illegalchar_regex_list[err][0];
-                var err_code = illegalchar_regex_list[err][1];
-                var err_evidence = illegalchar_regex_list[err][2];
+            for (var re_index = 0; re_index < illegalchar_regex_list.length; re_index++) {
+                var err_regex = illegalchar_regex_list[re_index][0];
+                var err_code = illegalchar_regex_list[re_index][1];
+                var err_evidence = illegalchar_regex_list[re_index][2];
 
                 if (err_regex.exec(completename)) {
                     self.issues.push(new Issue({

--- a/validators/bids.js
+++ b/validators/bids.js
@@ -117,14 +117,14 @@ BIDS = {
         };
 
 
-        //check for illegal charcter in task name and acq name
+        // check for illegal character in task name and acq name
 
         var task_re = /sub-(.*?)_task-[a-zA-Z0-9]*[_-][a-zA-Z0-9]*(?:_acq-[a-zA-Z0-9-]*)?(?:_run-\d+)?_/g;
         var acq_re = /sub-(.*?)_task-\w+.\w+(_acq-[a-zA-Z0-9]*[_-][a-zA-Z0-9]*)(?:_run-\d+)?_/g;
 
         var illegalchar_regex_list = [
-            [task_re, 58,"task name contains illegal character:"],
-            [acq_re,59, "acq name contains illegal character:"]
+            [task_re, 58, "task name contains illegal character:"],
+            [acq_re, 59, "acq name contains illegal character:"]
         ];
 
 
@@ -136,15 +136,15 @@ BIDS = {
                 var err_code = illegalchar_regex_list[err][1];
                 var err_evidence = illegalchar_regex_list[err][2];
 
-                    if (err_regex.exec(completename)){
+                if (err_regex.exec(completename)) {
                     self.issues.push(new Issue({
                         file: fileList[f],
                         code: err_code,
                         evidence: err_evidence + fileList[f].relativePath
                     }));
                 }
-              }
             }
+        }
 
 
         // validate individual files


### PR DESCRIPTION
This does not work in the browser because it descends into the Array.prototype methods after the list elements if they are iterable. After iterating over the expected items in the array, it sets err_regex to a function and that function does not have the expected regexp.exec property.

```javascript
for (var err in illegalchar_regex_list) {
  var err_regex = illegalchar_regex_list[err][0];
  var err_code = illegalchar_regex_list[err][1];
  var err_evidence = illegalchar_regex_list[err][2];
  if (err_regex.exec(completename)){
    ...
  }
}
```

The test added should catch this in the future for bad use of for ... in within fullTest.