### PR TITLE
Fix browser specific BIDS.quickTest filename bugs

### DIFF
--- a/validators/bids.js
+++ b/validators/bids.js
@@ -43,10 +43,7 @@ BIDS = {
                             self.fullTest(files, callback);
                         } else {
                             // Return an error immediately if quickTest fails
-                            var issue = new Issue({
-                                code: 61,
-                                file: utils.files.newFile(path.basename(dir))
-                            });
+                            var issue = self.quickTestError(dir);
                             var summary = {
                                 sessions: [],
                                 subjects: [],
@@ -61,6 +58,38 @@ BIDS = {
                 });
             }
         });
+    },
+
+    /*
+     * Generates an error for quickTest failures
+     */
+    quickTestError: function (dir) {
+        var filename;
+        if (typeof window === 'undefined') {
+            // For Node, grab the path from the dir string
+            filename = path.basename(dir);
+        } else {
+            // Browser side we need to look it up more carefully
+            if (dir.length && 'webkitRelativePath' in dir[0]) {
+                var wrp = dir[0].webkitRelativePath;
+                while (wrp.indexOf(path.sep) !== -1) {
+                    wrp = path.dirname(wrp);
+                }
+                filename = wrp;
+            } else {
+                // Fallback for non-standard webkitRelativePath
+                filename = 'uploaded-directory';
+            }
+        }
+        var issue = new Issue({
+            code: 61,
+            file: {
+                name: filename,
+                path: path.join('.', filename),
+                relativePath: path.join('', filename)
+            }
+        });
+        return issue;
     },
 
     /**


### PR DESCRIPTION
This fixes returning incorrect filenames when quickTest fails for a browser multifile upload. It fixes the [object FileList] bug discovered in OpenNeuroOrg/openneuro#53