### PR TITLE
References and links validation

### DIFF
--- a/tests/bids.spec.js
+++ b/tests/bids.spec.js
@@ -8,7 +8,7 @@ var fs = require('fs');
 var AdmZip = require('adm-zip');
 var path = require('path');
 var Test = require("mocha/lib/test");
-var test_version = "1.0.2u2";
+var test_version = "1.0.2u3";
 
 function getDirectories(srcpath) {
     return fs.readdirSync(srcpath).filter(function(file) {

--- a/tests/bids.spec.js
+++ b/tests/bids.spec.js
@@ -8,7 +8,7 @@ var fs = require('fs');
 var AdmZip = require('adm-zip');
 var path = require('path');
 var Test = require("mocha/lib/test");
-var test_version = "1.0.2u3";
+var test_version = "1.1.0rc1";
 
 function getDirectories(srcpath) {
     return fs.readdirSync(srcpath).filter(function(file) {

--- a/validators/schemas/dataset_description.json
+++ b/validators/schemas/dataset_description.json
@@ -28,7 +28,13 @@
         },
         "Name": {
             "type": "string"
-        }
+        },
+	"ReferencesAndLinks": {
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+	}
     },
     "required": [
         "Name",


### PR DESCRIPTION
ReferencesAndLinks is missing from validation, allowing datasets with unusual formats to pass validation.

See https://github.com/OpenNeuroOrg/openneuro/issues/518 and https://github.com/INCF/BIDS-examples/pull/70