### PR TITLE
catches illegal character in `acq`

### DIFF
--- a/validators/bids.js
+++ b/validators/bids.js
@@ -167,7 +167,7 @@ BIDS = {
         // check for illegal character in task name and acq name
 
         var task_re = /sub-(.*?)_task-[a-zA-Z0-9]*[_-][a-zA-Z0-9]*(?:_acq-[a-zA-Z0-9-]*)?(?:_run-\d+)?_/g;
-        var acq_re = /sub-(.*?)_task-\w+.\w+(_acq-[a-zA-Z0-9]*[_-][a-zA-Z0-9]*)(?:_run-\d+)?_/g;
+        var acq_re = /sub-(.*?)(_task-\w+.\w+)?(_acq-[a-zA-Z0-9]*[_-][a-zA-Z0-9]*)(?:_run-\d+)?_/g;
 
         var sub_re = /sub-[a-zA-Z0-9]*[_-][a-zA-Z0-9]*_/g;   // illegal character in sub
         var ses_re = /ses-[a-zA-Z0-9]*[_-][a-zA-Z0-9]*?_(.*?)/g; //illegal character in ses


### PR DESCRIPTION
solves #373. 

Didn't write test as, already three flavors of illegal characters in acq and task name is written using example dataset under tests. 

Tested validator with file name like sub-01_acq-T1_MPRAGE_1mm_p2_run-01_T1w.nii.gz or another bold variation. It catches the error successfully. 