### PR TITLE
Schema validator fixes

### DIFF
--- a/utils/issues/index.js
+++ b/utils/issues/index.js
@@ -80,9 +80,9 @@ var issues = {
         var severityMap = config.interpret(codes, options.config);
 
         // organize by severity
-        for (var key in categorized) {
-            issue = categorized[key];
-            issue.code = key;
+        for (var code in categorized) {
+            issue = categorized[code];
+            issue.code = code;
 
             if (severityMap.hasOwnProperty(issue.code)) {
                 issue.severity = severityMap[issue.code];
@@ -93,7 +93,13 @@ var issues = {
             }
 
             if (issue.severity === 'error') {
-                errors.push(issue);
+                // Schema validation issues will yield the JSON file invalid, we should display them first to attract
+                // user attention.
+                if (code == 55) {
+                    errors.unshift(issue);
+                } else {
+                    errors.push(issue);
+                }
             } else if (issue.severity === 'warning' && !options.ignoreWarnings) {
                 warnings.push(issue);
             } else if (issue.severity === 'ignore') {

--- a/utils/issues/list.js
+++ b/utils/issues/list.js
@@ -280,7 +280,7 @@ module.exports = {
     55: {
         key: 'JSON_SCHEMA_VALIDATION_ERROR',
         severity: 'error',
-        reason: 'JSON file is not formatted according the schema.'
+        reason: 'Invalid JSON file. The file is not formatted according the schema.'
     },
     56: {
         key: 'Participants age 89 or higher',

--- a/validators/schemas/bold.json
+++ b/validators/schemas/bold.json
@@ -33,10 +33,5 @@
         "TaskName": {
             "type": "string"
         }
-    },
-    "required": [
-      "TaskName",
-      "RepetitionTime"
-    ]
-
+    }
 }


### PR DESCRIPTION
- Don't use schema to check for mandatory fields (breaks inheritance rule)
- Show schema errors in front to nudge users to fix them first (failed schema validation will invalidate the whole JSON file and yield many addition errors)