### PR TITLE
Update nodejs to latest LTS and add an engine requirement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.9.4-alpine
+FROM node:8.11.3-alpine
 
 COPY . /src
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
    1. Go to http://incf.github.io/bids-validator/ and select a folder with your BIDs dataset.
 If the validator seems to be working longer than couple of minutes please open [developer tools ](https://developer.chrome.com/devtools) and report the error at [https://github.com/INCF/bids-validator/issues](https://github.com/INCF/bids-validator/issues).
 1. Command line version:
-   1. Install [Node.js](https://nodejs.org) (at least version 4.4.4)
+   1. Install [Node.js](https://nodejs.org) (at least version 8.0)
    1. From a terminal run `npm install -g bids-validator`
    1. Run `bids-validator` to start validating datasets.
 1. Docker

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "type": "git",
     "url": "https://github.com/INCF/bids-validator.git"
   },
+  "engines": {
+    "node": ">=8.0.0"
+  },
   "scripts": {
     "lint": "./node_modules/eslint/bin/eslint.js ./**/*.js",
     "test": "./node_modules/.bin/mocha tests/ tests/**/**.spec.js",


### PR DESCRIPTION
Updates the docker container to 8.11.3, the latest LTS with security fixes.

This will now warn you if your version of NodeJS is out of date and you attempt to install.