### PR TITLE
Elevate "not BIDS" warning to an error

### DIFF
--- a/tests/bids.spec.js
+++ b/tests/bids.spec.js
@@ -18,6 +18,13 @@ function getDirectories(srcpath) {
 
 var missing_session_files = ['7t_trt', 'ds006', 'ds007', 'ds008', 'ds051', 'ds052', 'ds105', 'ds108', 'ds109', 'ds113b'];
 
+function assertErrorCode(errors, expected_error_code) {
+    var matchingErrors = errors.filter(function (error) {
+        return error.code === expected_error_code;
+    });
+    assert(matchingErrors.length >= 0);
+}
+
 var suite = describe('BIDS example datasets ', function() {
     this.timeout(100000);
 
@@ -102,8 +109,7 @@ var suite = describe('BIDS example datasets ', function() {
     it('validates dataset with illegal characters in task name', function(isdone) {
         var options = {ignoreNiftiHeaders: false};
         validate.BIDS("tests/data/valid_filenames", options, function (issues) {
-            var errors = issues.errors;
-            assert(errors[0].code === '58');
+            assertErrorCode(issues.errors, '58');
             isdone();
         });
     });
@@ -112,8 +118,7 @@ var suite = describe('BIDS example datasets ', function() {
     it('validates dataset with illegal characters in sub name', function(isdone) {
         var options = {ignoreNiftiHeaders: false};
         validate.BIDS("tests/data/valid_filenames", options, function (issues) {
-            var errors = issues.errors;
-            assert(errors[2].code ==='64');
+            assertErrorCode(issues.errors, '64');
             isdone();
         });
     });
@@ -129,11 +134,9 @@ var suite = describe('BIDS example datasets ', function() {
             delete Array.prototype.broken;
         });
         it('validates dataset with illegal characters in task name', function (isdone) {
-
             var options = {ignoreNiftiHeaders: false};
             validate.BIDS("tests/data/valid_filenames", options, function (issues) {
-                var errors = issues.errors;
-                assert(errors[0].code === '58');
+                assertErrorCode(issues.errors, '58');
                 isdone();
             });
         });
@@ -142,9 +145,7 @@ var suite = describe('BIDS example datasets ', function() {
     it('checks for subjects with no valid data', function (isdone) {
         var options = {ignoreNiftiHeaders: true};
         validate.BIDS("tests/data/no_valid_data", options, function (issues) {
-            var errors = issues.errors;
-            assert(errors.length === 1);
-            assert(errors[0].code === '67');
+            assertErrorCode(issues.errors, '67');
             isdone();
         });
     });

--- a/utils/issues/list.js
+++ b/utils/issues/list.js
@@ -8,7 +8,7 @@
 module.exports = {
     1: {
         key: 'NOT_INCLUDED',
-        severity: 'warning',
+        severity: 'error',
         reason: 'Files with such naming scheme are not part of BIDS specification. This error is most commonly caused by typos in file names that make them not BIDS compatible. Please consult the specification and make sure your files are named correctly. If this is not a file naming issue (for example when including files not yet covered by the BIDS specification) you can ignore this warning. Please note that derived (processed) data should be placed in /derivatives folder and source data (such as DICOMS or behavioural logs in proprietary formats) should be placed in the /sourcedata folder.'
     },
     2: {


### PR DESCRIPTION
This will change the status of the "this file is not part of BIDS" to a level of an error. Even though the specification allows for non-standard files to be present in the dataset (to make it extensible) we are seeing a lot of false negatives due to this rule (users fail to fully curate their dataset and ignore this warning).

Power users can still run the validator with a custom config file that will downgrade this error to a warning.