### PR TITLE
Add --json flag to produce machine readable output.

### DIFF
--- a/bin/bids-validator
+++ b/bin/bids-validator
@@ -15,6 +15,8 @@ var argv = require('yargs')
     .describe('ignoreNiftiHeaders', 'disregard NIfTI header content during validation')
     .boolean('verbose')
     .describe('verbose', 'Log more extensive information about issues.')
+    .boolean('json')
+    .describe('json', 'Output results as JSON.')
     .option('config', {
         alias: 'c',
         describe: 'Optional configuration file. See https://github.com/INCF/bids-validator for more info.'

--- a/circle.yml
+++ b/circle.yml
@@ -16,6 +16,9 @@ test:
     - npm run lint
     # Run unit tests
     - npm run test
+    # Smoke tests
+    - bin/bids-validator tests/data/valid_headers/ --ignoreNiftiHeaders
+    - bin/bids-validator tests/data/valid_headers/ --ignoreNiftiHeaders --json
     # Test gh-pages build
     - rm -rf node_modules/
     - git checkout gh-pages


### PR DESCRIPTION
This is useful to run the validator from Python (or other environments) and work with the resulting errors, warnings, and summary.

This mode also does not set exit codes, the reader is expected to check for errors or warnings.