### PR TITLE
Upgrade JSON schemas to draft 6 and ajv to 5.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/INCF/bids-validator",
   "dependencies": {
-    "ajv": "^4.9.0",
+    "ajv": "^5.2.2",
     "async": "^2.1.5",
     "bytes": "^2.3.0",
     "cliff": "^0.1.10",

--- a/validators/schemas/bold.json
+++ b/validators/schemas/bold.json
@@ -1,33 +1,33 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "type": "object",
-  "properties": {
-    "CogAtlasID": {
-      "type": "string"
-    },
-    "EchoTime": {
-      "type": "number"
-    },
-    "EffectiveEchoSpacing": {
-      "type": "number"
-    },
-    "PhaseEncodingDirection": {
-      "type": "string"
-    },
-    "RepetitionTime": {
-      "type": "number"
-    },
-    "SliceEncodingDirection": {
-      "type": "string"
-    },
-    "SliceTiming": {
-      "type": "array",
-      "items": {
-        "type": "number"
-      }
-    },
-    "TaskName": {
-      "type": "string"
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "type": "object",
+    "properties": {
+        "CogAtlasID": {
+            "type": "string"
+        },
+        "EchoTime": {
+            "type": "number"
+        },
+        "EffectiveEchoSpacing": {
+            "type": "number"
+        },
+        "PhaseEncodingDirection": {
+            "type": "string"
+        },
+        "RepetitionTime": {
+            "type": "number"
+        },
+        "SliceEncodingDirection": {
+            "type": "string"
+        },
+        "SliceTiming": {
+            "type": "array",
+            "items": {
+                "type": "number"
+            }
+        },
+        "TaskName": {
+            "type": "string"
+        }
     }
-  }
 }

--- a/validators/schemas/dataset_description.json
+++ b/validators/schemas/dataset_description.json
@@ -1,32 +1,32 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "http://example.com/example.json",
-  "properties": {
-    "Authors": {
-      "items": {
-        "type": "string"
-      },
-      "type": "array"
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "http://example.com/example.json",
+    "properties": {
+        "Authors": {
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "BIDSVersion": {
+            "type": "string"
+        },
+        "Funding": {
+            "type": "string"
+        },
+        "HowToAcknowledge": {
+            "type": "string"
+        },
+        "License": {
+            "type": "string"
+        },
+        "Name": {
+            "type": "string"
+        }
     },
-    "BIDSVersion": {
-      "type": "string"
-    },
-    "Funding": {
-      "type": "string"
-    },
-    "HowToAcknowledge": {
-      "type": "string"
-    },
-    "License": {
-      "type": "string"
-    },
-    "Name": {
-      "type": "string"
-    }
-  },
-  "required": [
-    "Name",
-    "BIDSVersion"
-  ],
-  "type": "object"
+    "required": [
+        "Name",
+        "BIDSVersion"
+    ],
+    "type": "object"
 }


### PR DESCRIPTION
This upgrades ajv to fix a warning when bids-validator is included in webpack projects and converts the schemas to JSON schema draft 6 (the default in ajv 5+).