### PR TITLE
MINOR: add remaining optional fields

### DIFF
--- a/validators/schemas/dataset_description.json
+++ b/validators/schemas/dataset_description.json
@@ -21,7 +21,10 @@
             "items": {
                 "type": "string"
             },
-            "type": "array"
+            "type": [
+                "string",
+                "array"
+            ]
         },
         "HowToAcknowledge": {
             "items": {

--- a/validators/schemas/dataset_description.json
+++ b/validators/schemas/dataset_description.json
@@ -2,39 +2,54 @@
     "$schema": "http://json-schema.org/draft-06/schema#",
     "$id": "http://example.com/example.json",
     "properties": {
+        "Name": {
+            "type": "string"
+        },
+        "BIDSVersion": {
+            "type": "string"
+        },
+        "License": {
+            "type": "string"
+        },
         "Authors": {
             "items": {
                 "type": "string"
             },
             "type": "array"
         },
-        "BIDSVersion": {
-            "type": "string"
+        "Acknowledgements": {
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "HowToAcknowledge": {
+            "items": {
+                "type": "string"
+            },
+            "type": [
+                "string",
+                "array"
+            ]
         },
         "Funding": {
             "items": {
                 "type": "string"
             },
-            "type": ["array", "string"]
+            "type": [
+                "array",
+                "string"
+            ]
         },
-        "HowToAcknowledge": {
-          "items": {
-              "type": "string"
-            },
-            "type": ["string", "array"]
-        },
-        "License": {
-            "type": "string"
-        },
-        "Name": {
-            "type": "string"
-        },
-	"ReferencesAndLinks": {
+        "ReferencesAndLinks": {
             "items": {
                 "type": "string"
             },
             "type": "array"
-	}
+        },
+        "DatasetDOI": {
+            "type": "string"
+        }
     },
     "required": [
         "Name",


### PR DESCRIPTION
added the optional "DatasetDOI" and "Acknowledgements" fields to `dataset_description.json` as specified in the specification  section [8.1](https://docs.google.com/document/d/1HFUkAEE-pB-angVcYe6pf_-fVf4sCpOHKesUvfb8Grc/edit#heading=h.ie43v2mfgaeq).

I furthermore took the liberty and rearranged the order of fields to match the order as described in the BIDS spec. This makes it easier for developers to go through the list top to bottom using a combination of the specification and the validator code.