### PR TITLE
Fix incorrect dataset summary

### DIFF
--- a/tests/bids.spec.js
+++ b/tests/bids.spec.js
@@ -100,7 +100,7 @@ var suite = describe('BIDS example datasets ', function() {
             assert.deepEqual(summary.tasks, ['rhyme judgment']);
             assert(summary.modalities.includes('T1w'));
             assert(summary.modalities.includes('bold'));
-            assert(summary.totalFiles === 8);
+            assert(summary.totalFiles === 10);
             assert(errors[0].code === '60');
             assert(warnings.length === 1 && warnings[0].code === '13');
             isdone();

--- a/utils/files.js
+++ b/utils/files.js
@@ -163,7 +163,7 @@ function preprocessBrowser(filesObj, ig) {
         var fileObj = filesObj[i];
         fileObj.relativePath = harmonizeRelativePath(fileObj.webkitRelativePath);
         if (ig.ignores(path.relative('/', fileObj.relativePath))) {
-            continue;
+            fileObj.ignore = true;
         }
         filesList.push(fileObj);
     }
@@ -193,9 +193,7 @@ function getFiles(dir, files_, rootpath, ig){
         var fullPath = dir + '/' + files[i];
         var relativePath = fullPath.replace(rootpath, '');
         relativePath = harmonizeRelativePath(relativePath);
-        if (ig.ignores(path.relative('/', relativePath))) {
-            continue;
-        }
+        
         var fileName = files[i];
 
         var fileObj = {
@@ -203,6 +201,10 @@ function getFiles(dir, files_, rootpath, ig){
             path: fullPath,
             relativePath: relativePath
         };
+
+        if (ig.ignores(path.relative('/', relativePath))) {
+            fileObj.ignore = true;
+        }
 
         if (fs.lstatSync(fullPath).isDirectory()) {
             getFiles(fullPath, files_, rootpath, ig);

--- a/validators/bids.js
+++ b/validators/bids.js
@@ -216,8 +216,14 @@ BIDS = {
                 hasDatasetDescription = true;
             }
 
+            // ignore files flagged by utils.files.getBIDSIgnore()
+            if (file.ignore) {
+                console.log('ignored file: ', file)
+                process.nextTick(cb);
+            }
+
             // ignore associated data
-            if (utils.type.isStimuliData(file.relativePath)) {
+            else if (utils.type.isStimuliData(file.relativePath)) {
                 process.nextTick(cb);
             }
 

--- a/validators/bids.js
+++ b/validators/bids.js
@@ -206,11 +206,6 @@ BIDS = {
         async.eachOfLimit(fileList, 200, function (file, key, cb) {
             var path = file.relativePath;
 
-            // ignore files flagged by utils.files.getBIDSIgnore()
-            if (file.ignore) {
-                process.nextTick(cb);
-            }
-
             // check for subject directory presence
             if (path.startsWith('/sub-')) {
                 hasSubjectDir = true;
@@ -219,6 +214,11 @@ BIDS = {
             // check for dataset_description.json presence
             if (path === '/dataset_description.json') {
                 hasDatasetDescription = true;
+            }
+
+            // ignore files flagged by utils.files.getBIDSIgnore()
+            if (file.ignore) {
+                process.nextTick(cb);
             }
 
             // ignore associated data

--- a/validators/bids.js
+++ b/validators/bids.js
@@ -206,16 +206,6 @@ BIDS = {
         async.eachOfLimit(fileList, 200, function (file, key, cb) {
             var path = file.relativePath;
 
-            // check for subject directory presence
-            if (path.startsWith('/sub-')) {
-                hasSubjectDir = true;
-            }
-
-            // check for dataset_description.json presence
-            if (path === '/dataset_description.json') {
-                hasDatasetDescription = true;
-            }
-
             // ignore files flagged by utils.files.getBIDSIgnore()
             if (file.ignore) {
                 process.nextTick(cb);
@@ -347,6 +337,16 @@ BIDS = {
                 });
             } else {
                 process.nextTick(cb);
+            }
+
+            // check for subject directory presence
+            if (path.startsWith('/sub-')) {
+                hasSubjectDir = true;
+            }
+
+            // check for dataset_description.json presence
+            if (path === '/dataset_description.json') {
+                hasDatasetDescription = true;
             }
 
             // collect file stats

--- a/validators/bids.js
+++ b/validators/bids.js
@@ -206,6 +206,11 @@ BIDS = {
         async.eachOfLimit(fileList, 200, function (file, key, cb) {
             var path = file.relativePath;
 
+            // ignore files flagged by utils.files.getBIDSIgnore()
+            if (file.ignore) {
+                process.nextTick(cb);
+            }
+
             // check for subject directory presence
             if (path.startsWith('/sub-')) {
                 hasSubjectDir = true;
@@ -214,11 +219,6 @@ BIDS = {
             // check for dataset_description.json presence
             if (path === '/dataset_description.json') {
                 hasDatasetDescription = true;
-            }
-
-            // ignore files flagged by utils.files.getBIDSIgnore()
-            if (file.ignore) {
-                process.nextTick(cb);
             }
 
             // ignore associated data

--- a/validators/bids.js
+++ b/validators/bids.js
@@ -218,7 +218,6 @@ BIDS = {
 
             // ignore files flagged by utils.files.getBIDSIgnore()
             if (file.ignore) {
-                console.log('ignored file: ', file)
                 process.nextTick(cb);
             }
 


### PR DESCRIPTION
Ignored files (/.bidsignore, /derivatives, /sourcedata, /code, .*, etc) are now included in the summary stats. 

Fixes a bug referenced [here](https://github.com/OpenNeuroOrg/openneuro/issues/391) where ignored files were causing an inaccurate estimation of dataset size, as well as an incorrect count of files in the dataset.