### PR TITLE
Add global install command to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,9 @@ If you install the bids validator globally by using ```npm install -g bids-valid
 
 ## Development
 
-To develop locally, clone the project and run ```npm install``` from the project root. This will install external dependencies.
+To develop locally, clone the project and run ```npm install``` from the project root. This will install external dependencies. If
+you wish to install ```bids-validator``` globally (so that you can run it in other folders), use the following command to install it
+globally: ```npm install -g```
 
 #### Running Locally in a Browser
 


### PR DESCRIPTION
Makes it clearer to install the validator globally, in case you need to run it on other folders (e.g. as part of a testing pipeline for another package)