### PR TITLE
.gitignore all variations of the bids-examples test data.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,6 @@
 node_modules/
 .DS_Store
-tests/data/BIDS-examples-1.0.0-rc1u5
-tests/data/BIDS-examples-1.0.0-rc2
-tests/data/BIDS-examples-1.0.0-rc3u2
-tests/data/BIDS-examples-1.0.0-rc3u3
-tests/data/BIDS-examples-1.0.0-rc3u4
-tests/data/BIDS-examples-1.0.0-rc3u5
+tests/data/BIDS-examples-*
 tests/data/examples.zip
 npm-debug.log
 .idea/


### PR DESCRIPTION
This keeps these from being accidentally added as the BIDS-examples data is updated.