### PR TITLE
ENH - updated meg.json specification in line with BIDS version 1.1.1

### DIFF
--- a/validators/schemas/meg.json
+++ b/validators/schemas/meg.json
@@ -24,11 +24,10 @@
                 "EMGChannelCount": {"type" : "integer"},
                 "MiscChannelCount": {"type" : "integer"},
                 "TriggerChannelCount": {"type" : "integer"},
-                "EEGSamplingFrequency": {"type" : "number"},
                 "EEGPlacementScheme": {"type" : "string"},
                 "EEGReference": {"type" : "string"},
-                "ManufacturersAmplifierModelName": {"type": "string"},
-                "ManufacturersCapModelName": {"type": "string"},
+                "CapManufacturer": {"type": "string"},
+                "CapManufacturersModelName": {"type": "string"},
                 "DewarPosition": {"type" : "string"},
                 "SoftwareFilters": {
                   "anyOf": [


### PR DESCRIPTION
Changelog for 1.1.1
- Improved the MEG landmark coordinates description.
- Replaced ManufacturersCapModelName in meg.json with CapManufacturer and
CapManufacturersModelName.
- Remove EEGSamplingFrequency and ManufacturersAmplifierModelName from the meg.json.
- Improvemed the behavioural data description.

I tested the changes with ds000117, ds000246, ds000247 and ds000248 from the BIDS-examples.