### PR TITLE
enh: use `node:8.9.4-alpine` base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,7 @@
-FROM ubuntu:trusty
+FROM node:8.9.4-alpine
 
-## Install the validator
-RUN apt-get update && \
-    apt-get install -y curl && \
-    curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
-    apt-get remove -y curl && \
-    apt-get install -y nodejs && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-	
 COPY . /src
 
 RUN npm install -g /src
 
-ENTRYPOINT ["/usr/bin/bids-validator"]
+ENTRYPOINT ["/usr/local/bin/bids-validator"]


### PR DESCRIPTION
This pull request proposes using `node:8.9.4-alpine` as the base image. This has the benefit of removing a `RUN` layer and minimizing the footprint of the Docker image (83.8MB from 332MB, both uncompressed sizes).