### PR TITLE
Update linting to support ES2017 + Node 8 and add JS style guide

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,29 +1,23 @@
 {
-    "env": {
-        "browser": true,
-        "commonjs": true,
-        "node": true,
-        "es6": true
-    },
-    "globals": {
-        "Uint8Array": false,
-        "describe": false,
-        "before": false,
-        "it": false
-    },
-    "extends": "eslint:recommended",
-    "rules": {
-        "no-console": [
-            "error",
-            {"allow": ["warn"]}
-        ],
-        "linebreak-style": [
-            "error",
-            "unix"
-        ],
-        "semi": [
-            "error",
-            "always"
-        ]
-    }
+  "plugins": ["prettier"],
+  "parserOptions": {
+    "ecmaVersion": 2017,
+    "sourceType": "module"
+  },
+  "env": {
+    "es6": true,
+    "browser": true,
+    "commonjs": true,
+    "node": true,
+    "mocha": true
+  },
+  "globals": {
+    "Uint8Array": false
+  },
+  "extends": ["eslint:recommended", "prettier"],
+  "rules": {
+    "prettier/prettier": "error",
+    "no-console": ["error", { "allow": ["warn"] }],
+    "linebreak-style": ["error", "unix"]
+  }
 }

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,4 @@
+singleQuote: true
+jsxBracketSameLine: true
+semi: false
+trailingComma: all

--- a/cli.js
+++ b/cli.js
@@ -1,125 +1,163 @@
 /*eslint no-console: ["error", {allow: ["log"]}] */
 
-var validate  = require('./index.js');
-var colors    = require('colors/safe');
-var cliff     = require('cliff');
-var pluralize = require('pluralize');
-var bytes     = require('bytes');
-var fs        = require('fs');
+var validate = require('./index.js')
+var colors = require('colors/safe')
+var cliff = require('cliff')
+var pluralize = require('pluralize')
+var bytes = require('bytes')
+var fs = require('fs')
 
 module.exports = function(dir, options) {
-    if (fs.existsSync(dir)) {
-        if (options.json) {
-            validate.BIDS(dir, options, function (issues, summary) {
-                console.log(JSON.stringify({ issues, summary }));
-            });
-        } else {
-            validate.BIDS(dir, options, function (issues, summary) {
-                var errors = issues.errors;
-                var warnings = issues.warnings;
-                if (issues.errors.length === 1 && issues.errors[0].code === "61") {
-                    console.log(
-                        colors.red(
-                            "The directory " +
-                            dir +
-                            " failed an initial Quick Test. This means the basic names and structure of the files and directories do not comply with BIDS specification. For more info go to http://bids.neuroimaging.io/"
-                        )
-                    );
-                } else if (issues.config && issues.config.length >= 1) {
-                    console.log(colors.red("Invalid Config File"));
-                    for (var i = 0; i < issues.config.length; i++) {
-                        var issue = issues.config[i];
-                        issue.file.file = { relativePath: issue.file.path };
-                        issue.files = [issue.file];
-                    }
-                    logIssues(issues.config, "red", options);
-                } else if (errors.length >= 1 || warnings.length >= 1) {
-                    logIssues(errors, "red", options);
-                    logIssues(warnings, "yellow", options);
-                } else {
-                    console.log(
-                        colors.green("This dataset appears to be BIDS compatible.")
-                    );
-                }
-                logSummary(summary);
-                if (
-                    issues === "Invalid" ||
-                    (errors && errors.length >= 1) ||
-                    (issues.config && issues.config.length >= 1)
-                ) {
-                    process.exit(1);
-                }
-            });
-        }
+  if (fs.existsSync(dir)) {
+    if (options.json) {
+      validate.BIDS(dir, options, function(issues, summary) {
+        console.log(JSON.stringify({ issues, summary }))
+      })
     } else {
-        console.log(colors.red(dir + " does not exist"));
-        process.exit(2);
-    }
-};
-
-function logIssues (issues, color, options) {
-    for (var i = 0; i < issues.length; i++) {
-        var issue = issues[i];
-        console.log('\t' + colors[color]((i + 1) + ': ' + issue.reason + ' (code: ' + issue.code + ' - ' + issue.key + ')'));
-        for (var j = 0; j < issue.files.length; j++) {
-            var file = issues[i].files[j];
-            if (!file || !file.file) {continue;}
-            console.log('\t\t.' + file.file.relativePath);
-            if (options.verbose) {console.log('\t\t\t' + file.reason);}
-            if (file.line) {
-                var msg = '\t\t\t@ line: ' + file.line;
-                if (file.character) {
-                    msg += ' character: ' + file.character;
-                }
-                console.log(msg);
-            }
-            if (file.evidence) {
-                console.log('\t\t\tEvidence: ' + file.evidence);
-            }
-
+      validate.BIDS(dir, options, function(issues, summary) {
+        var errors = issues.errors
+        var warnings = issues.warnings
+        if (issues.errors.length === 1 && issues.errors[0].code === '61') {
+          console.log(
+            colors.red(
+              'The directory ' +
+                dir +
+                ' failed an initial Quick Test. This means the basic names and structure of the files and directories do not comply with BIDS specification. For more info go to http://bids.neuroimaging.io/',
+            ),
+          )
+        } else if (issues.config && issues.config.length >= 1) {
+          console.log(colors.red('Invalid Config File'))
+          for (var i = 0; i < issues.config.length; i++) {
+            var issue = issues.config[i]
+            issue.file.file = { relativePath: issue.file.path }
+            issue.files = [issue.file]
+          }
+          logIssues(issues.config, 'red', options)
+        } else if (errors.length >= 1 || warnings.length >= 1) {
+          logIssues(errors, 'red', options)
+          logIssues(warnings, 'yellow', options)
+        } else {
+          console.log(
+            colors.green('This dataset appears to be BIDS compatible.'),
+          )
         }
-        if (issue.additionalFileCount > 0) {
-            console.log('\t\t'+colors[color]('... and '+issue.additionalFileCount+' more files having this issue (Use --verbose to see them all).'));
+        logSummary(summary)
+        if (
+          issues === 'Invalid' ||
+          (errors && errors.length >= 1) ||
+          (issues.config && issues.config.length >= 1)
+        ) {
+          process.exit(1)
         }
-        console.log();
+      })
     }
+  } else {
+    console.log(colors.red(dir + ' does not exist'))
+    process.exit(2)
+  }
 }
 
-function logSummary (summary) {
-    if (summary) {
-        var numSessions = summary.sessions.length > 0 ? summary.sessions.length : 1;
-
-        // data
-        var column1 = [
-                summary.totalFiles + ' ' + pluralize('File', summary.totalFiles) + ', ' + bytes(summary.size),
-                summary.subjects.length + ' - ' + pluralize('Subject', summary.subjects.length),
-                numSessions + ' - ' + pluralize('Session', numSessions)
-            ],
-            column2 = summary.tasks,
-            column3 = summary.modalities;
-
-        var longestColumn = Math.max(column1.length, column2.length, column3.length);
-        var pad = '       ';
-
-        // headers
-        var headers = [pad, colors.blue.underline('Summary:') + pad, colors.blue.underline('Available Tasks:') + pad, colors.blue.underline('Available Modalities:')]
-
-        // rows
-        var rows = [headers];
-        for (var i = 0; i < longestColumn; i++) {
-            var val1, val2, val3;
-            val1 = column1[i] ? column1[i] + pad : '';
-            val2 = column2[i] ? column2[i] + pad : '';
-            val3 = column3[i] ? column3[i] : '';
-            rows.push(['       ', val1, val2, val3]);
+function logIssues(issues, color, options) {
+  for (var i = 0; i < issues.length; i++) {
+    var issue = issues[i]
+    console.log(
+      '\t' +
+        colors[color](
+          i +
+            1 +
+            ': ' +
+            issue.reason +
+            ' (code: ' +
+            issue.code +
+            ' - ' +
+            issue.key +
+            ')',
+        ),
+    )
+    for (var j = 0; j < issue.files.length; j++) {
+      var file = issues[i].files[j]
+      if (!file || !file.file) {
+        continue
+      }
+      console.log('\t\t.' + file.file.relativePath)
+      if (options.verbose) {
+        console.log('\t\t\t' + file.reason)
+      }
+      if (file.line) {
+        var msg = '\t\t\t@ line: ' + file.line
+        if (file.character) {
+          msg += ' character: ' + file.character
         }
-        console.log(cliff.stringifyRows(rows));
-
-        console.log();
-        
-        //Neurostars message
-        console.log(colors.red("If you have any questions please post on https://neurostars.org/tags/bids"));
-
-        console.log();
+        console.log(msg)
+      }
+      if (file.evidence) {
+        console.log('\t\t\tEvidence: ' + file.evidence)
+      }
     }
+    if (issue.additionalFileCount > 0) {
+      console.log(
+        '\t\t' +
+          colors[color](
+            '... and ' +
+              issue.additionalFileCount +
+              ' more files having this issue (Use --verbose to see them all).',
+          ),
+      )
+    }
+    console.log()
+  }
+}
+
+function logSummary(summary) {
+  if (summary) {
+    var numSessions = summary.sessions.length > 0 ? summary.sessions.length : 1
+
+    // data
+    var column1 = [
+        summary.totalFiles +
+          ' ' +
+          pluralize('File', summary.totalFiles) +
+          ', ' +
+          bytes(summary.size),
+        summary.subjects.length +
+          ' - ' +
+          pluralize('Subject', summary.subjects.length),
+        numSessions + ' - ' + pluralize('Session', numSessions),
+      ],
+      column2 = summary.tasks,
+      column3 = summary.modalities
+
+    var longestColumn = Math.max(column1.length, column2.length, column3.length)
+    var pad = '       '
+
+    // headers
+    var headers = [
+      pad,
+      colors.blue.underline('Summary:') + pad,
+      colors.blue.underline('Available Tasks:') + pad,
+      colors.blue.underline('Available Modalities:'),
+    ]
+
+    // rows
+    var rows = [headers]
+    for (var i = 0; i < longestColumn; i++) {
+      var val1, val2, val3
+      val1 = column1[i] ? column1[i] + pad : ''
+      val2 = column2[i] ? column2[i] + pad : ''
+      val3 = column3[i] ? column3[i] : ''
+      rows.push(['       ', val1, val2, val3])
+    }
+    console.log(cliff.stringifyRows(rows))
+
+    console.log()
+
+    //Neurostars message
+    console.log(
+      colors.red(
+        'If you have any questions please post on https://neurostars.org/tags/bids',
+      ),
+    )
+
+    console.log()
+  }
 }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
-// import validations 
-var validate = require('./validators');
+// import validations
+var validate = require('./validators')
 
 // export validations for use in other applications
-module.exports = validate;
-
+module.exports = validate

--- a/package.json
+++ b/package.json
@@ -44,7 +44,10 @@
     "adm-zip": "",
     "chai": "",
     "eslint": "^5.2.0",
+    "eslint-config-prettier": "^2.9.0",
+    "eslint-plugin-prettier": "^2.6.2",
     "mocha": "^5.2.0",
+    "prettier": "^1.14.2",
     "publish": "^0.6.0",
     "sync-request": "6.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -46,9 +46,16 @@
     "eslint": "^5.2.0",
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-prettier": "^2.6.2",
+    "husky": "^1.0.0-rc.13",
     "mocha": "^5.2.0",
     "prettier": "^1.14.2",
+    "pretty-quick": "^1.6.0",
     "publish": "^0.6.0",
     "sync-request": "6.0.0"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "pretty-quick --staged"
+    }
   }
 }

--- a/tests/bids.spec.js
+++ b/tests/bids.spec.js
@@ -1,189 +1,230 @@
 /*eslint no-console: ["error", { allow: ["log"] }] */
 
-var assert = require('chai').assert;
-var after = require('mocha').after;
-var validate = require('../index.js');
-var request = require('sync-request');
-var fs = require('fs');
-var AdmZip = require('adm-zip');
-var path = require('path');
-var Test = require("mocha/lib/test");
-var test_version = "68bed388276c7898f787bc13c37e0249d827e5ac";
+var assert = require('chai').assert
+var after = require('mocha').after
+var validate = require('../index.js')
+var request = require('sync-request')
+var fs = require('fs')
+var AdmZip = require('adm-zip')
+var path = require('path')
+var Test = require('mocha/lib/test')
+var test_version = '68bed388276c7898f787bc13c37e0249d827e5ac'
 
 function getDirectories(srcpath) {
-    return fs.readdirSync(srcpath).filter(function(file) {
-        return fs.statSync(path.join(srcpath, file)).isDirectory();
-    });
+  return fs.readdirSync(srcpath).filter(function(file) {
+    return fs.statSync(path.join(srcpath, file)).isDirectory()
+  })
 }
 
-var missing_session_files = ['7t_trt', 'ds006', 'ds007', 'ds008', 'ds051', 'ds052', 'ds105', 'ds108', 'ds109', 'ds113b',
-                             'ds000117', 'ds000246', 'ds000247'];
+var missing_session_files = [
+  '7t_trt',
+  'ds006',
+  'ds007',
+  'ds008',
+  'ds051',
+  'ds052',
+  'ds105',
+  'ds108',
+  'ds109',
+  'ds113b',
+  'ds000117',
+  'ds000246',
+  'ds000247',
+]
 
 function assertErrorCode(errors, expected_error_code) {
-    var matchingErrors = errors.filter(function (error) {
-        return error.code === expected_error_code;
-    });
-    assert(matchingErrors.length >= 0);
+  var matchingErrors = errors.filter(function(error) {
+    return error.code === expected_error_code
+  })
+  assert(matchingErrors.length >= 0)
 }
 
 var suite = describe('BIDS example datasets ', function() {
-    this.timeout(100000);
+  this.timeout(100000)
 
-    before(function(done) {
-        if (!fs.existsSync("tests/data/BIDS-examples-" + test_version + "/")) {
-            console.log('downloading test data');
-            var response = request("GET", "http://github.com/INCF/BIDS-examples/archive/" + test_version + ".zip");
-            if (!fs.existsSync("tests/data")) {
-                fs.mkdirSync("tests/data");
-            }
-            fs.writeFileSync("tests/data/examples.zip", response.body);
-            var zip = new AdmZip("tests/data/examples.zip");
-            console.log('unzipping test data');
-            zip.extractAllTo("tests/data/", true);
-        }
+  before(function(done) {
+    if (!fs.existsSync('tests/data/BIDS-examples-' + test_version + '/')) {
+      console.log('downloading test data')
+      var response = request(
+        'GET',
+        'http://github.com/INCF/BIDS-examples/archive/' + test_version + '.zip',
+      )
+      if (!fs.existsSync('tests/data')) {
+        fs.mkdirSync('tests/data')
+      }
+      fs.writeFileSync('tests/data/examples.zip', response.body)
+      var zip = new AdmZip('tests/data/examples.zip')
+      console.log('unzipping test data')
+      zip.extractAllTo('tests/data/', true)
+    }
 
-        var datasetDirectories = getDirectories("tests/data/BIDS-examples-" + test_version + "/");
+    var datasetDirectories = getDirectories(
+      'tests/data/BIDS-examples-' + test_version + '/',
+    )
 
-        datasetDirectories.forEach(function testDataset(path){
-            suite.addTest(new Test(path, function (isdone){
-                var options = {ignoreNiftiHeaders: true};
-                validate.BIDS("tests/data/BIDS-examples-" + test_version + "/" + path + "/", options, function (issues) {
-                    var errors = issues.errors;
-                    var warnings = issues.warnings;
-                    assert.deepEqual(errors, []);
-                    var session_flag = false;
-                    for (var warning in warnings) {
-                        if (warnings[warning]['code'] === '38') {
-                            session_flag = true;
-                            break;
-                        }
-                    }
-                    if (missing_session_files.indexOf(path) === -1) {
-                        assert.deepEqual(session_flag, false);
-                    } else {
-                        assert.deepEqual(session_flag, true);
-                    }
-                    isdone();
-                });
-            }));
-        });
-        done();
-    });
+    datasetDirectories.forEach(function testDataset(path) {
+      suite.addTest(
+        new Test(path, function(isdone) {
+          var options = { ignoreNiftiHeaders: true }
+          validate.BIDS(
+            'tests/data/BIDS-examples-' + test_version + '/' + path + '/',
+            options,
+            function(issues) {
+              var errors = issues.errors
+              var warnings = issues.warnings
+              assert.deepEqual(errors, [])
+              var session_flag = false
+              for (var warning in warnings) {
+                if (warnings[warning]['code'] === '38') {
+                  session_flag = true
+                  break
+                }
+              }
+              if (missing_session_files.indexOf(path) === -1) {
+                assert.deepEqual(session_flag, false)
+              } else {
+                assert.deepEqual(session_flag, true)
+              }
+              isdone()
+            },
+          )
+        }),
+      )
+    })
+    done()
+  })
 
-    // we need to have at least one non-dynamic test
-    it('validates path without trailing backslash', function(isdone) {
-        var options = {ignoreNiftiHeaders: true};
-        validate.BIDS("tests/data/BIDS-examples-" + test_version + "/ds001", options, function (issues, summary) {
-            var errors = issues.errors;
-            var warnings = issues.warnings;
-            assert(summary.sessions.length === 0);
-            assert(summary.subjects.length === 16);
-            assert.deepEqual(summary.tasks, ['balloon analog risk task']);
-            assert(summary.modalities.includes('T1w'));
-            assert(summary.modalities.includes('inplaneT2'));
-            assert(summary.modalities.includes('bold'));
-            assert(summary.totalFiles === 133);
-            assert.deepEqual(errors, []);
-            assert(warnings.length === 2 && warnings[0].code === '13');
-            isdone();
-        });
-    });
+  // we need to have at least one non-dynamic test
+  it('validates path without trailing backslash', function(isdone) {
+    var options = { ignoreNiftiHeaders: true }
+    validate.BIDS(
+      'tests/data/BIDS-examples-' + test_version + '/ds001',
+      options,
+      function(issues, summary) {
+        var errors = issues.errors
+        var warnings = issues.warnings
+        assert(summary.sessions.length === 0)
+        assert(summary.subjects.length === 16)
+        assert.deepEqual(summary.tasks, ['balloon analog risk task'])
+        assert(summary.modalities.includes('T1w'))
+        assert(summary.modalities.includes('inplaneT2'))
+        assert(summary.modalities.includes('bold'))
+        assert(summary.totalFiles === 133)
+        assert.deepEqual(errors, [])
+        assert(warnings.length === 2 && warnings[0].code === '13')
+        isdone()
+      },
+    )
+  })
 
-    // we need to have at least one non-dynamic test
-    it('validates dataset with valid nifti headers', function(isdone) {
-        var options = {ignoreNiftiHeaders: false};
-        validate.BIDS("tests/data/valid_headers", options, function (issues, summary) {
-            var errors = issues.errors;
-            var warnings = issues.warnings;
-            assert(summary.sessions.length === 0);
-            assert(summary.subjects.length === 1);
-            assert.deepEqual(summary.tasks, ['rhyme judgment']);
-            assert(summary.modalities.includes('T1w'));
-            assert(summary.modalities.includes('bold'));
-            assert(summary.totalFiles === 10);
-            assert(errors[0].code === '60');
-            assert(warnings.length === 3 && warnings[0].code === '13');
-            isdone();
-        });
-    });
+  // we need to have at least one non-dynamic test
+  it('validates dataset with valid nifti headers', function(isdone) {
+    var options = { ignoreNiftiHeaders: false }
+    validate.BIDS('tests/data/valid_headers', options, function(
+      issues,
+      summary,
+    ) {
+      var errors = issues.errors
+      var warnings = issues.warnings
+      assert(summary.sessions.length === 0)
+      assert(summary.subjects.length === 1)
+      assert.deepEqual(summary.tasks, ['rhyme judgment'])
+      assert(summary.modalities.includes('T1w'))
+      assert(summary.modalities.includes('bold'))
+      assert(summary.totalFiles === 10)
+      assert(errors[0].code === '60')
+      assert(warnings.length === 3 && warnings[0].code === '13')
+      isdone()
+    })
+  })
 
-    // test for duplicate files present with both .nii and .nii.gz extension
-    it('validates dataset for duplicate files present with both .nii and .nii.gz extension', function(isdone) {
-        var options = {ignoreNiftiHeaders: false};
-        validate.BIDS("tests/data/valid_filenames", options, function (issues) {
-            assertErrorCode(issues.errors, '74');
-            isdone();
-        });
-    });
+  // test for duplicate files present with both .nii and .nii.gz extension
+  it('validates dataset for duplicate files present with both .nii and .nii.gz extension', function(isdone) {
+    var options = { ignoreNiftiHeaders: false }
+    validate.BIDS('tests/data/valid_filenames', options, function(issues) {
+      assertErrorCode(issues.errors, '74')
+      isdone()
+    })
+  })
 
-    // test for illegal characters used in acq and task name
+  // test for illegal characters used in acq and task name
+  it('validates dataset with illegal characters in task name', function(isdone) {
+    var options = { ignoreNiftiHeaders: false }
+    validate.BIDS('tests/data/valid_filenames', options, function(issues) {
+      assertErrorCode(issues.errors, '58')
+      isdone()
+    })
+  })
+
+  // test for illegal characters used in sub name
+  it('validates dataset with illegal characters in sub name', function(isdone) {
+    var options = { ignoreNiftiHeaders: false }
+    validate.BIDS('tests/data/valid_filenames', options, function(issues) {
+      assertErrorCode(issues.errors, '64')
+      isdone()
+    })
+  })
+
+  // Catch some browser specific iteration issues with for .. in loops
+  describe('with enumerable array prototype methods', function() {
+    before(function() {
+      // Patch in a potentially iterable prototype
+      Array.prototype.broken = function() {
+        /* custom extension */
+      }
+    })
+    after(function() {
+      // Unpatch the above
+      delete Array.prototype.broken
+    })
     it('validates dataset with illegal characters in task name', function(isdone) {
-        var options = {ignoreNiftiHeaders: false};
-        validate.BIDS("tests/data/valid_filenames", options, function (issues) {
-            assertErrorCode(issues.errors, '58');
-            isdone();
-        });
-    });
+      var options = { ignoreNiftiHeaders: false }
+      validate.BIDS('tests/data/valid_filenames', options, function(issues) {
+        assertErrorCode(issues.errors, '58')
+        isdone()
+      })
+    })
+  })
 
-    // test for illegal characters used in sub name
-    it('validates dataset with illegal characters in sub name', function(isdone) {
-        var options = {ignoreNiftiHeaders: false};
-        validate.BIDS("tests/data/valid_filenames", options, function (issues) {
-            assertErrorCode(issues.errors, '64');
-            isdone();
-        });
-    });
+  it('checks for subjects with no valid data', function(isdone) {
+    var options = { ignoreNiftiHeaders: true }
+    validate.BIDS('tests/data/no_valid_data', options, function(issues) {
+      assertErrorCode(issues.errors, '67')
+      isdone()
+    })
+  })
 
-    // Catch some browser specific iteration issues with for .. in loops
-    describe('with enumerable array prototype methods', function() {
-        before(function () {
-            // Patch in a potentially iterable prototype
-            Array.prototype.broken = function () { /* custom extension */ };
-        });
-        after(function () {
-            // Unpatch the above
-            delete Array.prototype.broken;
-        });
-        it('validates dataset with illegal characters in task name', function (isdone) {
-            var options = {ignoreNiftiHeaders: false};
-            validate.BIDS("tests/data/valid_filenames", options, function (issues) {
-                assertErrorCode(issues.errors, '58');
-                isdone();
-            });
-        });
-    });
+  it('checks for tabular files without corresponding data dictionaries', function(isdone) {
+    var options = { ignoreNiftiHeaders: true }
+    validate.BIDS(
+      'tests/data/BIDS-examples-' + test_version + '/ds001',
+      options,
+      function(issues) {
+        assert(issues.warnings.length === 2 && issues.warnings[1].code === '82')
+        isdone()
+      },
+    )
+  })
 
-    it('checks for subjects with no valid data', function (isdone) {
-        var options = {ignoreNiftiHeaders: true};
-        validate.BIDS("tests/data/no_valid_data", options, function (issues) {
-            assertErrorCode(issues.errors, '67');
-            isdone();
-        });
-    });
-
-    it('checks for tabular files without corresponding data dictionaries', function (isdone) {
-        var options = {ignoreNiftiHeaders: true};
-        validate.BIDS("tests/data/BIDS-examples-" + test_version + "/ds001", options, function (issues) {
-            assert(issues.warnings.length === 2 && issues.warnings[1].code === '82');
-            isdone();
-        });
-    });
-
-    it('validates ieeg modalities', function(isdone) {
-        var options = {ignoreNiftiHeaders: true};
-        validate.BIDS("tests/data/BIDS-examples-" + test_version + "/ds001", options, function (issues, summary) {
-            var errors = issues.errors;
-            var warnings = issues.warnings;
-            assert(summary.sessions.length === 0);
-            assert(summary.subjects.length === 16);
-            assert.deepEqual(summary.tasks, ['balloon analog risk task']);
-            assert(summary.modalities.includes('T1w'));
-            assert(summary.modalities.includes('inplaneT2'));
-            assert(summary.modalities.includes('bold'));
-            assert(summary.totalFiles === 133);
-            assert.deepEqual(errors, []);
-            assert(warnings.length === 2 && warnings[0].code === '13');
-            isdone();
-        });
-    });
-});
+  it('validates ieeg modalities', function(isdone) {
+    var options = { ignoreNiftiHeaders: true }
+    validate.BIDS(
+      'tests/data/BIDS-examples-' + test_version + '/ds001',
+      options,
+      function(issues, summary) {
+        var errors = issues.errors
+        var warnings = issues.warnings
+        assert(summary.sessions.length === 0)
+        assert(summary.subjects.length === 16)
+        assert.deepEqual(summary.tasks, ['balloon analog risk task'])
+        assert(summary.modalities.includes('T1w'))
+        assert(summary.modalities.includes('inplaneT2'))
+        assert(summary.modalities.includes('bold'))
+        assert(summary.totalFiles === 133)
+        assert.deepEqual(errors, [])
+        assert(warnings.length === 2 && warnings[0].code === '13')
+        isdone()
+      },
+    )
+  })
+})

--- a/tests/bval.spec.js
+++ b/tests/bval.spec.js
@@ -1,27 +1,25 @@
-var assert   = require('assert');
-var validate = require('../index');
+var assert = require('assert')
+var validate = require('../index')
 
-describe('bval', function(){
+describe('bval', function() {
+  it('should allow proper bval contents', function() {
+    var bval = '4 6 2 5 3 23 5'
+    validate.bval({}, bval, function(issues) {
+      assert.deepEqual(issues, [])
+    })
+  })
 
-	it('should allow proper bval contents', function () {
-		var bval = '4 6 2 5 3 23 5';
-		validate.bval({}, bval, function (issues) {
-			assert.deepEqual(issues, []);
-		});
-	});
+  it('should not allow more than one row', function() {
+    var bval = '0 4 3 6 1 6 2 4 1\n 4 3 5 2 4 2 4 5'
+    validate.bval({}, bval, function(issues) {
+      assert(issues.length == 1 && issues[0].code == 30)
+    })
+  })
 
-	it('should not allow more than one row', function () {
-		var bval = '0 4 3 6 1 6 2 4 1\n 4 3 5 2 4 2 4 5';
-		validate.bval({}, bval, function (issues) {
-			assert(issues.length == 1 && issues[0].code == 30);
-		});
-	});
-
-	it('should catch doublespace separators', function () {
-		var bval = '4  6  2  5  3  23  5';
-		validate.bval({}, bval, function (issues) {
-            assert(issues.length == 1 && issues[0].code == 47);
-		});
-	});
-
-});
+  it('should catch doublespace separators', function() {
+    var bval = '4  6  2  5  3  23  5'
+    validate.bval({}, bval, function(issues) {
+      assert(issues.length == 1 && issues[0].code == 47)
+    })
+  })
+})

--- a/tests/bvec.spec.js
+++ b/tests/bvec.spec.js
@@ -1,39 +1,38 @@
-var assert   = require('assert');
-var validate = require('../index');
+var assert = require('assert')
+var validate = require('../index')
 
-describe('bvec', function(){
+describe('bvec', function() {
+  it('should allow valid bvec contents', function() {
+    var bvec = '4 6 2 5\n3 2 3 5\n6 4 3 5'
+    validate.bvec({}, bvec, function(issues) {
+      assert.deepEqual(issues, [])
+    })
+  })
 
-    it('should allow valid bvec contents', function () {
-        var bvec = '4 6 2 5\n3 2 3 5\n6 4 3 5';
-        validate.bvec({}, bvec, function (issues) {
-            assert.deepEqual(issues, []);
-        });
-    });
+  it('should not allow more or less than 3 rows', function() {
+    var bvec = '0 4 3 6 1 6 2 4\n 4 3 5 2 4 2 4 5'
+    validate.bvec({}, bvec, function(issues) {
+      assert(issues.length == 1 && issues[0].code == 31)
+    })
 
-	it('should not allow more or less than 3 rows', function () {
-        var bvec = '0 4 3 6 1 6 2 4\n 4 3 5 2 4 2 4 5';
-		validate.bvec({}, bvec, function (issues) {
-			assert(issues.length == 1 && issues[0].code == 31);
-		});
+    bvec =
+      '0 4 3 6 1 6 2 4\n 4 3 5 2 4 2 4 5\n 4 3 5 2 4 2 4 5\n 4 3 5 2 4 2 4 5'
+    validate.bvec({}, bvec, function(issues) {
+      assert(issues.length == 1 && issues[0].code == 31)
+    })
+  })
 
-        bvec = '0 4 3 6 1 6 2 4\n 4 3 5 2 4 2 4 5\n 4 3 5 2 4 2 4 5\n 4 3 5 2 4 2 4 5';
-        validate.bvec({}, bvec, function (issues) {
-            assert(issues.length == 1 && issues[0].code == 31);
-        });
-	});
+  it('should not allow rows of inconsistent length', function() {
+    var bvec = '0 4 3 6 1 6 4\n 4 3 4 2 4 5\n 4 3 5 2 4 2 4 5'
+    validate.bvec({}, bvec, function(issues) {
+      assert(issues.length == 1 && issues[0].code == 46)
+    })
+  })
 
-    it('should not allow rows of inconsistent length', function () {
-        var bvec = '0 4 3 6 1 6 4\n 4 3 4 2 4 5\n 4 3 5 2 4 2 4 5';
-        validate.bvec({}, bvec, function (issues) {
-            assert(issues.length == 1 && issues[0].code == 46);
-        });
-    });
-
-    it('should catch doublespace separators', function () {
-        var bvec = '4  6  2  5\n3  2  3  5\n6  4  3  5';
-        validate.bvec({}, bvec, function (issues) {
-            assert(issues.length == 1 && issues[0].code == 47);
-        });
-    });
-
-});
+  it('should catch doublespace separators', function() {
+    var bvec = '4  6  2  5\n3  2  3  5\n6  4  3  5'
+    validate.bvec({}, bvec, function(issues) {
+      assert(issues.length == 1 && issues[0].code == 47)
+    })
+  })
+})

--- a/tests/events.spec.js
+++ b/tests/events.spec.js
@@ -1,82 +1,96 @@
-const assert   = require('assert');
-const validate = require('../index');
+const assert = require('assert')
+const validate = require('../index')
 
-describe('Events', function(){
-    const headers = [[{path: 'sub01_task-test_bold.nii.gz', relativePath: 'sub01_task-test_bold.nii.gz'}, {dim: [4, 0, 0, 0, 10]}]];
+describe('Events', function() {
+  const headers = [
+    [
+      {
+        path: 'sub01_task-test_bold.nii.gz',
+        relativePath: 'sub01_task-test_bold.nii.gz',
+      },
+      { dim: [4, 0, 0, 0, 10] },
+    ],
+  ]
 
-    it('all files in the /stimuli folder should be included in an _events.tsv file', function () {
-        const issues = [];
+  it('all files in the /stimuli folder should be included in an _events.tsv file', function() {
+    const issues = []
 
-        // stimuli.events will have all of the
-        // files included in the stim_file column of every _events.tsv file.
-        // stimuli.directory will have all of the
-        // files included in the /stimuli directory.
-        const stimuli = {
-            events: ['/stimuli/images/red-square.jpg'],
-            directory: [{relativePath: '/stimuli/images/blue-square.jpg'}],
-        };
-        validate.Events.validateEvents([], stimuli, [], {}, issues);
-        assert(issues.length === 1 && issues[0].code === 77);
-    });
+    // stimuli.events will have all of the
+    // files included in the stim_file column of every _events.tsv file.
+    // stimuli.directory will have all of the
+    // files included in the /stimuli directory.
+    const stimuli = {
+      events: ['/stimuli/images/red-square.jpg'],
+      directory: [{ relativePath: '/stimuli/images/blue-square.jpg' }],
+    }
+    validate.Events.validateEvents([], stimuli, [], {}, issues)
+    assert(issues.length === 1 && issues[0].code === 77)
+  })
 
-    it('should not throw issues if all files in the /stimuli folder are included in an _events.tsv file', function () {
-        const issues = [];
-        const stimuli = {
-            events: ['/stimuli/images/red-square.jpg'],
-            directory: [{relativePath: '/stimuli/images/red-square.jpg'}],
-        };
-        validate.Events.validateEvents([], stimuli, [], {}, issues);
-        assert(issues.length === 0);
-    });
+  it('should not throw issues if all files in the /stimuli folder are included in an _events.tsv file', function() {
+    const issues = []
+    const stimuli = {
+      events: ['/stimuli/images/red-square.jpg'],
+      directory: [{ relativePath: '/stimuli/images/red-square.jpg' }],
+    }
+    validate.Events.validateEvents([], stimuli, [], {}, issues)
+    assert(issues.length === 0)
+  })
 
-    it('should throw an issue if the onset of the last event in _events.tsv is more than TR * number of volumes in corresponding nifti header', function () {
-        const issues = [];
-        const events = [{
-            file: {path: 'sub01_task-test_events.tsv'},
-            path: 'sub01_task-test_events.tsv',
-            contents: '12\tsomething\tsomething\n'
-        }];
-        const jsonDictionary = {
-            'sub01_task-test_bold.json': {
-                RepetitionTime: 1
-            }
-        };
+  it('should throw an issue if the onset of the last event in _events.tsv is more than TR * number of volumes in corresponding nifti header', function() {
+    const issues = []
+    const events = [
+      {
+        file: { path: 'sub01_task-test_events.tsv' },
+        path: 'sub01_task-test_events.tsv',
+        contents: '12\tsomething\tsomething\n',
+      },
+    ]
+    const jsonDictionary = {
+      'sub01_task-test_bold.json': {
+        RepetitionTime: 1,
+      },
+    }
 
-        validate.Events.validateEvents(events, [], headers, jsonDictionary, issues);
-        assert(issues.length === 1 && issues[0].code === 85);
-    });
+    validate.Events.validateEvents(events, [], headers, jsonDictionary, issues)
+    assert(issues.length === 1 && issues[0].code === 85)
+  })
 
-    it('should throw an issue if the onset of the last event in _events.tsv is less than .5 * TR * number of volumes in corresponding nifti header', function () {
-        const issues = [];
-        const events = [{
-            file: {path: 'sub01_task-test_events.tsv'},
-            path: 'sub01_task-test_events.tsv',
-            contents: '2\tsomething\tsomething\n'
-        }];
-        const jsonDictionary = {
-            'sub01_task-test_bold.json': {
-                RepetitionTime: 1
-            }
-        };
+  it('should throw an issue if the onset of the last event in _events.tsv is less than .5 * TR * number of volumes in corresponding nifti header', function() {
+    const issues = []
+    const events = [
+      {
+        file: { path: 'sub01_task-test_events.tsv' },
+        path: 'sub01_task-test_events.tsv',
+        contents: '2\tsomething\tsomething\n',
+      },
+    ]
+    const jsonDictionary = {
+      'sub01_task-test_bold.json': {
+        RepetitionTime: 1,
+      },
+    }
 
-        validate.Events.validateEvents(events, [], headers, jsonDictionary, issues);
-        assert(issues.length === 1 && issues[0].code === 86);
-    });
+    validate.Events.validateEvents(events, [], headers, jsonDictionary, issues)
+    assert(issues.length === 1 && issues[0].code === 86)
+  })
 
-    it('should not throw any issues if the onset of the last event in _events.tsv is a reasonable value', function () {
-        const issues = [];
-        const events = [{
-            file: {path: 'sub01_task-test_events.tsv'},
-            path: 'sub01_task-test_events.tsv',
-            contents: '7\tsomething\tsomething\n'
-        }];
-        const jsonDictionary = {
-            'sub01_task-test_bold.json': {
-                RepetitionTime: 1
-            }
-        };
+  it('should not throw any issues if the onset of the last event in _events.tsv is a reasonable value', function() {
+    const issues = []
+    const events = [
+      {
+        file: { path: 'sub01_task-test_events.tsv' },
+        path: 'sub01_task-test_events.tsv',
+        contents: '7\tsomething\tsomething\n',
+      },
+    ]
+    const jsonDictionary = {
+      'sub01_task-test_bold.json': {
+        RepetitionTime: 1,
+      },
+    }
 
-        validate.Events.validateEvents(events, [], headers, jsonDictionary, issues);
-        assert.deepEqual(issues, []);
-    });
-});
+    validate.Events.validateEvents(events, [], headers, jsonDictionary, issues)
+    assert.deepEqual(issues, [])
+  })
+})

--- a/tests/json.spec.js
+++ b/tests/json.spec.js
@@ -1,72 +1,76 @@
-var assert   = require('assert');
-var validate = require('../index');
+var assert = require('assert')
+var validate = require('../index')
 
-describe('JSON', function(){
+describe('JSON', function() {
+  var file = {
+    name: 'task-rest_bold.json',
+    relativePath: '/task-rest_bold.json',
+  }
 
-	var file = {
-		name: 'task-rest_bold.json',
-		relativePath: '/task-rest_bold.json'
-	};
+  it('should catch missing closing brackets', function() {
+    validate.JSON(file, '{', function(issues) {
+      assert(issues && issues.length > 0)
+    })
+  })
 
-	it('should catch missing closing brackets', function(){
-		validate.JSON(file, '{', function (issues) {
-			assert(issues && issues.length > 0);
-		});
-	});
+  it('sidecars should have key/value pair for "RepetitionTime" expressed in seconds', function() {
+    var jsonObj =
+      '{"RepetitionTime": 1.2, "echo_time": 0.005, "flip_angle": 90, "TaskName": "Rest"}'
+    validate.JSON(file, jsonObj, function(issues) {
+      assert(issues.length === 0)
+    })
+    var jsonObjInval =
+      '{"RepetitionTime": 1200, "echo_time": 0.005, "flip_angle": 90, "TaskName": "Rest"}'
+    validate.JSON(file, jsonObjInval, function(issues) {
+      assert(issues && issues.length === 1)
+    })
+  })
 
-	it('sidecars should have key/value pair for "RepetitionTime" expressed in seconds', function(){
-		var jsonObj = '{"RepetitionTime": 1.2, "echo_time": 0.005, "flip_angle": 90, "TaskName": "Rest"}';
-		validate.JSON(file, jsonObj, function (issues) {
-			assert(issues.length === 0);
-		});
-		var jsonObjInval = '{"RepetitionTime": 1200, "echo_time": 0.005, "flip_angle": 90, "TaskName": "Rest"}';
-		validate.JSON(file, jsonObjInval, function (issues) {
-			assert(issues && issues.length === 1);
-		});
-	});
-
-	it('should detect negative value for SliceTiming', function(){
-		var jsonObj = '{"RepetitionTime": 1.2, "SliceTiming": [-1.0, 0.0, 1.0], "TaskName": "Rest"}';
-		validate.JSON(file, jsonObj, function (issues) {
-			assert(issues.length === 1 && issues[0].code == 55);
-		});
-	});
+  it('should detect negative value for SliceTiming', function() {
+    var jsonObj =
+      '{"RepetitionTime": 1.2, "SliceTiming": [-1.0, 0.0, 1.0], "TaskName": "Rest"}'
+    validate.JSON(file, jsonObj, function(issues) {
+      assert(issues.length === 1 && issues[0].code == 55)
+    })
+  })
 
   var meg_file = {
-      name: 'sub-01_run-01_meg.json',
-      relativePath: '/sub-01_run-01_meg.json'
-  };
+    name: 'sub-01_run-01_meg.json',
+    relativePath: '/sub-01_run-01_meg.json',
+  }
 
-  it('*_meg.json sidecars should have required key/value pairs', function(){
-      var jsonObj = '{"TaskName": "Audiovis", "SamplingFrequency": 1000, ' +
-                    ' "PowerLineFrequency": 50, "DewarPosition": "Upright", ' +
-                    ' "SoftwareFilters": "n/a", "DigitizedLandmarks": true,' +
-                    ' "DigitizedHeadPoints": false}';
-      validate.JSON(meg_file, jsonObj, function (issues) {
-          assert(issues.length === 0);
-      });
+  it('*_meg.json sidecars should have required key/value pairs', function() {
+    var jsonObj =
+      '{"TaskName": "Audiovis", "SamplingFrequency": 1000, ' +
+      ' "PowerLineFrequency": 50, "DewarPosition": "Upright", ' +
+      ' "SoftwareFilters": "n/a", "DigitizedLandmarks": true,' +
+      ' "DigitizedHeadPoints": false}'
+    validate.JSON(meg_file, jsonObj, function(issues) {
+      assert(issues.length === 0)
+    })
 
-      var jsonObjInval = jsonObj.replace(/"SamplingFrequency": 1000, /g, '');
-      validate.JSON(meg_file, jsonObjInval, function(issues){
-          assert(issues && issues.length === 1);
-      });
-  });
+    var jsonObjInval = jsonObj.replace(/"SamplingFrequency": 1000, /g, '')
+    validate.JSON(meg_file, jsonObjInval, function(issues) {
+      assert(issues && issues.length === 1)
+    })
+  })
 
-	var ieeg_file = {
-      name: 'sub-01_run-01_ieeg.json',
-      relativePath: '/sub-01_run-01_ieeg.json'
-  };
+  var ieeg_file = {
+    name: 'sub-01_run-01_ieeg.json',
+    relativePath: '/sub-01_run-01_ieeg.json',
+  }
 
-  it('*_ieeg.json sidecars should have required key/value pairs', function(){
-      var jsonObj = '{"TaskName": "Audiovis", "Manufacturer": "TDT", ' +
-                    ' "PowerLineFrequency": 50, "SamplingFrequency": 10, "iEEGReference": "reference"}';
-      validate.JSON(ieeg_file, jsonObj, function (issues) {
-          assert(issues.length === 0);
-      });
+  it('*_ieeg.json sidecars should have required key/value pairs', function() {
+    var jsonObj =
+      '{"TaskName": "Audiovis", "Manufacturer": "TDT", ' +
+      ' "PowerLineFrequency": 50, "SamplingFrequency": 10, "iEEGReference": "reference"}'
+    validate.JSON(ieeg_file, jsonObj, function(issues) {
+      assert(issues.length === 0)
+    })
 
-      var jsonObjInval = jsonObj.replace(/"Manufacturer": "TDT", /g, '');
-      validate.JSON(ieeg_file, jsonObjInval, function(issues){
-          assert(issues && issues.length === 1);
-      });
-  });
-});
+    var jsonObjInval = jsonObj.replace(/"Manufacturer": "TDT", /g, '')
+    validate.JSON(ieeg_file, jsonObjInval, function(issues) {
+      assert(issues && issues.length === 1)
+    })
+  })
+})

--- a/tests/nii.spec.js
+++ b/tests/nii.spec.js
@@ -1,312 +1,365 @@
-var assert   = require('assert');
-var validate = require('../index');
+var assert = require('assert')
+var validate = require('../index')
 
-describe('NIFTI', function(){
+describe('NIFTI', function() {
+  var file = {
+    name: 'sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz',
+    relativePath:
+      '/sub-15/func/sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz',
+  }
+  var jsonContentsDict = {
+    '/sub-15/func/sub-15_task-mixedeventrelatedprobe_run-01_bold.json': {
+      EchoTime: 1,
+      PhaseEncodingDirection: 3,
+      EffectiveEchoSpacing: 5,
+      SliceTiming: 3,
+      SliceEncodingDirection: 4,
+      RepetitionTime: 1,
+      TotalReadoutTime: 3,
+      TaskName: 'Mixed Event Related Probe',
+    },
+  }
+  var events = [
+    {
+      path: '/sub-15/func/sub-14_task-mixedeventrelatedprobe_run-01_events.tsv',
+    },
+    {
+      path: '/sub-15/run-01_events.tsv',
+    },
+  ]
 
+  it('should warn user about misisng events file', function() {
+    validate.NIFTI(null, file, jsonContentsDict, {}, [], events, function(
+      issues,
+    ) {
+      assert((issues.length = 1 && issues[0].code == 25))
+    })
+  })
+
+  it('should ignore missing events files for rest scans', function() {
+    jsonContentsDict[
+      '/sub-15/func/sub-15_task-mixedeventrelatedproberest_run-01_bold.json'
+    ] =
+      jsonContentsDict[
+        '/sub-15/func/sub-15_task-mixedeventrelatedprobe_run-01_bold.json'
+      ]
+    file.relativePath =
+      '/sub-15/func/sub-15_task-mixedeventrelatedproberest_run-01_bold.nii.gz'
+    validate.NIFTI(null, file, jsonContentsDict, {}, [], events, function(
+      issues,
+    ) {
+      assert.deepEqual(issues, [])
+    })
+  })
+
+  it('should catch mismatched numbers of volumes in dwi scan and .bval/.bvec files', function() {
     var file = {
-        name: 'sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz',
-        relativePath: '/sub-15/func/sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz'
-    };
+      name: 'sub-09_ses-test_dwi.nii.gz',
+      path: '/ds114/sub-09/ses-test/dwi/sub-09_ses-test_dwi.nii.gz',
+      relativePath: '/sub-09/ses-test/dwi/sub-09_ses-test_dwi.nii.gz',
+    }
+    var header = {
+      dim: [4, 128, 128, 72, 71],
+      pixdim: [-1, 2, 2, 2, 16.5],
+      xyzt_units: ['mm', 'mm', 'mm', 's'],
+    }
+    jsonContentsDict['/sub-09/ses-test/dwi/sub-09_ses-test_dwi.json'] =
+      jsonContentsDict[
+        '/sub-15/func/sub-15_task-mixedeventrelatedprobe_run-01_bold.json'
+      ]
+    var bContentsDict = {
+      '/dwi.bval':
+        '0 0 0 0 0 0 0 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000\n',
+      '/dwi.bvec':
+        '0 0 0 0 0 0 0 -1 -0.002 0.026 -0.591 0.236 0.893 -0.796 -0.234 -0.936 -0.506 -0.346 -0.457 0.487 0.618 0.577 0.827 -0.894 -0.29 -0.116 0.8 -0.514 0.789 -0.949 -0.233 0.021 -0.217 -0.774 0.161 0.147 -0.888 0.562 0.381 0.306 0.332 0.963 0.959 -0.453 0.773 -0.709 0.693 -0.682 0.142 0.74 0.103 -0.584 0.088 0.552 -0.838 -0.363 0.184 0.721 -0.433 -0.502 0.171 -0.463 -0.385 0.713 -0.26 -0.001 -0.037 -0.57 0.282 -0.721 -0.267 \n0 0 0 0 0 0 0 0 1 0.649 -0.766 -0.524 -0.259 0.129 0.93 0.14 -0.845 -0.847 -0.631 -0.389 0.673 -0.105 -0.521 -0.04 -0.541 -0.963 0.403 0.84 0.153 -0.233 0.783 -0.188 -0.956 -0.604 0.356 0.731 0.417 0.232 0.143 -0.199 -0.13 -0.265 0.205 -0.889 0.628 0.408 0.024 0.529 -0.725 0.388 0.822 -0.596 -0.335 -0.792 -0.458 -0.561 0.392 -0.693 0.682 0.69 -0.509 0.423 -0.809 -0.247 0.885 0.077 -0.902 -0.303 0.145 0.608 0.96 \n0 0 0 0 0 0 0 0 0 0.76 0.252 0.818 0.368 0.591 0.284 0.324 -0.175 -0.402 -0.627 0.782 0.407 -0.81 0.213 -0.447 -0.789 -0.245 -0.444 0.174 -0.596 0.211 0.577 -0.982 0.199 0.19 0.921 -0.666 0.193 -0.794 0.914 -0.931 0.934 0.044 0.193 0.068 0.088 0.575 0.721 -0.506 0.674 0.549 0.56 0.551 0.938 0.259 -0.296 0.744 -0.901 0.009 -0.589 0.521 -0.844 0.779 0.444 0.656 -0.387 -0.997 0.43 -0.763 -0.948 0.332 -0.085 \n',
+    }
+    validate.NIFTI(
+      header,
+      file,
+      jsonContentsDict,
+      bContentsDict,
+      [],
+      [],
+      function(issues) {
+        assert(issues.length == 1 && issues[0].code == 29)
+      },
+    )
+  })
+
+  it('should catch missing .bval an .bvec files', function() {
+    var file = {
+      name: 'sub-09_ses-test_dwi.nii.gz',
+      path: '/ds114/sub-09/ses-test/dwi/sub-09_ses-test_dwi.nii.gz',
+      relativePath: '/sub-09/ses-test/dwi/sub-09_ses-test_dwi.nii.gz',
+    }
+    validate.NIFTI(null, file, jsonContentsDict, {}, [], [], function(issues) {
+      assert(issues.length == 2 && issues[0].code == 32 && issues[1].code == 33)
+    })
+  })
+
+  it('should catch missing task name definitions on task scans', function() {
+    delete jsonContentsDict[
+      '/sub-15/func/sub-15_task-mixedeventrelatedproberest_run-01_bold.json'
+    ].TaskName
+    validate.NIFTI(null, file, jsonContentsDict, {}, [], events, function(
+      issues,
+    ) {
+      assert((issues.length = 1 && issues[0].code == 50))
+    })
+  })
+
+  it('should ignore missing task name definitions on sbref task scans', function() {
+    var file = {
+      name: 'sub-15_task-mixedeventrelatedprobe_acq-LR_sbref.nii.gz',
+      relativePath:
+        '/sub-15/func/sub-15_task-mixedeventrelatedprobe_acq-LR_sbref.nii.gz',
+    }
+    jsonContentsDict[file.relativePath.replace('.nii.gz', '.json')] =
+      jsonContentsDict[
+        '/sub-15/func/sub-15_task-mixedeventrelatedproberest_run-01_bold.json'
+      ]
+    validate.NIFTI(null, file, jsonContentsDict, {}, [], events, function(
+      issues,
+    ) {
+      assert.deepEqual(issues, [])
+    })
+  })
+
+  it('should generate warning if files listed in IntendedFor of fieldmap json do not exist', function() {
+    var file = {
+      name: 'sub-09_ses-test_run-01_fieldmap.nii.gz',
+      path:
+        '/ds114/sub-09/ses-test/fmap/sub-09_ses-test_run-01_fieldmap.nii.gz',
+      relativePath:
+        '/sub-09/ses-test/fmap/sub-09_ses-test_run-01_fieldmap.nii.gz',
+    }
+
     var jsonContentsDict = {
-        '/sub-15/func/sub-15_task-mixedeventrelatedprobe_run-01_bold.json': {
-            EchoTime: 1,
-            PhaseEncodingDirection: 3,
-            EffectiveEchoSpacing: 5,
-            SliceTiming: 3,
-            SliceEncodingDirection: 4,
-            RepetitionTime: 1,
-            TotalReadoutTime: 3,
-            TaskName: 'Mixed Event Related Probe'
-        }
-    };
+      '/sub-09/ses-test/fmap/sub-09_ses-test_run-01_fieldmap.json': {
+        TaskName: 'Mixed Event Related Probe',
+        IntendedFor: [
+          'func/sub-15_task-mixedeventrelatedprobe_run-05_bold.nii.gz',
+          'func/sub-15_task-mixedeventrelatedprobe_run-02_bold.nii.gz',
+        ],
+      },
+    }
+    var fileList = []
+    fileList.push({
+      name: 'sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz',
+      path: 'sub-15/func/sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz',
+      relativePath:
+        '/func/sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz',
+    })
+    validate.NIFTI(null, file, jsonContentsDict, {}, [], [], function(issues) {
+      assert(
+        (issues.length = 2 && issues[0].code == 17 && issues[1].code == 37),
+      )
+    })
+  })
+
+  it('should not generate warning if files listed in IntendedFor of fieldmap json exist', function() {
+    var file = {
+      name: 'sub-15_ses-test_run-01_fieldmap.nii.gz',
+      path: '/ds114/sub-15/ses-test/dwi/sub-15_ses-test_run-01_fieldmap.nii.gz',
+      relativePath:
+        '/sub-15/ses-test/dwi/sub-15_ses-test_run-01_fieldmap.nii.gz',
+    }
+
+    var jsonContentsDict = {
+      '/sub-15/ses-test/dwi/sub-15_ses-test_run-01_fieldmap.json': {
+        TaskName: 'Mixed Event Related Probe',
+        Units: 'rad/s',
+        IntendedFor: [
+          'func/sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz',
+        ],
+      },
+    }
+
+    var fileList = [
+      {
+        name: 'sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz',
+        path:
+          'sub-15/func/sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz',
+        relativePath:
+          '/sub-15/func/sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz',
+      },
+    ]
+    validate.NIFTI(null, file, jsonContentsDict, {}, fileList, [], function(
+      issues,
+    ) {
+      assert.deepEqual(issues, [])
+    })
+  })
+
+  it('SliceTiming should not be greater than RepetitionTime', function() {
+    var jsonContentsDict_new = {
+      '/sub-15/func/sub-15_task-mixedeventrelatedprobe_run-01_bold.json': {
+        RepetitionTime: 1.5,
+        TaskName:
+          'AntiSaccade (AS) Rewarded & Neutral with varying dot position',
+        EchoTime: 0.025,
+        NumberofPhaseEncodingSteps: 64,
+        FlipAngle: 70,
+        PhaseEncodingDirection: 'j',
+        SliceTiming: [0.0, 1.3448, 1.6207, 1.3966, 0.6724, 1.4483, 1.7241],
+      },
+    }
+    var file_new = {
+      name: 'sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz',
+      relativePath:
+        '/sub-15/func/sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz',
+    }
+    validate.NIFTI(
+      null,
+      file_new,
+      jsonContentsDict_new,
+      {},
+      [],
+      events,
+      function(issues) {
+        assert(issues[2].code === 66 && issues.length === 3)
+      },
+    )
+  })
+
+  it('SliceTiming should be the same length as the k dimension of the corresponding nifti header', function() {
+    var jsonContents = {
+      '/sub-15/func/sub-15_task-mixedeventrelatedprobe_run-01_bold.json': {
+        RepetitionTime: 16.5,
+        TaskName:
+          'AntiSaccade (AS) Rewarded & Neutral with varying dot position',
+        EchoTime: 0.025,
+        EffectiveEchoSpacing: 0.05,
+        NumberofPhaseEncodingSteps: 64,
+        FlipAngle: 70,
+        PhaseEncodingDirection: 'j',
+        SliceTiming: [0.0, 1.3448, 1.6207, 1.3966, 0.6724, 1.4483, 1.7241],
+      },
+    }
+    var testFile = {
+      name: 'sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz',
+      relativePath:
+        '/sub-15/func/sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz',
+    }
+    var header = {
+      dim: [4, 128, 128, 7, 71],
+      pixdim: [-1, 2, 2, 2, 16.5],
+      xyzt_units: ['mm', 'mm', 'mm', 's'],
+    }
     var events = [
-        {
-            path: '/sub-15/func/sub-14_task-mixedeventrelatedprobe_run-01_events.tsv'
-        }, 
-        {
-            path: '/sub-15/run-01_events.tsv'
-        }
-    ];
+      {
+        path:
+          '/sub-15/func/sub-15_task-mixedeventrelatedprobe_run-01_events.tsv',
+      },
+      {
+        path: '/sub-15/run-01_events.tsv',
+      },
+    ]
+    validate.NIFTI(header, testFile, jsonContents, {}, [], events, function(
+      issues,
+    ) {
+      assert.deepEqual(issues, [])
+    })
+  })
 
-    it('should warn user about misisng events file', function() {
-        validate.NIFTI(null, file, jsonContentsDict, {}, [], events, function (issues) {
-            assert(issues.length = 1 && issues[0].code == 25);
-        });
-    });
+  it('SliceTiming should not have a length different than the k dimension of the corresponding nifti header', function() {
+    var jsonContents = {
+      '/sub-15/func/sub-15_task-mixedeventrelatedprobe_run-01_bold.json': {
+        RepetitionTime: 16.5,
+        TaskName:
+          'AntiSaccade (AS) Rewarded & Neutral with varying dot position',
+        EchoTime: 0.025,
+        EffectiveEchoSpacing: 0.05,
+        NumberofPhaseEncodingSteps: 64,
+        FlipAngle: 70,
+        PhaseEncodingDirection: 'j',
+        SliceTiming: [0.0, 1.3448, 1.6207, 1.3966, 0.6724, 1.4483, 1.7241],
+      },
+    }
+    var testFile = {
+      name: 'sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz',
+      relativePath:
+        '/sub-15/func/sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz',
+    }
+    var header = {
+      dim: [4, 128, 128, 5, 71],
+      pixdim: [-1, 2, 2, 2, 16.5],
+      xyzt_units: ['mm', 'mm', 'mm', 's'],
+    }
+    var events = [
+      {
+        path:
+          '/sub-15/func/sub-15_task-mixedeventrelatedprobe_run-01_events.tsv',
+      },
+      {
+        path: '/sub-15/run-01_events.tsv',
+      },
+    ]
 
-    it('should ignore missing events files for rest scans', function() {
-        jsonContentsDict['/sub-15/func/sub-15_task-mixedeventrelatedproberest_run-01_bold.json'] = jsonContentsDict['/sub-15/func/sub-15_task-mixedeventrelatedprobe_run-01_bold.json'];
-        file.relativePath = '/sub-15/func/sub-15_task-mixedeventrelatedproberest_run-01_bold.nii.gz';
-        validate.NIFTI(null, file, jsonContentsDict, {}, [], events, function (issues) {
-            assert.deepEqual(issues, []);
-        });
-    });
+    validate.NIFTI(header, testFile, jsonContents, {}, [], events, function(
+      issues,
+    ) {
+      assert(issues.length === 1 && issues[0].code === 87)
+    })
+  })
 
-    it('should catch mismatched numbers of volumes in dwi scan and .bval/.bvec files', function() {
-        var file = {
-            name: 'sub-09_ses-test_dwi.nii.gz',
-            path: '/ds114/sub-09/ses-test/dwi/sub-09_ses-test_dwi.nii.gz',
-            relativePath: '/sub-09/ses-test/dwi/sub-09_ses-test_dwi.nii.gz'
-        };
-        var header = {
-            dim: [ 4, 128, 128, 72, 71 ],
-            pixdim: [ -1, 2, 2, 2, 16.5 ],
-            xyzt_units: [ 'mm', 'mm', 'mm', 's' ]
-        };
-        jsonContentsDict['/sub-09/ses-test/dwi/sub-09_ses-test_dwi.json'] = jsonContentsDict['/sub-15/func/sub-15_task-mixedeventrelatedprobe_run-01_bold.json'];
-        var bContentsDict = {
-            '/dwi.bval': '0 0 0 0 0 0 0 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000\n',
-            '/dwi.bvec': '0 0 0 0 0 0 0 -1 -0.002 0.026 -0.591 0.236 0.893 -0.796 -0.234 -0.936 -0.506 -0.346 -0.457 0.487 0.618 0.577 0.827 -0.894 -0.29 -0.116 0.8 -0.514 0.789 -0.949 -0.233 0.021 -0.217 -0.774 0.161 0.147 -0.888 0.562 0.381 0.306 0.332 0.963 0.959 -0.453 0.773 -0.709 0.693 -0.682 0.142 0.74 0.103 -0.584 0.088 0.552 -0.838 -0.363 0.184 0.721 -0.433 -0.502 0.171 -0.463 -0.385 0.713 -0.26 -0.001 -0.037 -0.57 0.282 -0.721 -0.267 \n0 0 0 0 0 0 0 0 1 0.649 -0.766 -0.524 -0.259 0.129 0.93 0.14 -0.845 -0.847 -0.631 -0.389 0.673 -0.105 -0.521 -0.04 -0.541 -0.963 0.403 0.84 0.153 -0.233 0.783 -0.188 -0.956 -0.604 0.356 0.731 0.417 0.232 0.143 -0.199 -0.13 -0.265 0.205 -0.889 0.628 0.408 0.024 0.529 -0.725 0.388 0.822 -0.596 -0.335 -0.792 -0.458 -0.561 0.392 -0.693 0.682 0.69 -0.509 0.423 -0.809 -0.247 0.885 0.077 -0.902 -0.303 0.145 0.608 0.96 \n0 0 0 0 0 0 0 0 0 0.76 0.252 0.818 0.368 0.591 0.284 0.324 -0.175 -0.402 -0.627 0.782 0.407 -0.81 0.213 -0.447 -0.789 -0.245 -0.444 0.174 -0.596 0.211 0.577 -0.982 0.199 0.19 0.921 -0.666 0.193 -0.794 0.914 -0.931 0.934 0.044 0.193 0.068 0.088 0.575 0.721 -0.506 0.674 0.549 0.56 0.551 0.938 0.259 -0.296 0.744 -0.901 0.009 -0.589 0.521 -0.844 0.779 0.444 0.656 -0.387 -0.997 0.43 -0.763 -0.948 0.332 -0.085 \n'
-        };
-        validate.NIFTI(header, file, jsonContentsDict, bContentsDict, [], [], function (issues) {
-            assert(issues.length == 1 && issues[0].code == 29);
-        });
-    });
+  it('should throw an error for _phasediff.nii files with associated (EchoTime2 - EchoTime1) less than 0.0001', function() {
+    var phaseDiffJson = {
+      '/sub-01/func/sub-01_ses-mri_phasediff.json': {
+        RepetitionTime: 0.4,
+        EchoTime1: 0.00515,
+        EchoTime2: 0.00519,
+        FlipAngle: 60,
+      },
+    }
+    var phaseDiffFile = {
+      name: 'sub-01_ses-mri_phasediff.nii',
+      relativePath: '/sub-01/func/sub-01_ses-mri_phasediff.nii',
+    }
+    validate.NIFTI(null, phaseDiffFile, phaseDiffJson, {}, [], events, function(
+      issues,
+    ) {
+      assert(issues[0].code === 83 && issues.length === 1)
+    })
+  })
 
-    it('should catch missing .bval an .bvec files', function() {
-        var file = {
-            name: 'sub-09_ses-test_dwi.nii.gz',
-            path: '/ds114/sub-09/ses-test/dwi/sub-09_ses-test_dwi.nii.gz',
-            relativePath: '/sub-09/ses-test/dwi/sub-09_ses-test_dwi.nii.gz'
-        };
-        validate.NIFTI(null, file, jsonContentsDict, {}, [], [], function (issues) {
-            assert(issues.length == 2 && issues[0].code == 32 && issues[1].code == 33);
-        });
-    });
+  it('should throw an error for _phasediff.nii files with associated (EchoTime2 - EchoTime1) greater than 0.01', function() {
+    var phaseDiffJson = {
+      '/sub-01/func/sub-01_ses-mri_phasediff.json': {
+        RepetitionTime: 0.4,
+        EchoTime1: 0.00515,
+        EchoTime2: 0.1019,
+        FlipAngle: 60,
+      },
+    }
+    var phaseDiffFile = {
+      name: 'sub-01_ses-mri_phasediff.nii',
+      relativePath: '/sub-01/func/sub-01_ses-mri_phasediff.nii',
+    }
+    validate.NIFTI(null, phaseDiffFile, phaseDiffJson, {}, [], events, function(
+      issues,
+    ) {
+      assert(issues[0].code === 83 && issues.length === 1)
+    })
+  })
 
-    it('should catch missing task name definitions on task scans', function() {
-        delete jsonContentsDict['/sub-15/func/sub-15_task-mixedeventrelatedproberest_run-01_bold.json'].TaskName;
-        validate.NIFTI(null, file, jsonContentsDict, {}, [], events, function (issues) {
-            assert(issues.length = 1 && issues[0].code == 50);
-        });
-    });
-
-    it('should ignore missing task name definitions on sbref task scans', function() {
-        var file = {
-            name: 'sub-15_task-mixedeventrelatedprobe_acq-LR_sbref.nii.gz',
-            relativePath: '/sub-15/func/sub-15_task-mixedeventrelatedprobe_acq-LR_sbref.nii.gz'
-        };
-        jsonContentsDict[file.relativePath.replace('.nii.gz', '.json')] = jsonContentsDict['/sub-15/func/sub-15_task-mixedeventrelatedproberest_run-01_bold.json'];
-        validate.NIFTI(null, file, jsonContentsDict, {}, [], events, function (issues) {
-            assert.deepEqual(issues, []);
-        });
-    });
-
-    it('should generate warning if files listed in IntendedFor of fieldmap json do not exist', function() {
-      var file = {
-          name: 'sub-09_ses-test_run-01_fieldmap.nii.gz',
-          path: '/ds114/sub-09/ses-test/fmap/sub-09_ses-test_run-01_fieldmap.nii.gz',
-          relativePath: '/sub-09/ses-test/fmap/sub-09_ses-test_run-01_fieldmap.nii.gz'
-      };
-
-      var jsonContentsDict = {
-          '/sub-09/ses-test/fmap/sub-09_ses-test_run-01_fieldmap.json': {
-              TaskName: 'Mixed Event Related Probe',
-              IntendedFor: ['func/sub-15_task-mixedeventrelatedprobe_run-05_bold.nii.gz','func/sub-15_task-mixedeventrelatedprobe_run-02_bold.nii.gz'
-            ]
-          }
-        };
-      var fileList = [];
-      fileList.push({ name:'sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz',
-        path: 'sub-15/func/sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz',
-        relativePath: '/func/sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz'});
-      validate.NIFTI(null, file, jsonContentsDict, {}, [], [], function (issues) {
-          assert(issues.length = 2 && issues[0].code == 17  && issues[1].code == 37);
-      });
-    });
-
-    it('should not generate warning if files listed in IntendedFor of fieldmap json exist', function() {
-      var file = {
-          name: 'sub-15_ses-test_run-01_fieldmap.nii.gz',
-          path: '/ds114/sub-15/ses-test/dwi/sub-15_ses-test_run-01_fieldmap.nii.gz',
-          relativePath: '/sub-15/ses-test/dwi/sub-15_ses-test_run-01_fieldmap.nii.gz'
-      };
-
-      var jsonContentsDict = {
-          '/sub-15/ses-test/dwi/sub-15_ses-test_run-01_fieldmap.json': {
-              TaskName: 'Mixed Event Related Probe',
-              Units: 'rad/s',
-              IntendedFor: ['func/sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz'
-            ]
-          }
-        };
-
-      var fileList = [{ name:'sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz',
-        path: 'sub-15/func/sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz',
-        relativePath: '/sub-15/func/sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz'}];
-      validate.NIFTI(null, file, jsonContentsDict, {}, fileList, [], function (issues) {
-          assert.deepEqual(issues, []);
-      });
-    });
-
-    it('SliceTiming should not be greater than RepetitionTime', function(){
-        var jsonContentsDict_new = {
-            '/sub-15/func/sub-15_task-mixedeventrelatedprobe_run-01_bold.json': {
-                "RepetitionTime": 1.5,
-                "TaskName": "AntiSaccade (AS) Rewarded & Neutral with varying dot position",
-                "EchoTime": 0.025,
-                "NumberofPhaseEncodingSteps": 64,
-                "FlipAngle": 70,
-                "PhaseEncodingDirection": "j",
-                "SliceTiming": [
-                    0.0,
-                    1.3448,
-                    1.6207,
-                    1.3966,
-                    0.6724,
-                    1.4483,
-                    1.7241
-                ]
-            }
-        };
-        var file_new = {
-            name: 'sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz',
-            relativePath: '/sub-15/func/sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz'
-        };
-        validate.NIFTI(null, file_new, jsonContentsDict_new, {}, [], events, function (issues) {
-            assert(issues[2].code === 66 && issues.length === 3);
-        });
-    });
-
-    it('SliceTiming should be the same length as the k dimension of the corresponding nifti header', function(){
-        var jsonContents = {
-            '/sub-15/func/sub-15_task-mixedeventrelatedprobe_run-01_bold.json': {
-                "RepetitionTime": 16.5,
-                "TaskName": "AntiSaccade (AS) Rewarded & Neutral with varying dot position",
-                "EchoTime": 0.025,
-                "EffectiveEchoSpacing": .05, 
-                "NumberofPhaseEncodingSteps": 64,
-                "FlipAngle": 70,
-                "PhaseEncodingDirection": "j",
-                "SliceTiming": [
-                    0.0,
-                    1.3448,
-                    1.6207,
-                    1.3966,
-                    0.6724,
-                    1.4483,
-                    1.7241
-                ]
-            }
-        };
-        var testFile = {
-            name: 'sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz',
-            relativePath: '/sub-15/func/sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz'
-        };
-        var header = {
-            dim: [ 4, 128, 128, 7, 71 ],
-            pixdim: [ -1, 2, 2, 2, 16.5 ],
-            xyzt_units: [ 'mm', 'mm', 'mm', 's' ]
-        };
-        var events = [
-            {
-                path: '/sub-15/func/sub-15_task-mixedeventrelatedprobe_run-01_events.tsv'
-            }, 
-            {
-                path: '/sub-15/run-01_events.tsv'
-            }
-        ];
-        validate.NIFTI(header, testFile, jsonContents, {}, [], events, function (issues) {
-            assert.deepEqual(issues, []);
-        });
-    });
-
-    it('SliceTiming should not have a length different than the k dimension of the corresponding nifti header', function(){
-        var jsonContents = {
-            '/sub-15/func/sub-15_task-mixedeventrelatedprobe_run-01_bold.json': {
-                "RepetitionTime": 16.5,
-                "TaskName": "AntiSaccade (AS) Rewarded & Neutral with varying dot position",
-                "EchoTime": 0.025,
-                "EffectiveEchoSpacing": .05, 
-                "NumberofPhaseEncodingSteps": 64,
-                "FlipAngle": 70,
-                "PhaseEncodingDirection": "j",
-                "SliceTiming": [
-                    0.0,
-                    1.3448,
-                    1.6207,
-                    1.3966,
-                    0.6724,
-                    1.4483,
-                    1.7241
-                ]
-            }
-        };
-        var testFile = {
-            name: 'sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz',
-            relativePath: '/sub-15/func/sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz'
-        };
-        var header = {
-            dim: [ 4, 128, 128, 5, 71 ],
-            pixdim: [ -1, 2, 2, 2, 16.5 ],
-            xyzt_units: [ 'mm', 'mm', 'mm', 's' ]
-        };
-        var events = [
-            {
-                path: '/sub-15/func/sub-15_task-mixedeventrelatedprobe_run-01_events.tsv'
-            }, 
-            {
-                path: '/sub-15/run-01_events.tsv'
-            }
-        ];
-
-        validate.NIFTI(header, testFile, jsonContents, {}, [], events, function (issues) {
-            assert(issues.length === 1 && issues[0].code === 87);
-        });
-    });
-
-    it('should throw an error for _phasediff.nii files with associated (EchoTime2 - EchoTime1) less than 0.0001', function(){
-        var phaseDiffJson = {
-            '/sub-01/func/sub-01_ses-mri_phasediff.json': {
-                "RepetitionTime": 0.4,
-                "EchoTime1": 0.00515,
-                "EchoTime2": 0.00519,
-                "FlipAngle": 60,
-            }
-        };
-        var phaseDiffFile = {
-            name: 'sub-01_ses-mri_phasediff.nii',
-            relativePath: '/sub-01/func/sub-01_ses-mri_phasediff.nii'
-        };
-        validate.NIFTI(null, phaseDiffFile, phaseDiffJson, {}, [], events, function (issues) {
-            assert(issues[0].code === 83 && issues.length === 1);
-        });
-    });
-
-    it('should throw an error for _phasediff.nii files with associated (EchoTime2 - EchoTime1) greater than 0.01', function(){
-        var phaseDiffJson = {
-            '/sub-01/func/sub-01_ses-mri_phasediff.json': {
-                "RepetitionTime": 0.4,
-                "EchoTime1": 0.00515,
-                "EchoTime2": 0.1019,
-                "FlipAngle": 60,
-            }
-        };
-        var phaseDiffFile = {
-            name: 'sub-01_ses-mri_phasediff.nii',
-            relativePath: '/sub-01/func/sub-01_ses-mri_phasediff.nii'
-        };
-        validate.NIFTI(null, phaseDiffFile, phaseDiffJson, {}, [], events, function (issues) {
-            assert(issues[0].code === 83 && issues.length === 1);
-        });
-    });
-
-    it('should give not error for _phasediff.nii files with reasonable values of associated (EchoTime2 - EchoTime1)', function(){
-        var phaseDiffJson = {
-            '/sub-01/func/sub-01_ses-mri_phasediff.json': {
-                "RepetitionTime": 0.4,
-                "EchoTime1": 0.00515,
-                "EchoTime2": 0.00819,
-                "FlipAngle": 60,
-            }
-        };
-        var phaseDiffFile = {
-            name: 'sub-01_ses-mri_phasediff.nii',
-            relativePath: '/sub-01/func/sub-01_ses-mri_phasediff.nii'
-        };
-        validate.NIFTI(null, phaseDiffFile, phaseDiffJson, {}, [], events, function (issues) {
-            assert(issues.length === 0);
-        });
-    });
-
-});
+  it('should give not error for _phasediff.nii files with reasonable values of associated (EchoTime2 - EchoTime1)', function() {
+    var phaseDiffJson = {
+      '/sub-01/func/sub-01_ses-mri_phasediff.json': {
+        RepetitionTime: 0.4,
+        EchoTime1: 0.00515,
+        EchoTime2: 0.00819,
+        FlipAngle: 60,
+      },
+    }
+    var phaseDiffFile = {
+      name: 'sub-01_ses-mri_phasediff.nii',
+      relativePath: '/sub-01/func/sub-01_ses-mri_phasediff.nii',
+    }
+    validate.NIFTI(null, phaseDiffFile, phaseDiffJson, {}, [], events, function(
+      issues,
+    ) {
+      assert(issues.length === 0)
+    })
+  })
+})

--- a/tests/tsv.spec.js
+++ b/tests/tsv.spec.js
@@ -1,334 +1,361 @@
-var assert   = require('assert');
-var validate = require('../index');
+var assert = require('assert')
+var validate = require('../index')
 
-describe('TSV', function(){
+describe('TSV', function() {
+  // general tsv checks ------------------------------------------------------------------
 
-// general tsv checks ------------------------------------------------------------------
+  var file = {
+    name: 'sub-08_ses-test_task-­nback_physio.tsv.gz',
+    relativePath:
+      '/sub-08/ses-test/func/sub-08_ses-test_task-linebisection_events.tsv',
+  }
 
-    var file = {
-        name: 'sub-08_ses-test_task-­nback_physio.tsv.gz',
-        relativePath: '/sub-08/ses-test/func/sub-08_ses-test_task-linebisection_events.tsv'
-    };
+  it('should not allow empty values saved as empty cells.', function() {
+    var tsv = '1.0\t\t0.2\tresponse 1\t12.32'
+    validate.TSV.TSV(file, tsv, [], function(issues) {
+      assert(issues.length === 1 && issues[0].code === 23)
+    })
+  })
 
-    it('should not allow empty values saved as empty cells.', function () {
-        var tsv = "1.0\t\t0.2\tresponse 1\t12.32";
-        validate.TSV.TSV(file, tsv, [], function (issues) {
-            assert(issues.length === 1 && issues[0].code === 23);
-        });
+  it('should not allow missing values that are specified by something other than "n/a".', function() {
+    var tsv = '1.0\tNA\t0.2\tresponse 1\t12.32'
+    validate.TSV.TSV(file, tsv, [], function(issues) {
+      assert(issues.length === 1 && issues[0].code === 24)
+    })
+  })
 
-    });
+  it('should not allow different length rows', function() {
+    var tsv =
+      'header-one\theader-two\theader-three\n' +
+      'value-one\tvalue-two\n' +
+      'value-one\tvalue-two\tvalue-three'
+    validate.TSV.TSV(file, tsv, [], function(issues) {
+      assert(issues.length === 1 && issues[0].code === 22)
+    })
+  })
 
-    it('should not allow missing values that are specified by something other than "n/a".', function () {
-        var tsv = "1.0\tNA\t0.2\tresponse 1\t12.32";
-        validate.TSV.TSV(file, tsv, [], function (issues) {
-            assert(issues.length === 1 && issues[0].code === 24);
-        });
-    });
+  // events checks -----------------------------------------------------------------------
 
-    it('should not allow different length rows', function () {
-        var tsv = 'header-one\theader-two\theader-three\n' +
-                  'value-one\tvalue-two\n' +
-                  'value-one\tvalue-two\tvalue-three';
-        validate.TSV.TSV(file, tsv, [], function (issues) {
-            assert(issues.length === 1 && issues[0].code === 22);
-        });
-    });
+  var eventsFile = {
+    name: 'sub-08_ses-test_task-linebisection_events.tsv',
+    relativePath:
+      '/sub-08/ses-test/func/sub-08_ses-test_task-linebisection_events.tsv',
+  }
 
-// events checks -----------------------------------------------------------------------
+  it('should require events files to have "onset" as first header', function() {
+    var tsv =
+      'header-one\tduration\theader-three\n' +
+      'value-one\tvalue-two\tvalue-three'
+    validate.TSV.TSV(eventsFile, tsv, [], function(issues) {
+      assert(issues.length === 1 && issues[0].code === 20)
+    })
+  })
 
-    var eventsFile = {
-        name: 'sub-08_ses-test_task-linebisection_events.tsv',
-        relativePath: '/sub-08/ses-test/func/sub-08_ses-test_task-linebisection_events.tsv'
-    };
+  it('should require events files to have "duration" as second header', function() {
+    var tsv =
+      'onset\theader-two\theader-three\n' + 'value-one\tvalue-two\tvalue-three'
+    validate.TSV.TSV(eventsFile, tsv, [], function(issues) {
+      assert(issues.length === 1 && issues[0].code === 21)
+    })
+  })
 
-    it('should require events files to have "onset" as first header', function () {
-        var tsv = 'header-one\tduration\theader-three\n' +
-                  'value-one\tvalue-two\tvalue-three';
-        validate.TSV.TSV(eventsFile, tsv, [], function (issues) {
-            assert(issues.length === 1 && issues[0].code === 20);
-        });
-    });
+  it('should not throw issues for a valid events file', function() {
+    var tsv =
+      'onset\tduration\theader-three\n' + 'value-one\tvalue-two\tvalue-three'
+    validate.TSV.TSV(eventsFile, tsv, [], function(issues) {
+      assert.deepEqual(issues, [])
+    })
+  })
 
-    it('should require events files to have "duration" as second header', function () {
-        var tsv = 'onset\theader-two\theader-three\n' +
-                  'value-one\tvalue-two\tvalue-three';
-        validate.TSV.TSV(eventsFile, tsv, [], function (issues) {
-            assert(issues.length === 1 && issues[0].code === 21);
-        });
-    });
+  it('should not throw issues for a valid events file with only two columns', function() {
+    var tsv = 'onset\tduration\n' + 'value-one\tvalue-two'
+    validate.TSV.TSV(eventsFile, tsv, [], function(issues) {
+      assert.deepEqual(issues, [])
+    })
+  })
 
-    it('should not throw issues for a valid events file', function () {
-        var tsv = 'onset\tduration\theader-three\n' +
-                  'value-one\tvalue-two\tvalue-three';
-        validate.TSV.TSV(eventsFile, tsv, [], function (issues) {
-            assert.deepEqual(issues, []);
-        });
-    });
+  it('should check for the presence of any stimulus files declared', function() {
+    var tsv =
+      'onset\tduration\tstim_file\n' +
+      'value-one\tvalue-two\timages/red-square.jpg'
+    var fileList = [{ relativePath: '/stimuli/images/blue-square.jpg' }]
+    validate.TSV.TSV(eventsFile, tsv, fileList, function(issues) {
+      assert(issues.length === 1 && issues[0].code === 52)
+    })
 
-    it('should not throw issues for a valid events file with only two columns', function () {
-        var tsv = 'onset\tduration\n' +
-                  'value-one\tvalue-two';
-        validate.TSV.TSV(eventsFile, tsv, [], function (issues) {
-            assert.deepEqual(issues, []);
-        });
-    });
+    fileList.push({ relativePath: '/stimuli/images/red-square.jpg' })
+    validate.TSV.TSV(eventsFile, tsv, fileList, function(issues) {
+      assert.deepEqual(issues, [])
+    })
+  })
 
-    it('should check for the presence of any stimulus files declared', function () {
-        var tsv = 'onset\tduration\tstim_file\n' +
-                  'value-one\tvalue-two\timages/red-square.jpg';
-        var fileList = [{relativePath: '/stimuli/images/blue-square.jpg'}];
-        validate.TSV.TSV(eventsFile, tsv, fileList, function (issues) {
-            assert(issues.length === 1 && issues[0].code === 52);
-        });
+  it('should return all values in the stim_file column as a list', function() {
+    var tsv =
+      'onset\tduration\tstim_file\n' +
+      'value-one\tvalue-two\timages/red-square.jpg'
+    var fileList = [{ relativePath: '/stimuli/images/red-square.jpg' }]
+    validate.TSV.TSV(eventsFile, tsv, fileList, function(
+      issues,
+      participants,
+      stimFiles,
+    ) {
+      assert(
+        stimFiles.length === 1 &&
+          stimFiles[0] === '/stimuli/images/red-square.jpg',
+      )
+    })
+  })
 
-        fileList.push({relativePath: '/stimuli/images/red-square.jpg'});
-        validate.TSV.TSV(eventsFile, tsv, fileList, function (issues) {
-            assert.deepEqual(issues, []);
-        });
-    });
+  // participants checks -----------------------------------------------------------------
 
-    it('should return all values in the stim_file column as a list', function () {
-        var tsv = 'onset\tduration\tstim_file\n' +
-                  'value-one\tvalue-two\timages/red-square.jpg';
-        var fileList = [{relativePath: '/stimuli/images/red-square.jpg'}];
-        validate.TSV.TSV(eventsFile, tsv, fileList, function (issues, participants, stimFiles) {
-            assert(stimFiles.length === 1 && stimFiles[0] === '/stimuli/images/red-square.jpg');
-        });
-    });
+  var participantsFile = {
+    name: 'participants.tsv',
+    relativePath: '/participants.tsv',
+  }
 
-// participants checks -----------------------------------------------------------------
+  it('should not allow participants.tsv files without participant_id columns', function() {
+    var tsv =
+      'subject_id\theader-two\theader-three\n' +
+      'value-one\tvalue-two\tvalue-three'
+    validate.TSV.TSV(participantsFile, tsv, [], function(issues) {
+      assert(issues.length === 1 && issues[0].code === 48)
+    })
+  })
 
-    var participantsFile = {
-        name: 'participants.tsv',
-        relativePath: '/participants.tsv'
-    };
+  it('should allow a valid participants.tsv file', function() {
+    var tsv =
+      'participant_id\theader-two\theader-three\n' +
+      'value-one\tvalue-two\tvalue-three'
+    validate.TSV.TSV(participantsFile, tsv, [], function(issues) {
+      assert.deepEqual(issues, [])
+    })
+  })
 
-    it("should not allow participants.tsv files without participant_id columns", function () {
-        var tsv = 'subject_id\theader-two\theader-three\n' +
-                  'value-one\tvalue-two\tvalue-three';
-        validate.TSV.TSV(participantsFile, tsv, [], function (issues) {
-            assert(issues.length === 1 && issues[0].code === 48);
-        });
-    });
+  it('should not allow particpants with age 89 and above in participants.tsv file', function() {
+    var tsv = 'participant_id\theader-two\tage\n' + 'sub-01\tvalue-two\t89'
+    validate.TSV.TSV(participantsFile, tsv, [], function(issues) {
+      assert(issues.length === 1 && issues[0].code === 56)
+    })
+  })
 
-    it("should allow a valid participants.tsv file", function () {
-        var tsv = 'participant_id\theader-two\theader-three\n' +
-                  'value-one\tvalue-two\tvalue-three';
-        validate.TSV.TSV(participantsFile, tsv, [], function (issues) {
-            assert.deepEqual(issues, []);
-        });
-    });
+  // _scans checks -----------------------------------------------------------------
 
-    it("should not allow particpants with age 89 and above in participants.tsv file", function () {
-        var tsv = 'participant_id\theader-two\tage\n' + 'sub-01\tvalue-two\t89';
-        validate.TSV.TSV(participantsFile, tsv, [], function (issues) {
-            assert(issues.length === 1 && issues[0].code === 56);
-        });
-    });
+  var scansFile = {
+    name: 'sub-08_ses-test_task-linebisection_scans.tsv',
+    relativePath:
+      '/sub-08/ses-test/func/sub-08_ses-test_task-linebisection_scans.tsv',
+  }
 
-// _scans checks -----------------------------------------------------------------
+  it('should not allow _scans.tsv files without filename column', function() {
+    var tsv =
+      'header-one\theader-two\theader-three\n' +
+      'value-one\tvalue-two\tvalue-three'
+    validate.TSV.TSV(scansFile, tsv, [], function(issues) {
+      assert(issues.length === 1 && issues[0].code === 68)
+    })
+  })
 
-    var scansFile = {
-        name: 'sub-08_ses-test_task-linebisection_scans.tsv',
-        relativePath: '/sub-08/ses-test/func/sub-08_ses-test_task-linebisection_scans.tsv'
-    };
+  it('should allow _scans.tsv files with filename column', function() {
+    var tsv =
+      'header-one\tfilename\theader-three\n' +
+      'value-one\tvalue-two\tvalue-three'
+    validate.TSV.TSV(scansFile, tsv, [], function(issues) {
+      assert.deepEqual(issues, [])
+    })
+  })
 
-    it("should not allow _scans.tsv files without filename column", function () {
-        var tsv = 'header-one\theader-two\theader-three\n' +
-                  'value-one\tvalue-two\tvalue-three';
-        validate.TSV.TSV(scansFile, tsv, [], function (issues) {
-            assert(issues.length === 1 && issues[0].code === 68);
-        });
-    });
+  it('should not allow improperly formatted acq_time column entries', function() {
+    const tsv = 'filename\tacq_time\n' + 'value-one\t000001'
+    validate.TSV.TSV(scansFile, tsv, [], function(issues) {
+      assert(issues.length === 1 && issues[0].code === 84)
+    })
+  })
 
-    it("should allow _scans.tsv files with filename column", function () {
-        var tsv = 'header-one\tfilename\theader-three\n' +
-                  'value-one\tvalue-two\tvalue-three';
-        validate.TSV.TSV(scansFile, tsv, [], function (issues) {
-            assert.deepEqual(issues, []);
-        });
-    });
+  it('should allow properly formatted acq_time column entries', function() {
+    const tsv = 'filename\tacq_time\n' + 'value-one\t2017-05-03T06:45:45'
+    validate.TSV.TSV(scansFile, tsv, [], function(issues) {
+      assert.deepEqual(issues, [])
+    })
+  })
 
-    it("should not allow improperly formatted acq_time column entries", function() {
-        const tsv = 'filename\tacq_time\n' +
-                    'value-one\t000001';
-        validate.TSV.TSV(scansFile, tsv, [], function (issues) {
-            assert(issues.length === 1 && issues[0].code === 84);
-        });
-    });
+  it('should check participants listed in phenotype/*tsv and sub-ids ', function() {
+    var phenotypeParticipants = [
+      {
+        list: ['10159', '10171', '10189'],
+        file: {
+          name: 'vmnm.tsv',
+          path:
+            '/corral-repl/utexas/poldracklab/openfmri/shared2/ds000030/ds030_R1.0.5/ds000030_R1.0.5//phenotype/vmnm.tsv',
+          relativePath: '/phenotype/vmnm.tsv',
+        },
+      },
+    ]
+    var summary = {
+      sessions: [],
+      subjects: ['10159', '10171'],
+      tasks: [],
+      totalFiles: 43,
+      size: 11845,
+    }
+    var issues = []
+    validate.TSV.checkphenotype(
+      phenotypeParticipants,
+      summary,
+      issues,
+      function(issues) {
+        assert(issues.length === 1 && issues[0].code === 51)
+      },
+    )
+  })
 
-    it("should allow properly formatted acq_time column entries", function() {
-        const tsv = 'filename\tacq_time\n' +
-                    'value-one\t2017-05-03T06:45:45';
-        validate.TSV.TSV(scansFile, tsv, [], function (issues) {
-            assert.deepEqual(issues, []);
-        });
-    });
+  // channels checks -----------------------------------------------------------------
 
-    it("should check participants listed in phenotype/*tsv and sub-ids ", function () {
-        var phenotypeParticipants= [{
-            list:
-                [
-                    '10159',
-                    '10171',
-                    '10189'
-                ],
-            file:
-            { name: 'vmnm.tsv',
-            path: '/corral-repl/utexas/poldracklab/openfmri/shared2/ds000030/ds030_R1.0.5/ds000030_R1.0.5//phenotype/vmnm.tsv',
-            relativePath: '/phenotype/vmnm.tsv'}}];
-        var summary = { sessions: [],
-            subjects:
-                [
-                    '10159',
-                    '10171'
-                ],
-            tasks: [ ],
-            totalFiles: 43,
-            size: 11845 };
-        var issues = [];
-        validate.TSV.checkphenotype(phenotypeParticipants, summary, issues, function(issues){
-            assert(issues.length === 1 && issues[0].code === 51);
-        });
-    });
+  var channelsFile = {
+    name: 'sub-01_ses-meg_task-facerecognition_run-01_channels.tsv',
+    relativePath:
+      '/sub-01/ses-meg/meg/sub-01_ses-meg_task-facerecognition_run-01_channels.tsv',
+  }
 
-// channels checks -----------------------------------------------------------------
+  it('should not allow channels.tsv files without name column', function() {
+    var tsv = 'header-one\ttype\tunits\n' + 'value-one\tvalue-two\tvalue-three'
+    validate.TSV.TSV(channelsFile, tsv, [], function(issues) {
+      assert(issues.length === 1 && issues[0].code === 71)
+    })
+  })
 
-var channelsFile = {
-        name: 'sub-01_ses-meg_task-facerecognition_run-01_channels.tsv',
-        relativePath: '/sub-01/ses-meg/meg/sub-01_ses-meg_task-facerecognition_run-01_channels.tsv'
-    };
+  it('should not allow channels.tsv files without type column', function() {
+    var tsv = 'name\theader-two\tunits\n' + 'value-one\tvalue-two\tvalue-three'
+    validate.TSV.TSV(channelsFile, tsv, [], function(issues) {
+      assert(issues.length === 1 && issues[0].code === 71)
+    })
+  })
 
-    it("should not allow channels.tsv files without name column", function () {
-        var tsv = 'header-one\ttype\tunits\n' +
-            'value-one\tvalue-two\tvalue-three';
-        validate.TSV.TSV(channelsFile, tsv, [], function (issues) {
-            assert(issues.length === 1 && issues[0].code === 71);
-        });
-    });
+  it('should allow channels.tsv files with name, type and units columns', function() {
+    var tsv =
+      'name\ttype\tunits\theader-four\n' +
+      'value-one\tvalue-two\tvalue-three\tvalue-four'
+    validate.TSV.TSV(channelsFile, tsv, [], function(issues) {
+      assert(issues.length === 0)
+    })
+  })
 
-    it("should not allow channels.tsv files without type column", function () {
-        var tsv = 'name\theader-two\tunits\n' +
-            'value-one\tvalue-two\tvalue-three';
-        validate.TSV.TSV(channelsFile, tsv, [], function (issues) {
-            assert(issues.length === 1 && issues[0].code === 71);
-        });
-    });
+  var channelsFileIEEG = {
+    name: 'sub-01_ses-ieeg_task-facerecognition_run-01_channels.tsv',
+    relativePath:
+      '/sub-01/ses-ieeg/ieeg/sub-01_ses-meg_task-facerecognition_run-01_channels.tsv',
+  }
 
+  it('should not allow channels.tsv files without sampling_frequency column', function() {
+    var tsv =
+      'name\ttype\tunits\tcolumn_four\tlow_cutoff\thigh_cutoff\tnotch\treference\n' +
+      'value-one\tvalue-two\tvalue-three\tvalue-four\tvalue-five\tvalue-six\tvalue-seven\tvalue-eight'
+    validate.TSV.TSV(channelsFileIEEG, tsv, [], function(issues) {
+      assert(issues.length === 1 && issues[0].code === 72)
+    })
+  })
 
-    it("should allow channels.tsv files with name, type and units columns", function () {
-        var tsv = 'name\ttype\tunits\theader-four\n' +
-            'value-one\tvalue-two\tvalue-three\tvalue-four';
-        validate.TSV.TSV(channelsFile, tsv, [], function (issues) {
-            assert(issues.length === 0);
-        });
-    });
+  it('should not allow channels.tsv files without low_cutoff column', function() {
+    var tsv =
+      'name\ttype\tunits\tsampling_frequency\tcolumn_five\thigh_cutoff\tnotch\treference\n' +
+      'value-one\tvalue-two\tvalue-three\tvalue-four\tvalue-five\tvalue-six\tvalue-seven\tvalue-eight'
+    validate.TSV.TSV(channelsFileIEEG, tsv, [], function(issues) {
+      assert(issues.length === 1 && issues[0].code === 72)
+    })
+  })
 
-var channelsFileIEEG = {
-        name: 'sub-01_ses-ieeg_task-facerecognition_run-01_channels.tsv',
-        relativePath: '/sub-01/ses-ieeg/ieeg/sub-01_ses-meg_task-facerecognition_run-01_channels.tsv'
-    };
+  it('should not allow channels.tsv files without high_cutoff column', function() {
+    var tsv =
+      'name\ttype\tunits\tsampling_frequency\tlow_cutoff\tcolumn_six\tnotch\treference\n' +
+      'value-one\tvalue-two\tvalue-three\tvalue-four\tvalue-five\tvalue-six\tvalue-seven\tvalue-eight'
+    validate.TSV.TSV(channelsFileIEEG, tsv, [], function(issues) {
+      assert(issues.length === 1 && issues[0].code === 72)
+    })
+  })
 
-    it("should not allow channels.tsv files without sampling_frequency column", function () {
-        var tsv = 'name\ttype\tunits\tcolumn_four\tlow_cutoff\thigh_cutoff\tnotch\treference\n' +
-            'value-one\tvalue-two\tvalue-three\tvalue-four\tvalue-five\tvalue-six\tvalue-seven\tvalue-eight';
-        validate.TSV.TSV(channelsFileIEEG, tsv, [], function (issues) {
-            assert(issues.length === 1 && issues[0].code === 72);
-        });
-    });
+  it('should not allow channels.tsv files without notch column', function() {
+    var tsv =
+      'name\ttype\tunits\tsampling_frequency\tlow_cutoff\thigh_cutoff\tcolumn_seven\treference\n' +
+      'value-one\tvalue-two\tvalue-three\tvalue-four\tvalue-five\tvalue-six\tvalue-seven\tvalue-eight'
+    validate.TSV.TSV(channelsFileIEEG, tsv, [], function(issues) {
+      assert(issues.length === 1 && issues[0].code === 72)
+    })
+  })
 
-    it("should not allow channels.tsv files without low_cutoff column", function () {
-        var tsv = 'name\ttype\tunits\tsampling_frequency\tcolumn_five\thigh_cutoff\tnotch\treference\n' +
-            'value-one\tvalue-two\tvalue-three\tvalue-four\tvalue-five\tvalue-six\tvalue-seven\tvalue-eight';
-        validate.TSV.TSV(channelsFileIEEG, tsv, [], function (issues) {
-            assert(issues.length === 1 && issues[0].code === 72);
-        });
-    });
+  it('should not allow channels.tsv files without reference column', function() {
+    var tsv =
+      'name\ttype\tunits\tsampling_frequency\tlow_cutoff\thigh_cutoff\tnotch\tcolumn-eight\n' +
+      'value-one\tvalue-two\tvalue-three\tvalue-four\tvalue-five\tvalue-six\tvalue-seven\tvalue-eight'
+    validate.TSV.TSV(channelsFileIEEG, tsv, [], function(issues) {
+      assert(issues.length === 1 && issues[0].code === 72)
+    })
+  })
 
+  it('correct columns should pass for ieeg', function() {
+    var tsv =
+      'name\ttype\tunits\tsampling_frequency\tlow_cutoff\thigh_cutoff\tnotch\treference\n' +
+      'value-one\tvalue-two\tvalue-three\tvalue-four\tvalue-five\tvalue-six\tvalue-seven\tvalue-eight'
+    validate.TSV.TSV(channelsFileIEEG, tsv, [], function(issues) {
+      assert(issues.length === 0)
+    })
+  })
 
-    it("should not allow channels.tsv files without high_cutoff column", function () {
-        var tsv = 'name\ttype\tunits\tsampling_frequency\tlow_cutoff\tcolumn_six\tnotch\treference\n' +
-            'value-one\tvalue-two\tvalue-three\tvalue-four\tvalue-five\tvalue-six\tvalue-seven\tvalue-eight';
-        validate.TSV.TSV(channelsFileIEEG, tsv, [], function (issues) {
-            assert(issues.length === 1 && issues[0].code === 72);
-        });
-    });
+  var electrodesFileIEEG = {
+    name: 'sub-01_ses-ieeg_task-facerecognition_run-01_electrodes.tsv',
+    relativePath:
+      '/sub-01/ses-ieeg/ieeg/sub-01_ses-ieeg_task-facerecognition_run-01_electrodes.tsv',
+  }
 
-    it("should not allow channels.tsv files without notch column", function () {
-        var tsv = 'name\ttype\tunits\tsampling_frequency\tlow_cutoff\thigh_cutoff\tcolumn_seven\treference\n' +
-            'value-one\tvalue-two\tvalue-three\tvalue-four\tvalue-five\tvalue-six\tvalue-seven\tvalue-eight';
-        validate.TSV.TSV(channelsFileIEEG, tsv, [], function (issues) {
-            assert(issues.length === 1 && issues[0].code === 72);
-        });
-    });
+  it('should not allow electrodes.tsv files without name column', function() {
+    var tsv =
+      'blah\tx\ty\tz\tsize\ttype\n' +
+      'value-one\tvalue-two\tvalue-three\tvalue-four\tvalue-five\tvalue-six\n'
+    validate.TSV.TSV(electrodesFileIEEG, tsv, [], function(issues) {
+      assert(issues.length === 1 && issues[0].code === 73)
+    })
+  })
 
-    it("should not allow channels.tsv files without reference column", function () {
-        var tsv = 'name\ttype\tunits\tsampling_frequency\tlow_cutoff\thigh_cutoff\tnotch\tcolumn-eight\n' +
-            'value-one\tvalue-two\tvalue-three\tvalue-four\tvalue-five\tvalue-six\tvalue-seven\tvalue-eight';
-        validate.TSV.TSV(channelsFileIEEG, tsv, [], function (issues) {
-            assert(issues.length === 1 && issues[0].code === 72);
-        });
-    });
+  it('should not allow electrodes.tsv files without x column', function() {
+    var tsv =
+      'name\tblah\ty\tz\tsize\ttype\n' +
+      'value-one\tvalue-two\tvalue-three\tvalue-four\tvalue-five\tvalue-six\n'
+    validate.TSV.TSV(electrodesFileIEEG, tsv, [], function(issues) {
+      assert(issues.length === 1 && issues[0].code === 73)
+    })
+  })
 
-    it("correct columns should pass for ieeg", function () {
-        var tsv = 'name\ttype\tunits\tsampling_frequency\tlow_cutoff\thigh_cutoff\tnotch\treference\n' +
-            'value-one\tvalue-two\tvalue-three\tvalue-four\tvalue-five\tvalue-six\tvalue-seven\tvalue-eight';
-        validate.TSV.TSV(channelsFileIEEG, tsv, [], function (issues) {
-            assert(issues.length === 0);
-        });
-    });
+  it('should not allow electrodes.tsv files without y column', function() {
+    var tsv =
+      'name\tx\tblah\tz\tsize\ttype\n' +
+      'value-one\tvalue-two\tvalue-three\tvalue-four\tvalue-five\tvalue-six\n'
+    validate.TSV.TSV(electrodesFileIEEG, tsv, [], function(issues) {
+      assert(issues.length === 1 && issues[0].code === 73)
+    })
+  })
 
-var electrodesFileIEEG = {
-        name: 'sub-01_ses-ieeg_task-facerecognition_run-01_electrodes.tsv',
-        relativePath: '/sub-01/ses-ieeg/ieeg/sub-01_ses-ieeg_task-facerecognition_run-01_electrodes.tsv'
-    };
+  it('should not allow electrodes.tsv files without z column', function() {
+    var tsv =
+      'name\tx\ty\tblah\tsize\ttype\n' +
+      'value-one\tvalue-two\tvalue-three\tvalue-four\tvalue-five\tvalue-six\n'
+    validate.TSV.TSV(electrodesFileIEEG, tsv, [], function(issues) {
+      assert(issues.length === 1 && issues[0].code === 73)
+    })
+  })
 
-    it("should not allow electrodes.tsv files without name column", function () {
-        var tsv = 'blah\tx\ty\tz\tsize\ttype\n' +
-            'value-one\tvalue-two\tvalue-three\tvalue-four\tvalue-five\tvalue-six\n';
-        validate.TSV.TSV(electrodesFileIEEG, tsv, [], function (issues) {
-            assert(issues.length === 1 && issues[0].code === 73);
-        });
-    });
+  it('should not allow electrodes.tsv files without size column', function() {
+    var tsv =
+      'name\tx\ty\tz\tblah\ttype\n' +
+      'value-one\tvalue-two\tvalue-three\tvalue-four\tvalue-five\tvalue-six\n'
+    validate.TSV.TSV(electrodesFileIEEG, tsv, [], function(issues) {
+      assert(issues.length === 1 && issues[0].code === 73)
+    })
+  })
 
-    it("should not allow electrodes.tsv files without x column", function () {
-        var tsv = 'name\tblah\ty\tz\tsize\ttype\n' +
-            'value-one\tvalue-two\tvalue-three\tvalue-four\tvalue-five\tvalue-six\n';
-        validate.TSV.TSV(electrodesFileIEEG, tsv, [], function (issues) {
-            assert(issues.length === 1 && issues[0].code === 73);
-        });
-    });
-
-
-    it("should not allow electrodes.tsv files without y column", function () {
-        var tsv = 'name\tx\tblah\tz\tsize\ttype\n' +
-            'value-one\tvalue-two\tvalue-three\tvalue-four\tvalue-five\tvalue-six\n';
-        validate.TSV.TSV(electrodesFileIEEG, tsv, [], function (issues) {
-            assert(issues.length === 1 && issues[0].code === 73);
-        });
-    });
-
-    it("should not allow electrodes.tsv files without z column", function () {
-        var tsv = 'name\tx\ty\tblah\tsize\ttype\n' +
-            'value-one\tvalue-two\tvalue-three\tvalue-four\tvalue-five\tvalue-six\n';
-        validate.TSV.TSV(electrodesFileIEEG, tsv, [], function (issues) {
-            assert(issues.length === 1 && issues[0].code === 73);
-        });
-    });
-
-    it("should not allow electrodes.tsv files without size column", function () {
-        var tsv = 'name\tx\ty\tz\tblah\ttype\n' +
-            'value-one\tvalue-two\tvalue-three\tvalue-four\tvalue-five\tvalue-six\n';
-        validate.TSV.TSV(electrodesFileIEEG, tsv, [], function (issues) {
-            assert(issues.length === 1 && issues[0].code === 73);
-        });
-    });
-
-    it("correct columns should pass for ieeg electrodes file", function () {
-        var tsv = 'name\tx\ty\tz\tsize\ttype\n' +
-            'value-one\tvalue-two\tvalue-three\tvalue-four\tvalue-five\tvalue-six\n';
-        validate.TSV.TSV(electrodesFileIEEG, tsv, [], function (issues) {
-            assert(issues.length === 0);
-        });
-    });
-});
+  it('correct columns should pass for ieeg electrodes file', function() {
+    var tsv =
+      'name\tx\ty\tz\tsize\ttype\n' +
+      'value-one\tvalue-two\tvalue-three\tvalue-four\tvalue-five\tvalue-six\n'
+    validate.TSV.TSV(electrodesFileIEEG, tsv, [], function(issues) {
+      assert(issues.length === 0)
+    })
+  })
+})

--- a/tests/type.spec.js
+++ b/tests/type.spec.js
@@ -1,430 +1,492 @@
-var assert = require('chai').assert;
-var utils   = require('../utils');
-var Test = require("mocha/lib/test");
-var BIDS = require('../validators/bids');
+var assert = require('chai').assert
+var utils = require('../utils')
+var Test = require('mocha/lib/test')
+var BIDS = require('../validators/bids')
 
+var suiteAnat = describe('utils.type.isAnat', function() {
+  before(function(done) {
+    var goodFilenames = [
+      '/sub-15/anat/sub-15_inplaneT2.nii.gz',
+      '/sub-15/ses-12/anat/sub-15_ses-12_inplaneT2.nii.gz',
+      '/sub-16/anat/sub-16_T1w.nii.gz',
+      '/sub-16/anat/sub-16_T1w.json',
+      '/sub-16/anat/sub-16_run-01_T1w.nii.gz',
+      '/sub-16/anat/sub-16_acq-highres_T1w.nii.gz',
+      '/sub-16/anat/sub-16_rec-mc_T1w.nii.gz',
+    ]
 
-var suiteAnat = describe('utils.type.isAnat', function(){
-    before(function(done) {
-        var goodFilenames = ["/sub-15/anat/sub-15_inplaneT2.nii.gz",
-            "/sub-15/ses-12/anat/sub-15_ses-12_inplaneT2.nii.gz",
-            "/sub-16/anat/sub-16_T1w.nii.gz",
-            "/sub-16/anat/sub-16_T1w.json",
-            "/sub-16/anat/sub-16_run-01_T1w.nii.gz",
-            "/sub-16/anat/sub-16_acq-highres_T1w.nii.gz",
-            "/sub-16/anat/sub-16_rec-mc_T1w.nii.gz"
-        ];
+    goodFilenames.forEach(function(path) {
+      suiteAnat.addTest(
+        new Test("isAnat('" + path + "') === true", function(isdone) {
+          assert.equal(utils.type.isAnat(path), true)
+          isdone()
+        }),
+      )
+    })
 
-        goodFilenames.forEach(function (path) {
-            suiteAnat.addTest(new Test("isAnat('" + path + "') === true", function (isdone){
-                assert.equal(utils.type.isAnat(path), true);
-                isdone();
-            }));
-        });
+    var badFilenames = [
+      '/sub-1/anat/sub-15_inplaneT2.nii.gz',
+      '/sub-15/ses-12/anat/sub-15_inplaneT2.nii.gz',
+      '/sub-16/anat/sub-16_T1.nii.gz',
+      'blaaa.nii.gz',
+      '/sub-16/anat/sub-16_run-second_T1w.nii.gz',
+      '/sub-16/anat/sub-16_run-01_rec-mc_T1w.nii.gz',
+    ]
 
-        var badFilenames = [
-            "/sub-1/anat/sub-15_inplaneT2.nii.gz",
-            "/sub-15/ses-12/anat/sub-15_inplaneT2.nii.gz",
-            "/sub-16/anat/sub-16_T1.nii.gz",
-            "blaaa.nii.gz",
-            "/sub-16/anat/sub-16_run-second_T1w.nii.gz",
-            "/sub-16/anat/sub-16_run-01_rec-mc_T1w.nii.gz"
-        ];
+    badFilenames.forEach(function(path) {
+      suiteAnat.addTest(
+        new Test("isAnat('" + path + "') === false", function(isdone) {
+          assert.equal(utils.type.isAnat(path), false)
+          isdone()
+        }),
+      )
+    })
+    done()
+  })
 
-        badFilenames.forEach(function (path) {
-            suiteAnat.addTest(new Test("isAnat('" + path + "') === false", function (isdone){
-                assert.equal(utils.type.isAnat(path), false);
-                isdone();
-            }));
-        });
-        done();
-    });
+  // we need to have at least one non-dynamic test
+  return it('dummy test', function() {
+    require('assert').ok(true)
+  })
+})
 
-    // we need to have at least one non-dynamic test
-    return it('dummy test', function() {
-        require('assert').ok(true);
-    });
-});
+var suiteFunc = describe('utils.type.isFunc', function() {
+  before(function(done) {
+    var goodFilenames = [
+      '/sub-15/func/sub-15_task-0back_bold.nii.gz',
+      '/sub-15/ses-12/func/sub-15_ses-12_task-0back_bold.nii.gz',
+      '/sub-16/func/sub-16_task-0back_bold.json',
+      '/sub-16/func/sub-16_task-0back_run-01_bold.nii.gz',
+      '/sub-16/func/sub-16_task-0back_acq-highres_bold.nii.gz',
+      '/sub-16/func/sub-16_task-0back_rec-mc_bold.nii.gz',
+    ]
 
+    goodFilenames.forEach(function(path) {
+      suiteFunc.addTest(
+        new Test("isFunc('" + path + "') === true", function(isdone) {
+          assert.equal(utils.type.isFunc(path), true)
+          isdone()
+        }),
+      )
+    })
 
-var suiteFunc = describe('utils.type.isFunc', function(){
-    before(function(done) {
-        var goodFilenames = [
-            "/sub-15/func/sub-15_task-0back_bold.nii.gz",
-            "/sub-15/ses-12/func/sub-15_ses-12_task-0back_bold.nii.gz",
-            "/sub-16/func/sub-16_task-0back_bold.json",
-            "/sub-16/func/sub-16_task-0back_run-01_bold.nii.gz",
-            "/sub-16/func/sub-16_task-0back_acq-highres_bold.nii.gz",
-            "/sub-16/func/sub-16_task-0back_rec-mc_bold.nii.gz"
-        ];
+    var badFilenames = [
+      '/sub-1/func/sub-15_inplaneT2.nii.gz',
+      '/sub-15/ses-12/func/sub-15_inplaneT2.nii.gz',
+      '/sub-16/func/sub-16_T1.nii.gz',
+      'blaaa.nii.gz',
+      '/sub-16/func/sub-16_run-second_T1w.nii.gz',
+      '/sub-16/func/sub-16_task-0-back_rec-mc_bold.nii.gz',
+      '/sub-16/func/sub-16_run-01_rec-mc_T1w.nii.gz',
+    ]
 
-        goodFilenames.forEach(function (path) {
-            suiteFunc.addTest(new Test("isFunc('" + path + "') === true", function (isdone){
-                assert.equal(utils.type.isFunc(path), true);
-                isdone();
-            }));
-        });
+    badFilenames.forEach(function(path) {
+      suiteFunc.addTest(
+        new Test("isFunc('" + path + "') === false", function(isdone) {
+          assert.equal(utils.type.isFunc(path), false)
+          isdone()
+        }),
+      )
+    })
+    done()
+  })
 
-        var badFilenames = [
-            "/sub-1/func/sub-15_inplaneT2.nii.gz",
-            "/sub-15/ses-12/func/sub-15_inplaneT2.nii.gz",
-            "/sub-16/func/sub-16_T1.nii.gz",
-            "blaaa.nii.gz",
-            "/sub-16/func/sub-16_run-second_T1w.nii.gz",
-            "/sub-16/func/sub-16_task-0-back_rec-mc_bold.nii.gz",
-            "/sub-16/func/sub-16_run-01_rec-mc_T1w.nii.gz"
-        ];
+  // we need to have at least one non-dynamic test
+  return it('dummy test', function() {
+    require('assert').ok(true)
+  })
+})
 
-        badFilenames.forEach(function (path) {
-            suiteFunc.addTest(new Test("isFunc('" + path + "') === false", function (isdone){
-                assert.equal(utils.type.isFunc(path), false);
-                isdone();
-            }));
-        });
-        done();
-    });
+var suiteTop = describe('utils.type.isTopLevel', function() {
+  before(function(done) {
+    var goodFilenames = [
+      '/README',
+      '/CHANGES',
+      '/dataset_description.json',
+      '/ses-pre_task-rest_bold.json',
+      '/dwi.bval',
+      '/dwi.bvec',
+      '/T1w.json',
+      '/acq-test_dwi.json',
+      '/rec-test_physio.json',
+    ]
 
-    // we need to have at least one non-dynamic test
-    return it('dummy test', function() {
-        require('assert').ok(true);
-    });
-});
+    goodFilenames.forEach(function(path) {
+      suiteTop.addTest(
+        new Test("isTopLevel('" + path + "') === true", function(isdone) {
+          assert.equal(utils.type.isTopLevel(path), true)
+          isdone()
+        }),
+      )
+    })
 
+    var badFilenames = [
+      '/readme.txt',
+      '/changelog',
+      '/dataset_description.yml',
+      '/ses.json',
+      '/_T1w.json',
+      '/_dwi.json',
+      '/_task-test_physio.json',
+    ]
 
-var suiteTop = describe('utils.type.isTopLevel', function(){
-    before(function(done) {
-        var goodFilenames = ["/README",
-            "/CHANGES",
-            "/dataset_description.json",
-            "/ses-pre_task-rest_bold.json",
-            "/dwi.bval",
-            "/dwi.bvec",
-            "/T1w.json",
-            "/acq-test_dwi.json",
-            "/rec-test_physio.json"
-        ];
+    badFilenames.forEach(function(path) {
+      suiteTop.addTest(
+        new Test("isTopLevel('" + path + "') === false", function(isdone) {
+          assert.equal(utils.type.isTopLevel(path), false)
+          isdone()
+        }),
+      )
+    })
+    done()
+  })
 
-        goodFilenames.forEach(function (path) {
-            suiteTop.addTest(new Test("isTopLevel('" + path + "') === true", function (isdone){
-                assert.equal(utils.type.isTopLevel(path), true);
-                isdone();
-            }));
-        });
+  // we need to have at least one non-dynamic test
+  return it('dummy test', function() {
+    require('assert').ok(true)
+  })
+})
 
-        var badFilenames = [
-            "/readme.txt",
-            "/changelog",
-            "/dataset_description.yml",
-            "/ses.json",
-            "/_T1w.json",
-            "/_dwi.json",
-            "/_task-test_physio.json"
-        ];
+var suiteSession = describe('utils.type.isSessionLevel', function() {
+  before(function(done) {
+    var goodFilenames = [
+      '/sub-12/sub-12_scans.tsv',
+      '/sub-12/ses-pre/sub-12_ses-pre_scans.tsv',
+    ]
 
-        badFilenames.forEach(function (path) {
-            suiteTop.addTest(new Test("isTopLevel('" + path + "') === false", function (isdone){
-                assert.equal(utils.type.isTopLevel(path), false);
-                isdone();
-            }));
-        });
-        done();
-    });
+    goodFilenames.forEach(function(path) {
+      suiteSession.addTest(
+        new Test("isSessionLevel('" + path + "') === true", function(isdone) {
+          assert.equal(utils.type.isSessionLevel(path), true)
+          isdone()
+        }),
+      )
+    })
 
-    // we need to have at least one non-dynamic test
-    return it('dummy test', function() {
-        require('assert').ok(true);
-    });
-});
+    var badFilenames = [
+      '/sub-12/sub-12.tsv',
+      '/sub-12/ses-pre/sub-12_ses-pre_scan.tsv',
+    ]
 
-var suiteSession = describe('utils.type.isSessionLevel', function(){
-    before(function(done) {
-        var goodFilenames = [
-            "/sub-12/sub-12_scans.tsv",
-            "/sub-12/ses-pre/sub-12_ses-pre_scans.tsv"
-        ];
+    badFilenames.forEach(function(path) {
+      suiteSession.addTest(
+        new Test("isSessionLevel('" + path + "') === false", function(isdone) {
+          assert.equal(utils.type.isSessionLevel(path), false)
+          isdone()
+        }),
+      )
+    })
+    done()
+  })
 
-        goodFilenames.forEach(function (path) {
-            suiteSession.addTest(new Test("isSessionLevel('" + path + "') === true", function (isdone){
-                assert.equal(utils.type.isSessionLevel(path), true);
-                isdone();
-            }));
-        });
+  // we need to have at least one non-dynamic test
+  return it('dummy test', function() {
+    require('assert').ok(true)
+  })
+})
 
-        var badFilenames = ["/sub-12/sub-12.tsv",
-            "/sub-12/ses-pre/sub-12_ses-pre_scan.tsv"];
+var suiteDWI = describe('utils.type.isDWI', function() {
+  before(function(done) {
+    var goodFilenames = [
+      '/sub-12/dwi/sub-12_dwi.nii.gz',
+      '/sub-12/ses-pre/dwi/sub-12_ses-pre_dwi.nii.gz',
+      '/sub-12/ses-pre/dwi/sub-12_ses-pre_dwi.bvec',
+      '/sub-12/ses-pre/dwi/sub-12_ses-pre_dwi.bval',
+    ]
 
-        badFilenames.forEach(function (path) {
-            suiteSession.addTest(new Test("isSessionLevel('" + path + "') === false", function (isdone){
-                assert.equal(utils.type.isSessionLevel(path), false);
-                isdone();
-            }));
-        });
-        done();
-    });
+    goodFilenames.forEach(function(path) {
+      suiteDWI.addTest(
+        new Test("isDWI('" + path + "') === true", function(isdone) {
+          assert.equal(utils.type.isDWI(path), true)
+          isdone()
+        }),
+      )
+    })
 
-    // we need to have at least one non-dynamic test
-    return it('dummy test', function() {
-        require('assert').ok(true);
-    });
-});
+    var badFilenames = [
+      '/sub-12/sub-12.tsv',
+      '/sub-12/ses-pre/sub-12_ses-pre_scan.tsv',
+      '/sub-12/ses-pre/dwi/sub-12_ses-pre_dwi.bvecs',
+      '/sub-12/ses-pre/dwi/sub-12_ses-pre_dwi.bvals',
+    ]
 
-var suiteDWI = describe('utils.type.isDWI', function(){
-    before(function(done) {
-        var goodFilenames = [
-            "/sub-12/dwi/sub-12_dwi.nii.gz",
-            "/sub-12/ses-pre/dwi/sub-12_ses-pre_dwi.nii.gz",
-            "/sub-12/ses-pre/dwi/sub-12_ses-pre_dwi.bvec",
-            "/sub-12/ses-pre/dwi/sub-12_ses-pre_dwi.bval"
-        ];
+    badFilenames.forEach(function(path) {
+      suiteDWI.addTest(
+        new Test("isDWI('" + path + "') === false", function(isdone) {
+          assert.equal(utils.type.isDWI(path), false)
+          isdone()
+        }),
+      )
+    })
+    done()
+  })
 
-        goodFilenames.forEach(function (path) {
-            suiteDWI.addTest(new Test("isDWI('" + path + "') === true", function (isdone){
-                assert.equal(utils.type.isDWI(path), true);
-                isdone();
-            }));
-        });
+  // we need to have at least one non-dynamic test
+  return it('dummy test', function() {
+    require('assert').ok(true)
+  })
+})
 
-        var badFilenames = ["/sub-12/sub-12.tsv",
-            "/sub-12/ses-pre/sub-12_ses-pre_scan.tsv",
-            "/sub-12/ses-pre/dwi/sub-12_ses-pre_dwi.bvecs",
-            "/sub-12/ses-pre/dwi/sub-12_ses-pre_dwi.bvals"];
+var suiteMEG = describe('utils.type.isMEG', function() {
+  before(function(done) {
+    var goodFilenames = [
+      '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg/sub-01_ses-001_task-rest_run-01_meg.sqd',
+      '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg/sub-01_ses-001_task-rest_run-01_meg.raw.mhd',
+      '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg/xyz', // for e.g., BTi files
+      '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg/sub-01_ses-001_markers.sqd',
+      '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg.json',
+      '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_part-01_meg.fif',
+      '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_channels.tsv',
+    ]
 
-        badFilenames.forEach(function (path) {
-            suiteDWI.addTest(new Test("isDWI('" + path + "') === false", function (isdone){
-                assert.equal(utils.type.isDWI(path), false);
-                isdone();
-            }));
-        });
-        done();
-    });
+    goodFilenames.forEach(function(path) {
+      suiteMEG.addTest(
+        new Test("isMeg('" + path + "') === true", function(isdone) {
+          assert.equal(utils.type.isMeg(path), true)
+          isdone()
+        }),
+      )
+    })
 
-    // we need to have at least one non-dynamic test
-    return it('dummy test', function() {
-        require('assert').ok(true);
-    });
-});
+    var badFilenames = [
+      // only parent directory name matters for KIT/BTi systems
+      '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_megggg/sub-01_ses-001_task-rest_run-01_meg.sqd',
+      '/sub-01/meg/sub-01_ses-001_task-rest_run-01_meg.json',
+      '/sub-01/ses-001/meg/sub-12_ses-001_task-rest_run-01_part-01_meg.fif',
+      '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg.tsv',
+    ]
 
+    badFilenames.forEach(function(path) {
+      suiteMEG.addTest(
+        new Test("isMeg('" + path + "') === false", function(isdone) {
+          assert.equal(utils.type.isMeg(path), false)
+          isdone()
+        }),
+      )
+    })
+    done()
+  })
 
-var suiteMEG = describe('utils.type.isMEG', function(){
-    before(function(done) {
-        var goodFilenames = [
-            "/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg/sub-01_ses-001_task-rest_run-01_meg.sqd",
-            "/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg/sub-01_ses-001_task-rest_run-01_meg.raw.mhd",
-            "/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg/xyz",  // for e.g., BTi files
-            "/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg/sub-01_ses-001_markers.sqd",
-            "/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg.json",
-            "/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_part-01_meg.fif",
-            "/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_channels.tsv"
-        ];
+  // we need to have at least one non-dynamic test
+  return it('dummy test', function() {
+    require('assert').ok(true)
+  })
+})
 
-        goodFilenames.forEach(function (path) {
-            suiteMEG.addTest(new Test("isMeg('" + path + "') === true", function (isdone){
-                assert.equal(utils.type.isMeg(path), true);
-                isdone();
-            }));
-        });
+var suiteEEG = describe('utils.type.isEEG', function() {
+  before(function(done) {
+    var goodFilenames = [
+      '/sub-01/ses-001/eeg/sub-01_ses-001_task-rest_run-01_eeg.json',
+      '/sub-01/ses-001/eeg/sub-01_ses-001_task-rest_run-01_part-01_eeg.edf',
+      '/sub-01/ses-001/eeg/sub-01_ses-001_task-rest_run-01_channels.tsv',
+    ]
 
-        var badFilenames = [
-            // only parent directory name matters for KIT/BTi systems
-            "/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_megggg/sub-01_ses-001_task-rest_run-01_meg.sqd",
-            "/sub-01/meg/sub-01_ses-001_task-rest_run-01_meg.json",
-            "/sub-01/ses-001/meg/sub-12_ses-001_task-rest_run-01_part-01_meg.fif",
-            "/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg.tsv"];
+    goodFilenames.forEach(function(path) {
+      suiteEEG.addTest(
+        new Test("isEeg('" + path + "') === true", function(isdone) {
+          assert.equal(utils.type.isEeg(path), true)
+          isdone()
+        }),
+      )
+    })
 
-        badFilenames.forEach(function (path) {
-            suiteMEG.addTest(new Test("isMeg('" + path + "') === false", function (isdone){
-                assert.equal(utils.type.isMeg(path), false);
-                isdone();
-            }));
-        });
-        done();
-    });
+    var badFilenames = [
+      '/sub-01/eeg/sub-01_ses-001_task-rest_run-01_eeg.json',
+      '/sub-01/ses-001/eeg/sub-12_ses-001_task-rest_run-01_part-01_eeg.edf',
+      '/sub-01/ses-001/eeg/sub-01_ses-001_task-rest_run-01_eeg.tsv',
+    ]
 
-    // we need to have at least one non-dynamic test
-    return it('dummy test', function() {
-        require('assert').ok(true);
-    });
-});
+    badFilenames.forEach(function(path) {
+      suiteEEG.addTest(
+        new Test("isEeg('" + path + "') === false", function(isdone) {
+          assert.equal(utils.type.isEeg(path), false)
+          isdone()
+        }),
+      )
+    })
+    done()
+  })
 
-var suiteEEG = describe('utils.type.isEEG', function(){
-    before(function(done) {
-        var goodFilenames = [
-            "/sub-01/ses-001/eeg/sub-01_ses-001_task-rest_run-01_eeg.json",
-            "/sub-01/ses-001/eeg/sub-01_ses-001_task-rest_run-01_part-01_eeg.edf",
-            "/sub-01/ses-001/eeg/sub-01_ses-001_task-rest_run-01_channels.tsv"
-        ];
+  // we need to have at least one non-dynamic test
+  return it('dummy test', function() {
+    require('assert').ok(true)
+  })
+})
 
-        goodFilenames.forEach(function (path) {
-            suiteEEG.addTest(new Test("isEeg('" + path + "') === true", function (isdone){
-                assert.equal(utils.type.isEeg(path), true);
-                isdone();
-            }));
-        });
+var suiteIEEG = describe('utils.type.isIEEG', function() {
+  before(function(done) {
+    var goodFilenames = [
+      '/sub-01/ses-001/ieeg/sub-01_ses-001_task-rest_run-01_ieeg.json',
+      '/sub-01/ses-001/ieeg/sub-01_ses-001_task-rest_run-01_part-01_ieeg.edf',
+      '/sub-01/ses-001/ieeg/sub-01_ses-001_task-rest_run-01_part-01_ieeg.vhdr',
+      '/sub-01/ses-001/ieeg/sub-01_ses-001_task-rest_run-01_part-01_ieeg.vmrk',
+      '/sub-01/ses-001/ieeg/sub-01_ses-001_task-rest_run-01_part-01_ieeg.dat',
+      '/sub-01/ses-001/ieeg/sub-01_ses-001_task-rest_run-01_channels.tsv',
+      '/sub-01/ses-001/ieeg/sub-01_ses-001_task-rest_run-01_electrodes.tsv',
+    ]
 
-        var badFilenames = [
-            "/sub-01/eeg/sub-01_ses-001_task-rest_run-01_eeg.json",
-            "/sub-01/ses-001/eeg/sub-12_ses-001_task-rest_run-01_part-01_eeg.edf",
-            "/sub-01/ses-001/eeg/sub-01_ses-001_task-rest_run-01_eeg.tsv"];
+    goodFilenames.forEach(function(path) {
+      suiteIEEG.addTest(
+        new Test("isIEEG('" + path + "') === true", function(isdone) {
+          assert.equal(utils.type.isIEEG(path), true)
+          isdone()
+        }),
+      )
+    })
 
-        badFilenames.forEach(function (path) {
-            suiteEEG.addTest(new Test("isEeg('" + path + "') === false", function (isdone){
-                assert.equal(utils.type.isEeg(path), false);
-                isdone();
-            }));
-        });
-        done();
-    });
+    var badFilenames = [
+      '/sub-01/ieeg/sub-01_ses-001_task-rest_run-01_ieeg.json',
+      '/sub-01/ses-001/ieeg/sub-12_ses-001_task-rest_run-01_part-01_ieeg.fif',
+      '/sub-01/ses-001/ieeg/sub-01_ses-001_task-rest_run-01_ieeg.tsv',
+    ]
 
-    // we need to have at least one non-dynamic test
-    return it('dummy test', function() {
-        require('assert').ok(true);
-    });
-});
+    badFilenames.forEach(function(path) {
+      suiteIEEG.addTest(
+        new Test("isIEEG('" + path + "') === false", function(isdone) {
+          assert.equal(utils.type.isIEEG(path), false)
+          isdone()
+        }),
+      )
+    })
+    done()
+  })
 
-var suiteIEEG = describe('utils.type.isIEEG', function(){
-    before(function(done) {
-        var goodFilenames = [
-            "/sub-01/ses-001/ieeg/sub-01_ses-001_task-rest_run-01_ieeg.json",
-            "/sub-01/ses-001/ieeg/sub-01_ses-001_task-rest_run-01_part-01_ieeg.edf",
-            "/sub-01/ses-001/ieeg/sub-01_ses-001_task-rest_run-01_part-01_ieeg.vhdr",
-            "/sub-01/ses-001/ieeg/sub-01_ses-001_task-rest_run-01_part-01_ieeg.vmrk",
-            "/sub-01/ses-001/ieeg/sub-01_ses-001_task-rest_run-01_part-01_ieeg.dat",
-            "/sub-01/ses-001/ieeg/sub-01_ses-001_task-rest_run-01_channels.tsv",
-            "/sub-01/ses-001/ieeg/sub-01_ses-001_task-rest_run-01_electrodes.tsv"
-        ];
+  // we need to have at least one non-dynamic test
+  return it('dummy test', function() {
+    require('assert').ok(true)
+  })
+})
 
-        goodFilenames.forEach(function (path) {
-            suiteIEEG.addTest(new Test("isIEEG('" + path + "') === true", function (isdone){
-                assert.equal(utils.type.isIEEG(path), true);
-                isdone();
-            }));
-        });
+describe('utils.type.isPhenotypic', function() {
+  it('should allow .tsv and .json files in the /phenotype directory', function() {
+    assert(utils.type.isPhenotypic('/phenotype/acds_adult.json'))
+    assert(utils.type.isPhenotypic('/phenotype/acds_adult.tsv'))
+  })
 
-        var badFilenames = [
-            "/sub-01/ieeg/sub-01_ses-001_task-rest_run-01_ieeg.json",
-            "/sub-01/ses-001/ieeg/sub-12_ses-001_task-rest_run-01_part-01_ieeg.fif",
-            "/sub-01/ses-001/ieeg/sub-01_ses-001_task-rest_run-01_ieeg.tsv"];
+  it('should not allow non .tsv and .json files in the /phenotype directory', function() {
+    assert(!utils.type.isPhenotypic('/phenotype/acds_adult.jpeg'))
+    assert(!utils.type.isPhenotypic('/phenotype/acds_adult.gif'))
+  })
+})
 
-        badFilenames.forEach(function (path) {
-            suiteIEEG.addTest(new Test("isIEEG('" + path + "') === false", function (isdone){
-                assert.equal(utils.type.isIEEG(path), false);
-                isdone();
-            }));
-        });
-        done();
-    });
+describe('utils.type.isAssociatedData', function() {
+  it('should return false for unknown root directories', function() {
+    var badFilenames = ['/images/picture.jpeg', '/temporary/test.json']
 
-    // we need to have at least one non-dynamic test
-    return it('dummy test', function() {
-        require('assert').ok(true);
-    });
-});
+    badFilenames.forEach(function(path) {
+      assert.equal(utils.type.isAssociatedData(path), false)
+    })
+  })
 
-describe('utils.type.isPhenotypic', function () {
-    it('should allow .tsv and .json files in the /phenotype directory', function () {
-        assert(utils.type.isPhenotypic('/phenotype/acds_adult.json'));
-        assert(utils.type.isPhenotypic('/phenotype/acds_adult.tsv'));
-    });
+  it('should return true for associated data directories and any files within', function() {
+    var goodFilenames = [
+      '/code/test-script.py',
+      '/derivatives/sub-01_QA.pdf',
+      '/sourcedata/sub-01_ses-01_bold.dcm',
+      '/stimuli/text.pdf',
+    ]
 
-    it('should not allow non .tsv and .json files in the /phenotype directory', function () {
-        assert(!utils.type.isPhenotypic('/phenotype/acds_adult.jpeg'));
-        assert(!utils.type.isPhenotypic('/phenotype/acds_adult.gif'));
-    });
-});
+    goodFilenames.forEach(function(path) {
+      assert(utils.type.isAssociatedData(path))
+    })
+  })
+})
 
-describe('utils.type.isAssociatedData', function () {
-    it('should return false for unknown root directories', function () {
-        var badFilenames = [
-            "/images/picture.jpeg",
-            "/temporary/test.json"
-        ];
+describe('utils.type.isStimuliData', function() {
+  it('should return false for unknown root directories', function() {
+    var badFilenames = ['/images/picture.jpeg', '/temporary/test.json']
 
-        badFilenames.forEach(function (path) {
-            assert.equal(utils.type.isAssociatedData(path), false);
-        });
-    });
+    badFilenames.forEach(function(path) {
+      assert.equal(utils.type.isStimuliData(path), false)
+    })
+  })
 
-    it('should return true for associated data directories and any files within', function () {
-        var goodFilenames = [
-            "/code/test-script.py",
-            "/derivatives/sub-01_QA.pdf",
-            "/sourcedata/sub-01_ses-01_bold.dcm",
-            "/stimuli/text.pdf"
-        ];
+  it('should return true for stimuli data directories and any files within', function() {
+    var goodFilenames = ['/stimuli/sub-01/mov.avi', '/stimuli/text.pdf']
 
-        goodFilenames.forEach(function (path) {
-            assert(utils.type.isAssociatedData(path));
-        });
-    });
-});
+    goodFilenames.forEach(function(path) {
+      assert(utils.type.isStimuliData(path))
+    })
+  })
+})
 
-describe('utils.type.isStimuliData', function () {
-    it('should return false for unknown root directories', function () {
-        var badFilenames = [
-            "/images/picture.jpeg",
-            "/temporary/test.json"
-        ];
+describe('utils.type.getPathValues', function() {
+  it('should return the correct path values from a valid file path', function() {
+    assert.equal(
+      utils.type.getPathValues(
+        '/sub-22/ses-1/func/sub-22_ses-1_task-rest_acq-prefrontal_physio.tsv.gz',
+      ).sub,
+      22,
+    )
+    assert.equal(
+      utils.type.getPathValues(
+        '/sub-22/ses-1/func/sub-22_ses-1_task-rest_acq-prefrontal_physio.tsv.gz',
+      ).ses,
+      1,
+    )
+    assert.equal(
+      utils.type.getPathValues(
+        '/sub-22/func/sub-22_task-rest_acq-prefrontal_physio.tsv.gz',
+      ).sub,
+      22,
+    )
+    assert.equal(
+      utils.type.getPathValues(
+        '/sub-22/func/sub-22_task-rest_acq-prefrontal_physio.tsv.gz',
+      ).ses,
+      null,
+    )
+  })
+})
 
-        badFilenames.forEach(function (path) {
-            assert.equal(utils.type.isStimuliData(path), false);
-        });
-    });
-
-    it('should return true for stimuli data directories and any files within', function () {
-        var goodFilenames = [
-            "/stimuli/sub-01/mov.avi",
-            "/stimuli/text.pdf"
-        ];
-
-        goodFilenames.forEach(function (path) {
-            assert(utils.type.isStimuliData(path));
-        });
-    });
-});
-
-describe('utils.type.getPathValues', function () {
-    it('should return the correct path values from a valid file path', function () {
-        assert.equal(utils.type.getPathValues('/sub-22/ses-1/func/sub-22_ses-1_task-rest_acq-prefrontal_physio.tsv.gz').sub, 22);
-        assert.equal(utils.type.getPathValues('/sub-22/ses-1/func/sub-22_ses-1_task-rest_acq-prefrontal_physio.tsv.gz').ses, 1);
-        assert.equal(utils.type.getPathValues('/sub-22/func/sub-22_task-rest_acq-prefrontal_physio.tsv.gz').sub, 22);
-        assert.equal(utils.type.getPathValues('/sub-22/func/sub-22_task-rest_acq-prefrontal_physio.tsv.gz').ses, null);
-    });
-});
-
-describe('BIDS.subIDsesIDmismatchtest', function () {
-    var code64_seen = false;
-    var code65_seen = false;
-    it('should return if sub and ses doesnt match', function () {
-
-        var files = { '0':
-           { name: 'sub-22_ses-1_task-rest_acq-prefrontal_physio.tsv.gz',
-             path: 'tests/data/BIDS-examples-1.0.0-rc3u5/ds001/sub-22_ses-1_task-rest_acq-prefrontal_physio.tsv.gz',
-             relativePath: 'ds001/sub-22_ses-1_task-rest_acq-prefrontal_physio.tsv.gz' },
-          '1':
-           { name: '/sub-22/ses-1/func/sub-23_ses-1_task-rest_acq-prefrontal_physio.tsv.gz',
-             path: 'tests/data/BIDS-examples-1.0.0-rc3u5/ds001/sub-22/ses-1/func/sub-23_ses-1_task-rest_acq-prefrontal_physio.tsv.gz',
-             relativePath: 'ds001/sub-22/ses-1/func/sub-23_ses-1_task-rest_acq-prefrontal_physio.tsv.gz' },
-          '2':
-           { name: '/sub-22/ses-1/func/sub-22_ses-2_task-rest_acq-prefrontal_physio.tsv.gz',
-             path: 'tests/data/BIDS-examples-1.0.0-rc3u5/ds001/sub-22/ses-1/func/sub-22_ses-2_task-rest_acq-prefrontal_physio.tsv.gz',
-             relativePath: '/sub-22/ses-1/func/sub-22_ses-2_task-rest_acq-prefrontal_physio.tsv.gz' },
-          '3':
-           { name: '/sub-25/ses-2/func/sub-22_ses-1_task-rest_acq-prefrontal_physio.tsv.gz',
-             path: 'tests/data/BIDS-examples-1.0.0-rc3u5/ds001/sub-25/ses-2/func/sub-22_ses-1_task-rest_acq-prefrontal_physio.tsv.gz',
-             relativePath: 'ds001//sub-25/ses-2/func/sub-22_ses-1_task-rest_acq-prefrontal_physio.tsv.gz' }},
-
-        callback = function (issues) {
-            for (var i in issues) {
-                if (issues[i]['code'] === 64) {
-                    code64_seen = true;
-                }
-                else if (issues[i]['code'] === 65) {
-                    code65_seen = false;
-                }
-            }
-            assert(code64_seen);
-            assert(code65_seen);
-        };
-        assert.equal(BIDS.subIDsesIDmismatchtest(files, callback), true);
-        });
-});
+describe('BIDS.subIDsesIDmismatchtest', function() {
+  var code64_seen = false
+  var code65_seen = false
+  it('should return if sub and ses doesnt match', function() {
+    var files = {
+        '0': {
+          name: 'sub-22_ses-1_task-rest_acq-prefrontal_physio.tsv.gz',
+          path:
+            'tests/data/BIDS-examples-1.0.0-rc3u5/ds001/sub-22_ses-1_task-rest_acq-prefrontal_physio.tsv.gz',
+          relativePath:
+            'ds001/sub-22_ses-1_task-rest_acq-prefrontal_physio.tsv.gz',
+        },
+        '1': {
+          name:
+            '/sub-22/ses-1/func/sub-23_ses-1_task-rest_acq-prefrontal_physio.tsv.gz',
+          path:
+            'tests/data/BIDS-examples-1.0.0-rc3u5/ds001/sub-22/ses-1/func/sub-23_ses-1_task-rest_acq-prefrontal_physio.tsv.gz',
+          relativePath:
+            'ds001/sub-22/ses-1/func/sub-23_ses-1_task-rest_acq-prefrontal_physio.tsv.gz',
+        },
+        '2': {
+          name:
+            '/sub-22/ses-1/func/sub-22_ses-2_task-rest_acq-prefrontal_physio.tsv.gz',
+          path:
+            'tests/data/BIDS-examples-1.0.0-rc3u5/ds001/sub-22/ses-1/func/sub-22_ses-2_task-rest_acq-prefrontal_physio.tsv.gz',
+          relativePath:
+            '/sub-22/ses-1/func/sub-22_ses-2_task-rest_acq-prefrontal_physio.tsv.gz',
+        },
+        '3': {
+          name:
+            '/sub-25/ses-2/func/sub-22_ses-1_task-rest_acq-prefrontal_physio.tsv.gz',
+          path:
+            'tests/data/BIDS-examples-1.0.0-rc3u5/ds001/sub-25/ses-2/func/sub-22_ses-1_task-rest_acq-prefrontal_physio.tsv.gz',
+          relativePath:
+            'ds001//sub-25/ses-2/func/sub-22_ses-1_task-rest_acq-prefrontal_physio.tsv.gz',
+        },
+      },
+      callback = function(issues) {
+        for (var i in issues) {
+          if (issues[i]['code'] === 64) {
+            code64_seen = true
+          } else if (issues[i]['code'] === 65) {
+            code65_seen = false
+          }
+        }
+        assert(code64_seen)
+        assert(code65_seen)
+      }
+    assert.equal(BIDS.subIDsesIDmismatchtest(files, callback), true)
+  })
+})

--- a/tests/utils/config.spec.js
+++ b/tests/utils/config.spec.js
@@ -1,94 +1,83 @@
-var utils  = require('../../utils');
-var assert = require('assert');;
+var utils = require('../../utils')
+var assert = require('assert')
 
-describe('utils.config', function () {
+describe('utils.config', function() {
+  var codes = [1, 3, 4, 7, 21, 33, 34]
+  var conf = {
+    ignore: [3],
+    warn: [
+      4,
+      {
+        and: [7, { or: [33, 21] }],
+      },
+    ],
+    error: [34, 33],
+    ignoredFiles: ['**/**/**/.DS_Store'],
+  }
 
-    var codes = [1, 3, 4, 7, 21, 33, 34];
-    var conf = {
-        ignore: [3],
-        warn:   [
-            4,
-            {"and": [
-                7,
-                {"or": [33, 21]}
-            ]}
-        ],
-        error:  [34, 33],
-        ignoredFiles: ['**/**/**/.DS_Store']
-    };
-
-    describe('ignoredFile', function() {
-
-        it('should return true if the file is ignored', function () {
-            assert(utils.config.ignoredFile(conf, '/.DS_Store'));
-            assert(utils.config.ignoredFile(conf, 'ds001/.DS_Store'));
-            assert(utils.config.ignoredFile(conf, 'ds001/sub-01/.DS_Store'));
-        });
-
-        it('should return false if the file is not ignored', function () {
-            assert(!utils.config.ignoredFile(conf, '/participants.tsv'));
-            assert(!utils.config.ignoredFile(conf, 'ds001/README'));
-            assert(!utils.config.ignoredFile(conf, 'ds001/sub-16/anat/sub-16_T1w.nii.gz'));
-        });
-
-    });
-
-    describe('interpret', function () {
-
-        it('should return the correct severity mappings', function () {
-            var severityMap = utils.config.interpret(codes, conf);
-            assert.deepEqual(severityMap, {
-                '3':  'ignore',
-                '4':  'warning',
-                '7':  'warning',
-                '21': 'warning',
-                '33': 'error',
-                '34': 'error'
-            });
-        });
-
-    });
-
-    describe('match', function () {
-
-        it('should return a list of triggered codes that match the config', function () {
-            assert.deepEqual([3], utils.config.match(codes, conf.ignore));
-            assert.deepEqual([4, 7, 33, 21], utils.config.match(codes, conf.warn));
-            assert.deepEqual([34, 33], utils.config.match(codes, conf.error));
-        });
-
-    });
-
-    describe('flatten', function () {
-
-        it('should return a flattened list of codes', function () {
-            assert.deepEqual([3], utils.config.flatten(conf.ignore));
-            assert.deepEqual([4, 7, 33, 21], utils.config.flatten(conf.warn));
-            assert.deepEqual([34, 33], utils.config.flatten(conf.error));
-        });
-
-    });
-
-    describe('andFullfilled', function () {
-
-        it('should return true if the \'and\' array is fulfilled by the triggered codes', function () {
-            assert(utils.config.andFulfilled(codes, conf.warn[1].and));
-        });
-
-        it('should return false if the \'and\' array is not fulfilled', function () {
-            assert(!utils.config.andFulfilled(codes, [1, 4, 7, 21, 22]));
-        });
-
-    });
-
-    describe('orFulfilled', function () {
-
-        it('should return true if the \'or\' array is fulfilled by the triggered codes', function () {
-            assert(utils.config.orFulfilled(codes, conf.warn[1].and[1].or))
-        });
-
-        it('should return false if the \'or\' array is not fulfilled', function () {
-            assert(!utils.config.orFulfilled(codes, [5, 6]));
-        });
+  describe('ignoredFile', function() {
+    it('should return true if the file is ignored', function() {
+      assert(utils.config.ignoredFile(conf, '/.DS_Store'))
+      assert(utils.config.ignoredFile(conf, 'ds001/.DS_Store'))
+      assert(utils.config.ignoredFile(conf, 'ds001/sub-01/.DS_Store'))
     })
+
+    it('should return false if the file is not ignored', function() {
+      assert(!utils.config.ignoredFile(conf, '/participants.tsv'))
+      assert(!utils.config.ignoredFile(conf, 'ds001/README'))
+      assert(
+        !utils.config.ignoredFile(conf, 'ds001/sub-16/anat/sub-16_T1w.nii.gz'),
+      )
+    })
+  })
+
+  describe('interpret', function() {
+    it('should return the correct severity mappings', function() {
+      var severityMap = utils.config.interpret(codes, conf)
+      assert.deepEqual(severityMap, {
+        '3': 'ignore',
+        '4': 'warning',
+        '7': 'warning',
+        '21': 'warning',
+        '33': 'error',
+        '34': 'error',
+      })
+    })
+  })
+
+  describe('match', function() {
+    it('should return a list of triggered codes that match the config', function() {
+      assert.deepEqual([3], utils.config.match(codes, conf.ignore))
+      assert.deepEqual([4, 7, 33, 21], utils.config.match(codes, conf.warn))
+      assert.deepEqual([34, 33], utils.config.match(codes, conf.error))
+    })
+  })
+
+  describe('flatten', function() {
+    it('should return a flattened list of codes', function() {
+      assert.deepEqual([3], utils.config.flatten(conf.ignore))
+      assert.deepEqual([4, 7, 33, 21], utils.config.flatten(conf.warn))
+      assert.deepEqual([34, 33], utils.config.flatten(conf.error))
+    })
+  })
+
+  describe('andFullfilled', function() {
+    it("should return true if the 'and' array is fulfilled by the triggered codes", function() {
+      assert(utils.config.andFulfilled(codes, conf.warn[1].and))
+    })
+
+    it("should return false if the 'and' array is not fulfilled", function() {
+      assert(!utils.config.andFulfilled(codes, [1, 4, 7, 21, 22]))
+    })
+  })
+
+  describe('orFulfilled', function() {
+    it("should return true if the 'or' array is fulfilled by the triggered codes", function() {
+      assert(utils.config.orFulfilled(codes, conf.warn[1].and[1].or))
+    })
+
+    it("should return false if the 'or' array is not fulfilled", function() {
+      assert(!utils.config.orFulfilled(codes, [5, 6]))
+    })
+  })
 })

--- a/tests/utils/files.spec.js
+++ b/tests/utils/files.spec.js
@@ -1,44 +1,44 @@
-const assert = require('assert');
-const after = require('mocha').after;
-const utils = require('../../utils');
+const assert = require('assert')
+const after = require('mocha').after
+const utils = require('../../utils')
 
 const setupMocks = () => {
-    // Mock version of the File API for tests
-    global.File = function MockFile(data, fileName, options) {
-        assert(data.hasOwnProperty('length'));
-        assert.equal(typeof data[0], 'string');
-        this._data = data;
-        this._options = options;
-        this.name = fileName;
-    };
-};
+  // Mock version of the File API for tests
+  global.File = function MockFile(data, fileName, options) {
+    assert(data.hasOwnProperty('length'))
+    assert.equal(typeof data[0], 'string')
+    this._data = data
+    this._options = options
+    this.name = fileName
+  }
+}
 const cleanupMocks = () => {
-    delete global.File;
-};
+  delete global.File
+}
 
 describe('files utils in nodejs', () => {
-    describe('FileAPI', () => {
-        it('should return a mock implementation', () => {
-            let File = utils.files.FileAPI();
-            assert(typeof File !== 'undefined');
-            assert(File.name === 'NodeFile');
-        });
-    });
-    describe('newFile', () => {
-        it('creates a new File API object', () => {
-            let file = utils.files.newFile('test-file');
-            assert.equal(file.name, 'test-file');
-        });
-    });
-});
+  describe('FileAPI', () => {
+    it('should return a mock implementation', () => {
+      let File = utils.files.FileAPI()
+      assert(typeof File !== 'undefined')
+      assert(File.name === 'NodeFile')
+    })
+  })
+  describe('newFile', () => {
+    it('creates a new File API object', () => {
+      let file = utils.files.newFile('test-file')
+      assert.equal(file.name, 'test-file')
+    })
+  })
+})
 
 describe('files utils in browsers', () => {
-    before(setupMocks);
-    after(cleanupMocks);
-    describe('newFile', () => {
-        it('creates a new File API object', () => {
-            const test_file = utils.files.newFile('test-file');
-            assert(File.prototype.isPrototypeOf(test_file));
-        });
-    });
-});
+  before(setupMocks)
+  after(cleanupMocks)
+  describe('newFile', () => {
+    it('creates a new File API object', () => {
+      const test_file = utils.files.newFile('test-file')
+      assert(File.prototype.isPrototypeOf(test_file))
+    })
+  })
+})

--- a/utils/array.js
+++ b/utils/array.js
@@ -1,63 +1,63 @@
 var array = {
-
-    /**
-     * Equals
-     *
-     * Takes two arrays and returns true if they're
-     * equal. Takes a third optional boolean argument
-     * to sort arrays before checking equality.
-     */
-    equals: function (array1, array2, sort) {
-        // if the other array is a falsy value, return
-        if (!array1 || !array2) {
-            return false;
-        }
-
-        // compare lengths
-        if (array1.length != array2.length) {
-            return false;
-        }
-
-        // optionally sort arrays
-        if (sort) {
-            array1.sort();
-            array2.sort();
-        }
-
-        for (var i = 0, l = array1.length; i < l; i++) {
-            // Check if we have nested arrays
-            if (array1[i] instanceof Array && array2[i] instanceof Array) {
-                // recurse into the nested arrays
-                if (!array.equals(array1[i], array2[i], sort)) {
-                    return false;
-                }
-            } else if (array1[i] != array2[i]) {
-                // Warning - two different object instances will never be equal: {x:20} != {x:20}
-                return false;
-            }
-        }
-        return true;
-    },
-
-    /**
-     * Takes to arrays and returns an array of two
-     * arrays contains the differences contained
-     * in each array.
-     */
-    diff: function (array1, array2) {
-        var diff1 = [], diff2 = [];
-        for (var i = 0; i < array1.length; i++) {
-            var elem1 = array1[i];
-            var index = array2.indexOf(elem1);
-            if (index > -1) {
-                array2.splice(index, 1);
-            } else {
-                diff1.push(elem1);
-            }
-        }
-        diff2 = array2;
-        return [diff1, diff2];
+  /**
+   * Equals
+   *
+   * Takes two arrays and returns true if they're
+   * equal. Takes a third optional boolean argument
+   * to sort arrays before checking equality.
+   */
+  equals: function(array1, array2, sort) {
+    // if the other array is a falsy value, return
+    if (!array1 || !array2) {
+      return false
     }
-};
 
-module.exports = array;
+    // compare lengths
+    if (array1.length != array2.length) {
+      return false
+    }
+
+    // optionally sort arrays
+    if (sort) {
+      array1.sort()
+      array2.sort()
+    }
+
+    for (var i = 0, l = array1.length; i < l; i++) {
+      // Check if we have nested arrays
+      if (array1[i] instanceof Array && array2[i] instanceof Array) {
+        // recurse into the nested arrays
+        if (!array.equals(array1[i], array2[i], sort)) {
+          return false
+        }
+      } else if (array1[i] != array2[i]) {
+        // Warning - two different object instances will never be equal: {x:20} != {x:20}
+        return false
+      }
+    }
+    return true
+  },
+
+  /**
+   * Takes to arrays and returns an array of two
+   * arrays contains the differences contained
+   * in each array.
+   */
+  diff: function(array1, array2) {
+    var diff1 = [],
+      diff2 = []
+    for (var i = 0; i < array1.length; i++) {
+      var elem1 = array1[i]
+      var index = array2.indexOf(elem1)
+      if (index > -1) {
+        array2.splice(index, 1)
+      } else {
+        diff1.push(elem1)
+      }
+    }
+    diff2 = array2
+    return [diff1, diff2]
+  },
+}
+
+module.exports = array

--- a/utils/config.js
+++ b/utils/config.js
@@ -1,150 +1,150 @@
-
-var minimatch = require('minimatch');
+var minimatch = require('minimatch')
 
 var config = {
-
-    /**
-     * Ignored File
-     */
-    ignoredFile: function (conf, filePath) {
-        if (conf.ignoredFiles) {
-            for (var i = 0; i < conf.ignoredFiles.length; i++) {
-                var ignoredPattern = conf.ignoredFiles[i];
-                if (minimatch(filePath, ignoredPattern)) {
-                    return true;
-                }
-            }
+  /**
+   * Ignored File
+   */
+  ignoredFile: function(conf, filePath) {
+    if (conf.ignoredFiles) {
+      for (var i = 0; i < conf.ignoredFiles.length; i++) {
+        var ignoredPattern = conf.ignoredFiles[i]
+        if (minimatch(filePath, ignoredPattern)) {
+          return true
         }
-        return false;
-    },
+      }
+    }
+    return false
+  },
 
-    /**
-     * Interpret Config
-     *
-     * Takes a list of triggered codes and a config object
-     * and create a map of modified severities
-     */
-    interpret: function (codes, conf) {
-        var severityMap = {};
+  /**
+   * Interpret Config
+   *
+   * Takes a list of triggered codes and a config object
+   * and create a map of modified severities
+   */
+  interpret: function(codes, conf) {
+    var severityMap = {}
 
-        if (conf.ignore && conf.ignore.length > 0) {
-            var ignoreCodes = this.match(codes, conf.ignore);
-            for (var i = 0; i < ignoreCodes.length; i++) {
-                var ignoreCode = ignoreCodes[i];
-                severityMap[ignoreCode] = 'ignore';
-            }
-        }
-
-        if (conf.warn && conf.warn.length > 0) {
-            var warnCodes = this.match(codes, conf.warn);
-            for (var j = 0; j < warnCodes.length; j++) {
-                var warnCode = warnCodes[j];
-                severityMap[warnCode] = 'warning';
-            }
-        }
-
-        if (conf.error && conf.error.length > 0) {
-            var errorCodes = this.match(codes, conf.error);
-            for (var k = 0; k < errorCodes.length; k++) {
-                var errorCode = errorCodes[k];
-                severityMap[errorCode] = 'error';
-            }
-        }
-
-        return severityMap;
-    },
-
-    /**
-     * Match
-     *
-     * Takes a list of triggered codes and a config
-     * object and returns the matched codes.
-     */
-    match: function (codes, conf) {
-        var matches = [];
-        for (var i = 0; i < conf.length; i++) {
-            var confCode = conf[i];
-            if (codes.indexOf(confCode) > -1) {
-                matches.push(confCode);
-            } else if (confCode.hasOwnProperty('and') && this.andFulfilled(codes, confCode.and)) {
-                // 'and' array fulfilled
-                matches = matches.concat(this.flatten(confCode.and));
-            }
-        }
-        return matches;
-    },
-
-    /**
-     * Flatten
-     *
-     * Takes an array that may contain objects with
-     * 'and' or 'or' properties and flattens it.
-     */
-    flatten: function (list) {
-        var codes = [];
-        for (var i = 0; i < list.length; i++) {
-            var code = list[i];
-            if (code.hasOwnProperty('and')) {
-                codes = codes.concat(this.flatten(code.and));
-            } else if (code.hasOwnProperty('or')) {
-                codes = codes.concat(this.flatten(code.or));
-            } else {
-                codes.push(code);
-            }
-        }
-        return codes;
-    },
-
-    /**
-     * And Fulfilled
-     *
-     * Takes an array of triggered code and an 'and'
-     * array, recursively checks if it's fulfilled
-     * and returns true if it is.
-     */
-    andFulfilled: function (codes, and) {
-        for (var i = 0; i < and.length; i++) {
-            var andCode = and[i];
-            if (andCode.hasOwnProperty('and')) {
-                if (!this.andFulfilled(codes, andCode.and)) {
-                    return false;
-                }
-            } else if (andCode.hasOwnProperty('or')) {
-                if (!this.orFulfilled(codes, andCode.or)) {
-                    return false;
-                }
-            } else if (codes.indexOf(andCode) < 0) {
-                return false;
-            }
-        }
-        return true;
-    },
-
-    /**
-     * Or Fulfilled
-     *
-     * Takes an array of triggered code and an 'or'
-     * array, recursively checks if it's fulfilled
-     * and returns true if it is.
-     */
-    orFulfilled: function (codes, or) {
-        for (var i = 0; i < or.length; i++) {
-            var orCode = or[i];
-            if (orCode.hasOwnProperty('and')) {
-                if (this.andFulfilled(codes, orCode.and)) {
-                    return true;
-                }
-            } else if (orCode.hasOwnProperty('or')) {
-                if (this.orFulfilled(codes, orCode.or)) {
-                    return true;
-                }
-            } else if (codes.indexOf(orCode) > -1) {
-                return true;
-            }
-        }
-        return false;
+    if (conf.ignore && conf.ignore.length > 0) {
+      var ignoreCodes = this.match(codes, conf.ignore)
+      for (var i = 0; i < ignoreCodes.length; i++) {
+        var ignoreCode = ignoreCodes[i]
+        severityMap[ignoreCode] = 'ignore'
+      }
     }
 
-};
+    if (conf.warn && conf.warn.length > 0) {
+      var warnCodes = this.match(codes, conf.warn)
+      for (var j = 0; j < warnCodes.length; j++) {
+        var warnCode = warnCodes[j]
+        severityMap[warnCode] = 'warning'
+      }
+    }
 
-module.exports = config;
+    if (conf.error && conf.error.length > 0) {
+      var errorCodes = this.match(codes, conf.error)
+      for (var k = 0; k < errorCodes.length; k++) {
+        var errorCode = errorCodes[k]
+        severityMap[errorCode] = 'error'
+      }
+    }
+
+    return severityMap
+  },
+
+  /**
+   * Match
+   *
+   * Takes a list of triggered codes and a config
+   * object and returns the matched codes.
+   */
+  match: function(codes, conf) {
+    var matches = []
+    for (var i = 0; i < conf.length; i++) {
+      var confCode = conf[i]
+      if (codes.indexOf(confCode) > -1) {
+        matches.push(confCode)
+      } else if (
+        confCode.hasOwnProperty('and') &&
+        this.andFulfilled(codes, confCode.and)
+      ) {
+        // 'and' array fulfilled
+        matches = matches.concat(this.flatten(confCode.and))
+      }
+    }
+    return matches
+  },
+
+  /**
+   * Flatten
+   *
+   * Takes an array that may contain objects with
+   * 'and' or 'or' properties and flattens it.
+   */
+  flatten: function(list) {
+    var codes = []
+    for (var i = 0; i < list.length; i++) {
+      var code = list[i]
+      if (code.hasOwnProperty('and')) {
+        codes = codes.concat(this.flatten(code.and))
+      } else if (code.hasOwnProperty('or')) {
+        codes = codes.concat(this.flatten(code.or))
+      } else {
+        codes.push(code)
+      }
+    }
+    return codes
+  },
+
+  /**
+   * And Fulfilled
+   *
+   * Takes an array of triggered code and an 'and'
+   * array, recursively checks if it's fulfilled
+   * and returns true if it is.
+   */
+  andFulfilled: function(codes, and) {
+    for (var i = 0; i < and.length; i++) {
+      var andCode = and[i]
+      if (andCode.hasOwnProperty('and')) {
+        if (!this.andFulfilled(codes, andCode.and)) {
+          return false
+        }
+      } else if (andCode.hasOwnProperty('or')) {
+        if (!this.orFulfilled(codes, andCode.or)) {
+          return false
+        }
+      } else if (codes.indexOf(andCode) < 0) {
+        return false
+      }
+    }
+    return true
+  },
+
+  /**
+   * Or Fulfilled
+   *
+   * Takes an array of triggered code and an 'or'
+   * array, recursively checks if it's fulfilled
+   * and returns true if it is.
+   */
+  orFulfilled: function(codes, or) {
+    for (var i = 0; i < or.length; i++) {
+      var orCode = or[i]
+      if (orCode.hasOwnProperty('and')) {
+        if (this.andFulfilled(codes, orCode.and)) {
+          return true
+        }
+      } else if (orCode.hasOwnProperty('or')) {
+        if (this.orFulfilled(codes, orCode.or)) {
+          return true
+        }
+      } else if (codes.indexOf(orCode) > -1) {
+        return true
+      }
+    }
+    return false
+  },
+}
+
+module.exports = config

--- a/utils/files.js
+++ b/utils/files.js
@@ -1,34 +1,33 @@
 // dependencies -------------------------------------------------------------------
 
-var nifti = require('nifti-js');
-var Issue = require('./issues').Issue;
-var ignore = require('ignore');
-var path = require('path');
+var nifti = require('nifti-js')
+var Issue = require('./issues').Issue
+var ignore = require('ignore')
+var path = require('path')
 
 /**
  * If the current environment is server side
  * nodejs/iojs import fs.
  */
 if (typeof window === 'undefined') {
-    var fs = require('fs');
-    var zlib = require('zlib');
+  var fs = require('fs')
+  var zlib = require('zlib')
 } else {
-    var pako = require('pako');
+  var pako = require('pako')
 }
 
 // public API ---------------------------------------------------------------------
 
 var fileUtils = {
-    FileAPI: FileAPI,
-    newFile: newFile,
-    readFile: readFile,
-    readDir: readDir,
-    readNiftiHeader: readNiftiHeader,
-    generateMergedSidecarDict: generateMergedSidecarDict,
-    potentialLocations: potentialLocations,
-    getBFileContent: getBFileContent
-
-};
+  FileAPI: FileAPI,
+  newFile: newFile,
+  readFile: readFile,
+  readDir: readDir,
+  readNiftiHeader: readNiftiHeader,
+  generateMergedSidecarDict: generateMergedSidecarDict,
+  potentialLocations: potentialLocations,
+  getBFileContent: getBFileContent,
+}
 
 // implementations ----------------------------------------------------------------
 
@@ -44,52 +43,56 @@ var fileUtils = {
  * In node the file should be a path to a file.
  *
  */
-function readFile (file, callback) {
-    if (fs) {
-        testFile(file, function (issue) {
-            if (issue) {
-                process.nextTick(function() { callback(issue, null); });
-                return;
-            }
-            fs.readFile(file.path, 'utf8', function (err, data) {
-                process.nextTick(function() { callback(null, data); });
-            });
-        });
-    } else {
-        var reader = new FileReader();
-        reader.onloadend = function (e) {
-            if (e.target.readyState == FileReader.DONE) {
-                if (!e.target.result) {
-                    callback(new Issue({code: 44, file: file}), null);
-                    return;
-                }
-                callback(null, e.target.result);
-            }
-        };
-        reader.readAsBinaryString(file);
+function readFile(file, callback) {
+  if (fs) {
+    testFile(file, function(issue) {
+      if (issue) {
+        process.nextTick(function() {
+          callback(issue, null)
+        })
+        return
+      }
+      fs.readFile(file.path, 'utf8', function(err, data) {
+        process.nextTick(function() {
+          callback(null, data)
+        })
+      })
+    })
+  } else {
+    var reader = new FileReader()
+    reader.onloadend = function(e) {
+      if (e.target.readyState == FileReader.DONE) {
+        if (!e.target.result) {
+          callback(new Issue({ code: 44, file: file }), null)
+          return
+        }
+        callback(null, e.target.result)
+      }
     }
+    reader.readAsBinaryString(file)
+  }
 }
 
 function getBIDSIgnoreFileObjNode(dir) {
-    var bidsIgnoreFileObj = null;
-    var path = dir + "/.bidsignore";
-    if (fs.existsSync(path)) {
-        bidsIgnoreFileObj = {path: path};
-    }
-    return bidsIgnoreFileObj;
+  var bidsIgnoreFileObj = null
+  var path = dir + '/.bidsignore'
+  if (fs.existsSync(path)) {
+    bidsIgnoreFileObj = { path: path }
+  }
+  return bidsIgnoreFileObj
 }
 
 function getBIDSIgnoreFileObjBrowser(dir) {
-    var bidsIgnoreFileObj = null;
-    for (var i = 0; i < dir.length; i++) {
-        var fileObj = dir[i];
-        var relativePath = harmonizeRelativePath(fileObj.webkitRelativePath);
-        if (relativePath === "/.bidsignore") {
-            bidsIgnoreFileObj = fileObj;
-            break;
-        }
+  var bidsIgnoreFileObj = null
+  for (var i = 0; i < dir.length; i++) {
+    var fileObj = dir[i]
+    var relativePath = harmonizeRelativePath(fileObj.webkitRelativePath)
+    if (relativePath === '/.bidsignore') {
+      bidsIgnoreFileObj = fileObj
+      break
     }
-    return bidsIgnoreFileObj;
+  }
+  return bidsIgnoreFileObj
 }
 
 /**
@@ -98,33 +101,33 @@ function getBIDSIgnoreFileObjBrowser(dir) {
  * @returns File object or null if not found
  */
 function getBIDSIgnoreFileObj(dir) {
-    var bidsIgnoreFileObj = null;
-    if (fs) {
-        bidsIgnoreFileObj = getBIDSIgnoreFileObjNode(dir);
-    } else {
-        bidsIgnoreFileObj = getBIDSIgnoreFileObjBrowser(dir);
-    }
-    return bidsIgnoreFileObj;
+  var bidsIgnoreFileObj = null
+  if (fs) {
+    bidsIgnoreFileObj = getBIDSIgnoreFileObjNode(dir)
+  } else {
+    bidsIgnoreFileObj = getBIDSIgnoreFileObjBrowser(dir)
+  }
+  return bidsIgnoreFileObj
 }
 
 function getBIDSIgnore(dir, callback) {
-    var ig = ignore()
-        .add('.*')
-        .add('!*.icloud')
-        .add('/derivatives')
-        .add('/sourcedata')
-        .add('/code');
+  var ig = ignore()
+    .add('.*')
+    .add('!*.icloud')
+    .add('/derivatives')
+    .add('/sourcedata')
+    .add('/code')
 
-    var bidsIgnoreFileObj = getBIDSIgnoreFileObj(dir);
-    if (bidsIgnoreFileObj) {
-        readFile(bidsIgnoreFileObj, function (issue, content) {
-            ig = ig.add(content);
-            callback(ig);
-        });
-    } else {
-        callback(ig);
-    }
-    return ig;
+  var bidsIgnoreFileObj = getBIDSIgnoreFileObj(dir)
+  if (bidsIgnoreFileObj) {
+    readFile(bidsIgnoreFileObj, function(issue, content) {
+      ig = ig.add(content)
+      callback(ig)
+    })
+  } else {
+    callback(ig)
+  }
+  return ig
 }
 
 /**
@@ -137,23 +140,23 @@ function getBIDSIgnore(dir, callback) {
  * In the browser it simply passes the file dir
  * object to the callback.
  */
-function readDir (dir, callback) {
-    var filesObj = {};
-    var filesList = [];
+function readDir(dir, callback) {
+  var filesObj = {}
+  var filesList = []
 
-    function callbackWrapper(ig) {
-        if (fs) {
-            filesList = preprocessNode(dir, ig);
-        } else {
-            filesList = preprocessBrowser(dir, ig);
-        }
-        // converting array to object
-        for (var j = 0; j < filesList.length; j++) {
-            filesObj[j] = filesList[j];
-        }
-        callback(filesObj);
+  function callbackWrapper(ig) {
+    if (fs) {
+      filesList = preprocessNode(dir, ig)
+    } else {
+      filesList = preprocessBrowser(dir, ig)
     }
-    getBIDSIgnore(dir, callbackWrapper);
+    // converting array to object
+    for (var j = 0; j < filesList.length; j++) {
+      filesObj[j] = filesList[j]
+    }
+    callback(filesObj)
+  }
+  getBIDSIgnore(dir, callbackWrapper)
 }
 
 /**
@@ -163,16 +166,16 @@ function readDir (dir, callback) {
  * 2. Adds 'relativePath' field of each file object.
  */
 function preprocessBrowser(filesObj, ig) {
-    var filesList = [];
-    for (var i = 0; i < filesObj.length; i++) {
-        var fileObj = filesObj[i];
-        fileObj.relativePath = harmonizeRelativePath(fileObj.webkitRelativePath);
-        if (ig.ignores(path.relative('/', fileObj.relativePath))) {
-            fileObj.ignore = true;
-        }
-        filesList.push(fileObj);
+  var filesList = []
+  for (var i = 0; i < filesObj.length; i++) {
+    var fileObj = filesObj[i]
+    fileObj.relativePath = harmonizeRelativePath(fileObj.webkitRelativePath)
+    if (ig.ignores(path.relative('/', fileObj.relativePath))) {
+      fileObj.ignore = true
     }
-    return filesList;
+    filesList.push(fileObj)
+  }
+  return filesList
 }
 
 /**
@@ -183,43 +186,42 @@ function preprocessBrowser(filesObj, ig) {
  * 3. Harmonizes the 'relativePath' field
  */
 function preprocessNode(dir, ig) {
-    var str = dir.substr(dir.lastIndexOf('/') + 1) + '$';
-    var rootpath = dir.replace(new RegExp(str), '');
-    return getFiles(dir, [], rootpath, ig);
+  var str = dir.substr(dir.lastIndexOf('/') + 1) + '$'
+  var rootpath = dir.replace(new RegExp(str), '')
+  return getFiles(dir, [], rootpath, ig)
 }
 
 /**
  * Recursive helper function for 'preprocessNode'
  */
-function getFiles(dir, files_, rootpath, ig){
-    files_ = files_ || [];
-    var files = fs.readdirSync(dir);
-    for (var i = 0; i < files.length; i++) {
-        var fullPath = dir + '/' + files[i];
-        var relativePath = fullPath.replace(rootpath, '');
-        relativePath = harmonizeRelativePath(relativePath);
-        
-        var fileName = files[i];
+function getFiles(dir, files_, rootpath, ig) {
+  files_ = files_ || []
+  var files = fs.readdirSync(dir)
+  for (var i = 0; i < files.length; i++) {
+    var fullPath = dir + '/' + files[i]
+    var relativePath = fullPath.replace(rootpath, '')
+    relativePath = harmonizeRelativePath(relativePath)
 
-        var fileObj = {
-            name: fileName,
-            path: fullPath,
-            relativePath: relativePath
-        };
+    var fileName = files[i]
 
-        if (ig.ignores(path.relative('/', relativePath))) {
-            fileObj.ignore = true;
-        }
-
-        if (fs.lstatSync(fullPath).isDirectory()) {
-            getFiles(fullPath, files_, rootpath, ig);
-        } else {
-            files_.push(fileObj);
-        }
+    var fileObj = {
+      name: fileName,
+      path: fullPath,
+      relativePath: relativePath,
     }
-    return files_;
-}
 
+    if (ig.ignores(path.relative('/', relativePath))) {
+      fileObj.ignore = true
+    }
+
+    if (fs.lstatSync(fullPath).isDirectory()) {
+      getFiles(fullPath, files_, rootpath, ig)
+    } else {
+      files_.push(fileObj)
+    }
+  }
+  return files_
+}
 
 /**
  * Read Nifti Header
@@ -227,83 +229,86 @@ function getFiles(dir, files_, rootpath, ig){
  * Takes a files and returns a json parsed nifti
  * header without reading any extra bytes.
  */
-function readNiftiHeader (file, callback) {
-    var bytesRead = 500;
+function readNiftiHeader(file, callback) {
+  var bytesRead = 500
 
-    if (fs) {
-        testFile(file, function (issue, stats) {
-            file.stats = stats;
-            if (issue) {
-                callback({error: issue});
-                return;
-            }
-            if (stats.size < 348) {
-                callback({error: new Issue({code: 36, file: file})});
-                return;
-            }
+  if (fs) {
+    testFile(file, function(issue, stats) {
+      file.stats = stats
+      if (issue) {
+        callback({ error: issue })
+        return
+      }
+      if (stats.size < 348) {
+        callback({ error: new Issue({ code: 36, file: file }) })
+        return
+      }
 
-            var buffer = new Buffer(bytesRead);
+      var buffer = new Buffer(bytesRead)
 
-            var decompressStream = zlib.createGunzip()
-                .on('data', function (chunk) {
-                    callback(parseNIfTIHeader(chunk, file));
-                    decompressStream.pause();
-                }).on('error', function() {
-                    callback(handleGunzipError(buffer, file));
-                });
+      var decompressStream = zlib
+        .createGunzip()
+        .on('data', function(chunk) {
+          callback(parseNIfTIHeader(chunk, file))
+          decompressStream.pause()
+        })
+        .on('error', function() {
+          callback(handleGunzipError(buffer, file))
+        })
 
-            fs.open(file.path, 'r', function(err, fd) {
-                if (err){
-                    callback({error: new Issue({code: 44, file: file})});
-                    return;
-                } else {
-                    fs.read(fd, buffer, 0, bytesRead, 0, function () {
-                        if (file.name.endsWith('.nii')) {
-                            callback(parseNIfTIHeader(buffer, file));
-                        } else {
-                            decompressStream.write(buffer);
-                        }
-                    });
-                }
-            });
-        });
-    } else {
-
-        if (file.size == 0) {
-            callback({error: new Issue({code: 44, file: file})});
-            return;
-        }
-
-        // file size is smaller than nifti header size
-        if (file.size < 348) {
-            callback({error: new Issue({code: 36, file: file})});
-            return;
-        }
-
-        var blobSlice = File.prototype.slice || File.prototype.mozSlice || File.prototype.webkitSlice,
-        fileReader = new FileReader();
-
-        fileReader.onloadend = function () {
-            var buffer = new Uint8Array(fileReader.result);
-            var unzipped;
-
+      fs.open(file.path, 'r', function(err, fd) {
+        if (err) {
+          callback({ error: new Issue({ code: 44, file: file }) })
+          return
+        } else {
+          fs.read(fd, buffer, 0, bytesRead, 0, function() {
             if (file.name.endsWith('.nii')) {
-                unzipped = buffer;
+              callback(parseNIfTIHeader(buffer, file))
             } else {
-                try {
-                    unzipped = pako.inflate(buffer);
-                }
-                catch (err) {
-                    callback(handleGunzipError(buffer, file));
-                    return;
-                }
+              decompressStream.write(buffer)
             }
-
-            callback(parseNIfTIHeader(unzipped, file));
-        };
-
-        fileReader.readAsArrayBuffer(blobSlice.call(file, 0, bytesRead));
+          })
+        }
+      })
+    })
+  } else {
+    if (file.size == 0) {
+      callback({ error: new Issue({ code: 44, file: file }) })
+      return
     }
+
+    // file size is smaller than nifti header size
+    if (file.size < 348) {
+      callback({ error: new Issue({ code: 36, file: file }) })
+      return
+    }
+
+    var blobSlice =
+        File.prototype.slice ||
+        File.prototype.mozSlice ||
+        File.prototype.webkitSlice,
+      fileReader = new FileReader()
+
+    fileReader.onloadend = function() {
+      var buffer = new Uint8Array(fileReader.result)
+      var unzipped
+
+      if (file.name.endsWith('.nii')) {
+        unzipped = buffer
+      } else {
+        try {
+          unzipped = pako.inflate(buffer)
+        } catch (err) {
+          callback(handleGunzipError(buffer, file))
+          return
+        }
+      }
+
+      callback(parseNIfTIHeader(unzipped, file))
+    }
+
+    fileReader.readAsArrayBuffer(blobSlice.call(file, 0, bytesRead))
+  }
 }
 
 /**
@@ -313,16 +318,15 @@ function readNiftiHeader (file, callback) {
  * actually gzipped to begin with by trying to parse
  * the original header.
  */
-function handleGunzipError (buffer, file) {
-    try {
-        nifti.parseNIfTIHeader(buffer);
-    }
-    catch (err) {
-        // file is unreadable
-        return {error: new Issue({code: 26, file: file})};
-    }
-    // file was not originally gzipped
-    return {error: new Issue({code: 28, file: file})};
+function handleGunzipError(buffer, file) {
+  try {
+    nifti.parseNIfTIHeader(buffer)
+  } catch (err) {
+    // file is unreadable
+    return { error: new Issue({ code: 26, file: file }) }
+  }
+  // file was not originally gzipped
+  return { error: new Issue({ code: 28, file: file }) }
 }
 
 /**
@@ -331,17 +335,16 @@ function handleGunzipError (buffer, file) {
  * Attempts to parse a header buffer with
  * nifti-js and handles errors.
  */
-function parseNIfTIHeader (buffer, file) {
-    var header;
-    try {
-        header = nifti.parseNIfTIHeader(buffer);
-    }
-    catch (err) {
-        // file is unreadable
-        return {error: new Issue({code: 26, file: file})};
-    }
-    // file was not originally gzipped
-    return header;
+function parseNIfTIHeader(buffer, file) {
+  var header
+  try {
+    header = nifti.parseNIfTIHeader(buffer)
+  } catch (err) {
+    // file is unreadable
+    return { error: new Issue({ code: 26, file: file }) }
+  }
+  // file was not originally gzipped
+  return header
 }
 
 /**
@@ -354,19 +357,19 @@ function parseNIfTIHeader (buffer, file) {
  * sidecars.
  */
 function generateMergedSidecarDict(potentialSidecars, jsonContents) {
-    var mergedDictionary = {};
-    for (var i = 0; i < potentialSidecars.length; i++) {
-        var sidecarName = potentialSidecars[i];
-        var jsonObject = jsonContents[sidecarName];
-        if (jsonObject) {
-            for (var key in jsonObject) {
-                mergedDictionary[key] = jsonObject[key];
-            }
-        } else if (jsonObject === null) {
-            mergedDictionary.invalid = true;
-        }
+  var mergedDictionary = {}
+  for (var i = 0; i < potentialSidecars.length; i++) {
+    var sidecarName = potentialSidecars[i]
+    var jsonObject = jsonContents[sidecarName]
+    if (jsonObject) {
+      for (var key in jsonObject) {
+        mergedDictionary[key] = jsonObject[key]
+      }
+    } else if (jsonObject === null) {
+      mergedDictionary.invalid = true
     }
-    return mergedDictionary;
+  }
+  return mergedDictionary
 }
 
 /**
@@ -378,49 +381,60 @@ function generateMergedSidecarDict(potentialSidecars, jsonContents) {
  * file.
  */
 function potentialLocations(path) {
-    var potentialPaths = [path];
-    var pathComponents = path.split('/');
-    var filenameComponents = pathComponents[pathComponents.length - 1].split("_");
+  var potentialPaths = [path]
+  var pathComponents = path.split('/')
+  var filenameComponents = pathComponents[pathComponents.length - 1].split('_')
 
-    var sessionLevelComponentList = [],
-        subjectLevelComponentList = [],
-        topLevelComponentList = [],
-        ses = null,
-        sub = null;
+  var sessionLevelComponentList = [],
+    subjectLevelComponentList = [],
+    topLevelComponentList = [],
+    ses = null,
+    sub = null
 
-    filenameComponents.forEach(function (filenameComponent) {
-        if (filenameComponent.substring(0, 3) != "run") {
-            sessionLevelComponentList.push(filenameComponent);
-            if (filenameComponent.substring(0, 3) == "ses") {
-                ses = filenameComponent;
-
-            } else {
-                subjectLevelComponentList.push(filenameComponent);
-                if (filenameComponent.substring(0, 3) == "sub") {
-                    sub = filenameComponent;
-                } else {
-                    topLevelComponentList.push(filenameComponent);
-                }
-            }
+  filenameComponents.forEach(function(filenameComponent) {
+    if (filenameComponent.substring(0, 3) != 'run') {
+      sessionLevelComponentList.push(filenameComponent)
+      if (filenameComponent.substring(0, 3) == 'ses') {
+        ses = filenameComponent
+      } else {
+        subjectLevelComponentList.push(filenameComponent)
+        if (filenameComponent.substring(0, 3) == 'sub') {
+          sub = filenameComponent
+        } else {
+          topLevelComponentList.push(filenameComponent)
         }
-    });
-
-    if (ses) {
-        addPotentialPaths(sessionLevelComponentList, potentialPaths, 2, "/" + sub + "/" + ses + "/");
+      }
     }
-    addPotentialPaths(subjectLevelComponentList, potentialPaths, 1, "/" + sub + "/");
-    addPotentialPaths(topLevelComponentList, potentialPaths, 0, "/");
-    potentialPaths.reverse();
+  })
 
-    return potentialPaths;
+  if (ses) {
+    addPotentialPaths(
+      sessionLevelComponentList,
+      potentialPaths,
+      2,
+      '/' + sub + '/' + ses + '/',
+    )
+  }
+  addPotentialPaths(
+    subjectLevelComponentList,
+    potentialPaths,
+    1,
+    '/' + sub + '/',
+  )
+  addPotentialPaths(topLevelComponentList, potentialPaths, 0, '/')
+  potentialPaths.reverse()
+
+  return potentialPaths
 }
 
 function addPotentialPaths(componentList, potentialPaths, offset, prefix) {
-    for (var i = componentList.length; i > offset; i--) {
-        var tmpList = componentList.slice(0, i-1).concat([componentList[componentList.length-1]]);
-        var sessionLevelPath = prefix + tmpList.join("_");
-        potentialPaths.push(sessionLevelPath);
-    }
+  for (var i = componentList.length; i > offset; i--) {
+    var tmpList = componentList
+      .slice(0, i - 1)
+      .concat([componentList[componentList.length - 1]])
+    var sessionLevelPath = prefix + tmpList.join('_')
+    potentialPaths.push(sessionLevelPath)
+  }
 }
 
 /**
@@ -431,12 +445,12 @@ function addPotentialPaths(componentList, potentialPaths, offset, prefix) {
  * the contents of the desired file.
  */
 function getBFileContent(potentialBFiles, bContentsDict) {
-    for (var i = 0; i < potentialBFiles.length; i++) {
-        var potentialBFile = potentialBFiles[i];
-        if (bContentsDict.hasOwnProperty(potentialBFile)) {
-            return bContentsDict[potentialBFile];
-        }
+  for (var i = 0; i < potentialBFiles.length; i++) {
+    var potentialBFile = potentialBFiles[i]
+    if (bContentsDict.hasOwnProperty(potentialBFile)) {
+      return bContentsDict[potentialBFile]
     }
+  }
 }
 
 /**
@@ -446,13 +460,12 @@ function getBFileContent(potentialBFiles, bContentsDict) {
  * base on the environment.
  */
 function harmonizeRelativePath(path) {
-
-    // This hack uniforms relative paths for command line calls to 'BIDS-examples/ds001/' and 'BIDS-examples/ds001'
-    if (path[0] !== '/') {
-        var pathParts = path.split('/');
-        path = '/' + pathParts.slice(1).join('/');
-    }
-    return path;
+  // This hack uniforms relative paths for command line calls to 'BIDS-examples/ds001/' and 'BIDS-examples/ds001'
+  if (path[0] !== '/') {
+    var pathParts = path.split('/')
+    path = '/' + pathParts.slice(1).join('/')
+  }
+  return path
 }
 
 /**
@@ -462,67 +475,71 @@ function harmonizeRelativePath(path) {
  * reading. Calls back with an error and stats if it isn't
  * or null and stats if it is.
  */
-function testFile (file, callback) {
-    fs.stat(file.path, function (statErr, stats) {
-        if (statErr) {
-            fs.lstat(file.path, function (lstatErr, lstats) {
-                if (lstatErr) {
-                    callback(new Issue({code: 44, file: file}), stats);
-                } else if (lstats && lstats.isSymbolicLink()) {
-                    callback(new Issue({code: 43, file: file}), stats);
-                } else {
-                    callback(new Issue({code: 44, file: file}), stats);
-                }
-            });
+function testFile(file, callback) {
+  fs.stat(file.path, function(statErr, stats) {
+    if (statErr) {
+      fs.lstat(file.path, function(lstatErr, lstats) {
+        if (lstatErr) {
+          callback(new Issue({ code: 44, file: file }), stats)
+        } else if (lstats && lstats.isSymbolicLink()) {
+          callback(new Issue({ code: 43, file: file }), stats)
         } else {
-            fs.access(file.path, function (accessErr) {
-                if (!accessErr) {
-                    process.nextTick(function() { callback(null, stats); });
-                } else {
-                    process.nextTick(function() { callback(new Issue({code: 44, file: file}), stats); });
-                }
-            });
+          callback(new Issue({ code: 44, file: file }), stats)
         }
-    });
+      })
+    } else {
+      fs.access(file.path, function(accessErr) {
+        if (!accessErr) {
+          process.nextTick(function() {
+            callback(null, stats)
+          })
+        } else {
+          process.nextTick(function() {
+            callback(new Issue({ code: 44, file: file }), stats)
+          })
+        }
+      })
+    }
+  })
 }
 
 /**
  * Simulates some of the browser File API interface.
  * https://developer.mozilla.org/en-US/docs/Web/API/File
- * 
+ *
  * @param {string[]} parts - file contents as bytes
  * @param {string} filename - filename without path info
  * @param {Object} properties - unused Blob properties
  */
 function NodeFile(parts, filename, properties) {
-    this.parts = parts;
-    this.name = filename;
-    this.properties = properties;
-    this.size = parts.reduce(function (a, val) {
-        return a + val.length;
-    }, 0);
-    // Unknown defacto mime-type
-    this.type = 'application/octet-stream';
-    this.lastModified = 0;
+  this.parts = parts
+  this.name = filename
+  this.properties = properties
+  this.size = parts.reduce(function(a, val) {
+    return a + val.length
+  }, 0)
+  // Unknown defacto mime-type
+  this.type = 'application/octet-stream'
+  this.lastModified = 0
 }
 
 /**
  * Return a either a mock or real FileAPI if one is available
  */
 function FileAPI() {
-    return typeof File === 'undefined' ? NodeFile: File;
+  return typeof File === 'undefined' ? NodeFile : File
 }
 
 /**
  * New File
  *
  * Creates an empty File object
- * 
+ *
  * @param {string} filename - the filename without path info
  */
 function newFile(filename) {
-    var File = FileAPI();
-    return new File([''], filename);
+  var File = FileAPI()
+  return new File([''], filename)
 }
 
-module.exports = fileUtils;
+module.exports = fileUtils

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,20 +1,20 @@
-require('./prototype');
-var array      = require('./array');
-var config     = require('./config');
-var files      = require('./files');
-var issues     = require('./issues');
-var json       = require('./json');
-var modalities = require('./modalities');
-var options    = require('./options');
-var type       = require('./type');
+require('./prototype')
+var array = require('./array')
+var config = require('./config')
+var files = require('./files')
+var issues = require('./issues')
+var json = require('./json')
+var modalities = require('./modalities')
+var options = require('./options')
+var type = require('./type')
 
 module.exports = {
-	array:      array,
-	config:     config,
-	files:      files,
-	issues:     issues,
-	json:       json,
-	modalities: modalities,
-	options:    options,
-	type:       type
-};
+  array: array,
+  config: config,
+  files: files,
+  issues: issues,
+  json: json,
+  modalities: modalities,
+  options: options,
+  type: type,
+}

--- a/utils/issues/index.js
+++ b/utils/issues/index.js
@@ -1,139 +1,142 @@
-var list      = require('./list');
-var Issue     = require('./issue');
-var config    = require('../config');
+var list = require('./list')
+var Issue = require('./issue')
+var config = require('../config')
 
 var issues = {
+  /**
+   * List
+   *
+   * List of all validator issues.
+   */
+  list: list,
 
-	/**
-	 * List
-	 *
-	 * List of all validator issues.
-	 */
-	list: list,
+  /**
+   * Issue
+   *
+   * Issue constructor
+   */
+  Issue: Issue,
 
-	/**
-	 * Issue
-	 *
-	 * Issue constructor
-	 */
-	Issue: Issue,
-
-    /**
-     * Filter Fieldmaps
-     *
-     * Remove fieldmap related warnings if no fieldmaps
-     * are present.
-     */
-    filterFieldMaps: function (issueList) {
-        var filteredIssueList = [];
-        var fieldmapRelatedCodes = [6, 7, 8, 9];
-        for (var i = 0; i < issueList.length; i++) {
-            var issue = issueList[i];
-            if (fieldmapRelatedCodes.indexOf(issue.code) < 0) {
-                filteredIssueList.push(issue);
-            }
-        }
-        return filteredIssueList
-    },
-
-	/**
-     * Format Issues
-     */
-    format: function (issueList, summary, options) {
-        var errors = [], warnings = [], ignored = [];
-
-        if (summary.modalities.indexOf("fieldmap") < 0) {
-            issueList = this.filterFieldMaps(issueList);
-        }
-
-        // sort alphabetically by relative path of files
-        issueList.sort(function (a,b) {
-            var aPath = a.file ? a.file.relativePath : '';
-            var bPath = b.file ? b.file.relativePath : '';
-            return (aPath > bPath) ? 1 : ((bPath > aPath) ? -1 : 0);
-        });
-
-        // organize by issue code
-        var categorized = {};
-        var codes = []
-        for (var i = 0; i < issueList.length; i++) {
-            var issue = issueList[i];
-
-            if (issue.file && config.ignoredFile(options.config, issue.file.relativePath)) {
-                continue;
-            }
-
-            if (!categorized[issue.code]) {
-                codes.push(issue.key);
-                codes.push(issue.code);
-                categorized[issue.code] = list[issue.code];
-                categorized[issue.code].files = [];
-                categorized[issue.code].additionalFileCount = 0;
-            }
-            if (options.verbose || (categorized[issue.code].files.length < 10)) {
-                categorized[issue.code].files.push(issue);
-            } else {
-                categorized[issue.code].additionalFileCount++;
-            }
-        }
-
-        var severityMap = config.interpret(codes, options.config);
-
-        // organize by severity
-        for (var code in categorized) {
-            issue = categorized[code];
-            issue.code = code;
-
-            if (severityMap.hasOwnProperty(issue.code)) {
-                issue.severity = severityMap[issue.code];
-            }
-
-            if (severityMap.hasOwnProperty(issue.key)) {
-                issue.severity = severityMap[issue.key];
-            }
-
-            if (issue.severity === 'error') {
-                // Schema validation issues will yield the JSON file invalid, we should display them first to attract
-                // user attention.
-                if (code == 55) {
-                    errors.unshift(issue);
-                } else {
-                    errors.push(issue);
-                }
-            } else if (issue.severity === 'warning' && !options.ignoreWarnings) {
-                warnings.push(issue);
-            } else if (issue.severity === 'ignore') {
-                ignored.push(issue);
-            }
-
-        }
-
-        return {errors: errors, warnings: warnings, ignored: ignored};
-    },
-
-    /**
-     * Reformat
-     *
-     * Takes an already formatted set of issues, a
-     * summary and a config object and returns the
-     * same issues reformatted against the config.
-     */
-    reformat: function (issueList, summary, config) {
-        var errors   = issueList.errors   ? issueList.errors   : [],
-            warnings = issueList.warnings ? issueList.warnings : [],
-            ignored  = issueList.ignored  ? issueList.ignored  : [];
-
-        issueList = errors.concat(warnings).concat(ignored);
-        var unformatted = [];
-        for (var i = 0; i < issueList.length; i++) {
-            var issue = issueList[i];
-            for (var j = 0; j < issue.files.length; j++) {
-                var file = issue.files[j];
-                unformatted.push(file);
-            }
-        }
-        return issues.format(unformatted, summary, {config: config});
+  /**
+   * Filter Fieldmaps
+   *
+   * Remove fieldmap related warnings if no fieldmaps
+   * are present.
+   */
+  filterFieldMaps: function(issueList) {
+    var filteredIssueList = []
+    var fieldmapRelatedCodes = [6, 7, 8, 9]
+    for (var i = 0; i < issueList.length; i++) {
+      var issue = issueList[i]
+      if (fieldmapRelatedCodes.indexOf(issue.code) < 0) {
+        filteredIssueList.push(issue)
+      }
     }
-};
+    return filteredIssueList
+  },
 
-module.exports = issues;
+  /**
+   * Format Issues
+   */
+  format: function(issueList, summary, options) {
+    var errors = [],
+      warnings = [],
+      ignored = []
+
+    if (summary.modalities.indexOf('fieldmap') < 0) {
+      issueList = this.filterFieldMaps(issueList)
+    }
+
+    // sort alphabetically by relative path of files
+    issueList.sort(function(a, b) {
+      var aPath = a.file ? a.file.relativePath : ''
+      var bPath = b.file ? b.file.relativePath : ''
+      return aPath > bPath ? 1 : bPath > aPath ? -1 : 0
+    })
+
+    // organize by issue code
+    var categorized = {}
+    var codes = []
+    for (var i = 0; i < issueList.length; i++) {
+      var issue = issueList[i]
+
+      if (
+        issue.file &&
+        config.ignoredFile(options.config, issue.file.relativePath)
+      ) {
+        continue
+      }
+
+      if (!categorized[issue.code]) {
+        codes.push(issue.key)
+        codes.push(issue.code)
+        categorized[issue.code] = list[issue.code]
+        categorized[issue.code].files = []
+        categorized[issue.code].additionalFileCount = 0
+      }
+      if (options.verbose || categorized[issue.code].files.length < 10) {
+        categorized[issue.code].files.push(issue)
+      } else {
+        categorized[issue.code].additionalFileCount++
+      }
+    }
+
+    var severityMap = config.interpret(codes, options.config)
+
+    // organize by severity
+    for (var code in categorized) {
+      issue = categorized[code]
+      issue.code = code
+
+      if (severityMap.hasOwnProperty(issue.code)) {
+        issue.severity = severityMap[issue.code]
+      }
+
+      if (severityMap.hasOwnProperty(issue.key)) {
+        issue.severity = severityMap[issue.key]
+      }
+
+      if (issue.severity === 'error') {
+        // Schema validation issues will yield the JSON file invalid, we should display them first to attract
+        // user attention.
+        if (code == 55) {
+          errors.unshift(issue)
+        } else {
+          errors.push(issue)
+        }
+      } else if (issue.severity === 'warning' && !options.ignoreWarnings) {
+        warnings.push(issue)
+      } else if (issue.severity === 'ignore') {
+        ignored.push(issue)
+      }
+    }
+
+    return { errors: errors, warnings: warnings, ignored: ignored }
+  },
+
+  /**
+   * Reformat
+   *
+   * Takes an already formatted set of issues, a
+   * summary and a config object and returns the
+   * same issues reformatted against the config.
+   */
+  reformat: function(issueList, summary, config) {
+    var errors = issueList.errors ? issueList.errors : [],
+      warnings = issueList.warnings ? issueList.warnings : [],
+      ignored = issueList.ignored ? issueList.ignored : []
+
+    issueList = errors.concat(warnings).concat(ignored)
+    var unformatted = []
+    for (var i = 0; i < issueList.length; i++) {
+      var issue = issueList[i]
+      for (var j = 0; j < issue.files.length; j++) {
+        var file = issue.files[j]
+        unformatted.push(file)
+      }
+    }
+    return issues.format(unformatted, summary, { config: config })
+  },
+}
+
+module.exports = issues

--- a/utils/issues/issue.js
+++ b/utils/issues/issue.js
@@ -1,20 +1,24 @@
-var issues = require('./list');
+var issues = require('./list')
 
 /**
  * Issue
  *
  * A constructor for BIDS issues.
  */
-module.exports = function (options) {
-	var code = options.hasOwnProperty('code') ? options.code : null;
-	var issue = issues[code];
+module.exports = function(options) {
+  var code = options.hasOwnProperty('code') ? options.code : null
+  var issue = issues[code]
 
-	this.key       = issue.key;
-	this.code      = code;
-	this.file      = options.hasOwnProperty('file')      ? options.file      : null;
-	this.evidence  = options.hasOwnProperty('evidence')  ? options.evidence  : null;
-    this.line      = options.hasOwnProperty('line')      ? options.line      : null;
-    this.character = options.hasOwnProperty('character') ? options.character : null;
-    this.severity  = options.hasOwnProperty('severity')  ? options.severity  : issue.severity;
-    this.reason    = options.hasOwnProperty('reason')    ? options.reason    : issue.reason;
-};
+  this.key = issue.key
+  this.code = code
+  this.file = options.hasOwnProperty('file') ? options.file : null
+  this.evidence = options.hasOwnProperty('evidence') ? options.evidence : null
+  this.line = options.hasOwnProperty('line') ? options.line : null
+  this.character = options.hasOwnProperty('character')
+    ? options.character
+    : null
+  this.severity = options.hasOwnProperty('severity')
+    ? options.severity
+    : issue.severity
+  this.reason = options.hasOwnProperty('reason') ? options.reason : issue.reason
+}

--- a/utils/issues/list.js
+++ b/utils/issues/list.js
@@ -6,426 +6,478 @@
  * agnostic to file specifics.
  */
 module.exports = {
-    1: {
-        key: 'NOT_INCLUDED',
-        severity: 'error',
-        reason: 'Files with such naming scheme are not part of BIDS specification. This error is most commonly ' +
-        'caused by typos in file names that make them not BIDS compatible. Please consult the specification and ' +
-        'make sure your files are named correctly. If this is not a file naming issue (for example when including ' +
-        'files not yet covered by the BIDS specification) you should include a ".bidsignore" file in your dataset (see' +
-        ' https://github.com/INCF/bids-validator#bidsignore for details). Please ' +
-        'note that derived (processed) data should be placed in /derivatives folder and source data (such as DICOMS ' +
-        'or behavioural logs in proprietary formats) should be placed in the /sourcedata folder.'
-    },
-    2: {
-        key: 'REPETITION_TIME_GREATER_THAN',
-        severity: 'warning',
-        reason: "'RepetitionTime' is greater than 100 are you sure it's expressed in seconds?"
-    },
-    3: {
-        key: 'ECHO_TIME_GREATER_THAN',
-        severity: 'warning',
-        reason: "'EchoTime' is greater than 1 are you sure it's expressed in seconds?"
-    },
-    4: {
-        key: 'ECHO_TIME_DIFFERENCE_GREATER_THAN',
-        severity: 'warning',
-        reason: "'EchoTimeDifference' is greater than 1 are you sure it's expressed in seconds?"
-    },
-    5: {
-        key: 'TOTAL_READOUT_TIME_GREATER_THAN',
-        severity: 'warning',
-        reason: "'TotalReadoutTime' is greater than 10 are you sure it's expressed in seconds?"
-    },
-    6: {
-        key: 'ECHO_TIME_NOT_DEFINED',
-        severity: 'warning',
-        reason:   "You should define 'EchoTime' for this file. If you don't provide this information field map correction will not be possible."
-    },
-    7: {
-        key: 'PHASE_ENCODING_DIRECTION_NOT_DEFINED',
-        severity: 'warning',
-        reason:   "You should define 'PhaseEncodingDirection' for this file. If you don't provide this information field map correction will not be possible."
-    },
-    8: {
-        key: 'EFFECTIVE_ECHO_SPACING_NOT_DEFINED',
-        severity: 'warning',
-        reason:   "You should define 'EffectiveEchoSpacing' for this file. If you don't provide this information field map correction will not be possible."
-    },
-    9: {
-        key: 'TOTAL_READOUT_TIME_NOT_DEFINED',
-        severity: 'warning',
-        reason:   "You should define 'TotalReadoutTime' for this file. If you don't provide this information field map correction using TOPUP might not be possible."
-    },
-    10: {
-        key: 'REPETITION_TIME_MUST_DEFINE',
-        severity: 'error',
-        reason:   "You have to define 'RepetitionTime' for this file."
-    },
-    11: {
-        key: 'REPETITION_TIME_UNITS',
-        severity: 'error',
-        reason:   "Repetition time was not defined in seconds, milliseconds or microseconds in the scan's header."
-    },
-    12: {
-        key: 'REPETITION_TIME_MISMATCH',
-        severity: 'error',
-        reason:   "Repetition time did not match between the scan's header and the associated JSON metadata file."
-    },
-    13: {
-        key: 'SLICE_TIMING_NOT_DEFINED',
-        severity: 'warning',
-        reason:   "You should define 'SliceTiming' for this file. If you don't provide this information slice time correction will not be possible."
-    },
-    15: {
-        key: 'ECHO_TIME1-2_NOT_DEFINED',
-        severity: 'error',
-        reason:   "You have to define 'EchoTime1' and 'EchoTime2' for this file."
-    },
-    16: {
-        key: 'ECHO_TIME_MUST_DEFINE',
-        severity: 'error',
-        reason:   "You have to define 'EchoTime' for this file."
-    },
-    17: {
-        key: 'UNITS_MUST_DEFINE',
-        severity: 'error',
-        reason:   "You have to define 'Units' for this file."
-    },
-    18: {
-        key: 'PHASE_ENCODING_DIRECTION_MUST_DEFINE',
-        severity: 'error',
-        reason:   "You have to define 'PhaseEncodingDirection' for this file."
-    },
-    19: {
-        key: 'TOTAL_READOUT_TIME_MUST_DEFINE',
-        severity: 'error',
-        reason:   "You have to define 'TotalReadoutTime' for this file."
-    },
-    20: {
-        key: 'EVENTS_COLUMN_ONSET',
-        severity: 'error',
-        reason:   "First column of the events file must be named 'onset'"
-    },
-    21: {
-        key: 'EVENTS_COLUMN_DURATION',
-        severity: 'error',
-        reason:   "Second column of the events file must be named 'duration'"
-    },
-    22: {
-        key: 'TSV_EQUAL_ROWS',
-        severity: 'error',
-        reason:   'All rows must have the same number of columns as there are headers.'
-    },
-    23: {
-        key: 'TSV_EMPTY_CELL',
-        severity: 'error',
-        reason:   'Empty cell in TSV file detected: The proper way of labeling missing values is "n/a".'
-    },
-    24: {
-        key: 'TSV_IMPROPER_NA',
-        severity: 'warning',
-        reason:   'A proper way of labeling missing values is "n/a".'
-    },
-    25: {
-        key: 'EVENTS_TSV_MISSING',
-        severity: 'warning',
-        reason:   'Task scans should have a corresponding events.tsv file. If this is a resting state scan you can ignore this warning or rename the task to include the word "rest".'
-    },
-    26: {
-        key: 'NIFTI_HEADER_UNREADABLE',
-        severity: 'error',
-        reason:   "We were unable to parse header data from this NIfTI file. Please ensure it is not corrupted or mislabeled."
-    },
-    27: {
-        key: 'JSON_INVALID',
-        severity: 'error',
-        reason: "Not a valid JSON file."
-    },
-    28: {
-        key: 'GZ_NOT_GZIPPED',
-        severity: 'error',
-        reason: "This file ends in the .gz extension but is not actually gzipped."
-    },
-    29: {
-        key: 'VOLUME_COUNT_MISMATCH',
-        severity: 'error',
-        reason: "The number of volumes in this scan does not match the number of volumes in the corresponding .bvec and .bval files."
-    },
-    30: {
-        key: 'BVAL_MULTIPLE_ROWS',
-        severity: 'error',
-        reason: ".bval files should contain exactly one row of volumes."
-    },
-    31: {
-        key: 'BVEC_NUMBER_ROWS',
-        severity: 'error',
-        reason: ".bvec files should contain exactly three rows of volumes."
-    },
-    32: {
-        key: 'DWI_MISSING_BVEC',
-        severity: 'error',
-        reason: "DWI scans should have a corresponding .bvec file."
-    },
-    33: {
-        key: 'DWI_MISSING_BVAL',
-        severity: 'error',
-        reason: "DWI scans should have a corresponding .bval file."
-    },
-    36: {
-        key: 'NIFTI_TOO_SMALL',
-        severity: 'error',
-        reason: "This file is too small to contain the minimal NIfTI header."
-    },
-    37: {
-        key: 'INTENDED_FOR',
-        severity: 'error',
-        reason: "'IntendedFor' field needs to point to an existing file."
-    },
-    38: {
-        key: 'INCONSISTENT_SUBJECTS',
-        severity: 'warning',
-        reason: "Not all subjects contain the same files. Each subject should contain the same number of files with " +
-        "the same naming unless some files are known to be missing."
-    },
-    39: {
-        key: 'INCONSISTENT_PARAMETERS',
-        severity: 'warning',
-        reason: "Not all subjects/sessions/runs have the same scanning parameters."
-    },
-    40: {
-        key: 'NIFTI_DIMENSION',
-        severity: 'warning',
-        reason: "Nifti file's header field for dimension information blank or too short."
-    },
-    41: {
-        key: 'NIFTI_UNIT',
-        severity: 'warning',
-        reason: "Nifti file's header field for unit information for x, y, z, and t dimensions empty or too short"
-    },
-    42: {
-        key: 'NIFTI_PIXDIM',
-        severity: 'warning',
-        reason: "Nifti file's header field for pixel dimension information empty or too short."
-    },
-    43: {
-        key: 'ORPHANED_SYMLINK',
-        severity: 'error',
-        reason: "This file appears to be an orphaned symlink. Make sure it correctly points to its referent."
-    },
-    44: {
-        key: 'FILE_READ',
-        severity: 'error',
-        reason: "We were unable to read this file. Make sure it is not corrupted, incorrectly named or incorrectly symlinked."
-    },
-    45: {
-        key: 'SUBJECT_FOLDERS',
-        severity: 'error',
-        reason: "There are no subject folders (labeled \"sub-*\") in the root of this dataset."
-    },
-    46: {
-        key: 'BVEC_ROW_LENGTH',
-        severity: 'error',
-        reason: "Each row in a .bvec file should contain the same number of values."
-    },
-    47: {
-        key: 'B_FILE',
-        severity: 'error',
-        reason: ".bval and .bvec files must be single space delimited and contain only numerical values."
-    },
-    48: {
-        key: 'PARTICIPANT_ID_COLUMN',
-        severity: 'error',
-        reason:   "Participants and phenotype .tsv files must have a 'participant_id' column."
-    },
-    49: {
-        key: 'PARTICIPANT_ID_MISMATCH',
-        severity: 'error',
-        reason:   "Participant labels found in this dataset did not match the values in participant_id column found in the participants.tsv file."
-    },
-    50: {
-        key: 'TASK_NAME_MUST_DEFINE',
-        severity: 'error',
-        reason: "You have to define 'TaskName' for this file."
-    },
-    51: {
-        key: 'PHENOTYPE_SUBJECTS_MISSING',
-        severity: 'error',
-        reason: 'A phenotype/ .tsv file lists subjects that were not found in the dataset.'
-    },
-    52: {
-        key: 'STIMULUS_FILE_MISSING',
-        severity: 'error',
-        reason: "A stimulus file was declared but not found in the dataset."
-    },
-    53: {
-        key: 'NO_T1W',
-        severity: 'ignore',
-        reason: "Dataset does not contain any T1w scans."
-    },
-    54: {
-        key: 'BOLD_NOT_4D',
-        severity: 'error',
-        reason: 'Bold scans must be 4 dimensional.'
-    },
-    55: {
-        key: 'JSON_SCHEMA_VALIDATION_ERROR',
-        severity: 'error',
-        reason: 'Invalid JSON file. The file is not formatted according the schema.'
-    },
-    56: {
-        key: 'Participants age 89 or higher',
-        severity: 'warning',
-        reason: 'As per section 164.514(C) of "The De-identification Standard" under HIPAA guidelines, participants with age 89 or higher should be tagged as 89+. More information can be found at https://www.hhs.gov/hipaa/for-professionals/privacy/special-topics/de-identification/#standard'
-    },
-    57: {
-        key: 'DATASET_DESCRIPTION_JSON_MISSING',
-        severity: 'error',
-        reason: 'The compulsory file /dataset_description.json is missing. See Section 8.1 of the BIDS specification.'
-    },
-    58: {
-        key: 'TASK_NAME_CONTAIN_ILLEGAL_CHARACTER',
-        severity: 'error',
-        reason: 'Task Name contain an Illegal Character hyphen or underscore. Please edit the filename as per BIDS spec.'
-    },
-    59: {
-        key: 'ACQ_NAME_CONTAIN_ILLEGAL_CHARACTER',
-        severity: 'error',
-        reason: 'acq Name contain an Illegal Character hyphen or underscore. Please edit the filename as per BIDS spec.'
-    },
-    60: {
-        key: 'SFORM_AND_QFORM_IN_IMAGE_HEADER_ARE_ZERO',
-        severity: 'error',
-        reason: 'sform_code and qform_code in the image header are 0. The image/file will be considered invalid or assumed to be in LAS orientation.'
-    },
-    61: {
-        key: 'QUICK_VALIDATION_FAILED',
-        severity: 'error',
-        reason: 'Quick validation failed - the general folder structure does not resemble a BIDS dataset. Have you chosen the right folder (with "sub-*/" subfolders)? Check for structural/naming issues and presence of at least one subject.',
-    },
-    62: {
-        key: 'SUBJECT_VALUE_CONTAINS_ILLEGAL_CHARECTER',
-        severity: 'error',
-        reason: 'Sub label contain an Illegal Character hyphen or underscore. Please edit the filename as per BIDS spec.',
-    },
-    63: {
-        key: 'SESSION_VALUE_CONTAINS_ILLEGAL_CHARECTER',
-        severity: 'error',
-        reason: 'Ses label contain an Illegal Character hyphen or underscore. Please edit the filename as per BIDS spec.',
-    },
-    64: {
-        key: 'SUBJECT_LABEL_IN_FILENAME_DOESNOT_MATCH_DIRECTORY',
-        severity: 'error',
-        reason: 'Subject label in the filename doesn\'t match with the path of the file. File seems to be saved in incorrect subject directory.'
-    },
-    65: {
-        key: 'SESSION_LABEL_IN_FILENAME_DOESNOT_MATCH_DIRECTORY',
-        severity: 'error',
-        reason: 'Session label in the filename doesn\'t match with the path of the file. File seems to be saved in incorrect session directory.'
-    },
-    66: {
-        key: 'SLICETIMING_VALUES_GREATOR_THAN_REPETITION_TIME',
-        severity: 'error',
-        reason: '"SliceTiming" value/s contains invalid value as it is greater than RepetitionTime.  SliceTiming values should be in seconds not milliseconds (common mistake).'
-    },
-    67: {
-        key: 'NO_VALID_DATA_FOUND_FOR_SUBJECT',
-        severity: 'error',
-        reason: 'No BIDS compatible data found for at least one subject.'
-    },
-    68: {
-        key: 'FILENAME_COLUMN',
-        severity: 'error',
-        reason:   "_scans.tsv files must have a 'filename' column."
-    },
-    70: {
-        key: 'WRONG_NEW_LINE',
-        severity: 'error',
-        reason: "All TSV files must use Line Feed '\\n' characters to denote new lines. This files uses Carriage Return '\\r'."
-    },
-    71: {
-        key: 'MISSING_TSV_COLUMN_MEG',
-        severity: 'error',
-        reason:   "The column names of the channels file must begin with ['name', 'type', 'units']"
-    },
-    72: {
-        key: 'MISSING_TSV_COLUMN_IEEG_CHANNELS',
-        severity: 'error',
-        reason:   "The column names of the channels file must begin with ['name', 'type', 'units', 'sampling_frequency', 'low_cutoff', 'high_cutoff', 'notch', 'reference']"
-    },
-    73: {
-        key: 'MISSING_TSV_COLUMN_IEEG_ELECTRODES',
-        severity: 'error',
-        reason:   "The column names of the electrodes file must begin with ['name', 'x', 'y', 'z', 'size', 'type']"
-    },
-    74: {
-        key: 'DUPLICATE_NIFTI_FILES',
-        severity: 'error',
-        reason:   "Nifti file exist with both '.nii' and '.nii.gz' extensions."
-    },
-    75: {
-        key: 'NIFTI_PIXDIM4',
-        severity: 'error',
-        reason: "Nifti file's header is missing time dimension information."
-    },
-    76: {
-        key: 'EFFECTIVEECHOSPACING_TOO_LARGE',
-        severity: 'error',
-        reason: "Abnormally high value of 'EffectiveEchoSpacing'."
-    },
-    77: {
-        key: 'UNUSED_STIMULUS',
-        severity: 'warning',
-        reason: 'There are files in the /stimuli directory that are not utilized in any _events.tsv file.'
-    },
-    78: {
-        key: 'CHANNELS_COLUMN_SFREQ',
-        severity: 'error',
-        reason:   "Fourth column of the channels file must be named 'sampling_frequency'"
-    },
-    79: {
-        key: 'CHANNELS_COLUMN_LOWCUT',
-        severity: 'error',
-        reason:   "Third column of the channels file must be named 'low_cutoff'"
-    },
-    80: {
-        key: 'CHANNELS_COLUMN_HIGHCUT',
-        severity: 'error',
-        reason:   "Third column of the channels file must be named 'high_cutoff'"
-    },
-    81: {
-        key: 'CHANNELS_COLUMN_NOTCH',
-        severity: 'error',
-        reason:   "Third column of the channels file must be named 'notch'"
-    },
-    82: {
-        key: 'TABULARFILE_WITHOUT_DATADICTIONARY',
-        severity: 'warning',
-        reason: "Tabular file does not have accompanying data dictionary."
-    },
-    83: {
-        key: 'ECHOTIME1_2_DIFFERENCE_UNREASONABLE',
-        severity: 'error',
-        reason: 'The value of (EchoTime2 - EchoTime1) should be within the range of 0.0001 - 0.01.'
-    },
-    84: {
-        key: 'ACQTIME_FMT',
-        severity: 'error',
-        reason: 'Entries in the "acq_time" column of _scans.tsv should be expressed in the following format YYYY-MM-DDTHH:mm:ss (year, month, day, hour (24h), minute, second; this is equivalent to the RFC3339 “date-time” format. '
-    },
-    85: {
-        key: 'SUSPICIOUSLY_LONG_EVENT_DESIGN',
-        severity: 'warning',
-        reason: 'The onset of the last event is after the total duration of the corresponding scan. This design is suspiciously long. '
-    },
-    86: {
-        key: 'SUSPICIOUSLY_SHORT_EVENT_DESIGN',
-        severity: 'warning',
-        reason: 'The onset of the last event is less than half the total duration of the corresponding scan. This design is suspiciously short. '
-    },
-    87: {
-        key: 'SLICETIMING_ELEMENTS',
-        severity: 'warning',
-        reason: 'The number of elements in the SliceTiming array should match the \'k\' dimension of the corresponding nifti volume.'
-    },
-};
+  1: {
+    key: 'NOT_INCLUDED',
+    severity: 'error',
+    reason:
+      'Files with such naming scheme are not part of BIDS specification. This error is most commonly ' +
+      'caused by typos in file names that make them not BIDS compatible. Please consult the specification and ' +
+      'make sure your files are named correctly. If this is not a file naming issue (for example when including ' +
+      'files not yet covered by the BIDS specification) you should include a ".bidsignore" file in your dataset (see' +
+      ' https://github.com/INCF/bids-validator#bidsignore for details). Please ' +
+      'note that derived (processed) data should be placed in /derivatives folder and source data (such as DICOMS ' +
+      'or behavioural logs in proprietary formats) should be placed in the /sourcedata folder.',
+  },
+  2: {
+    key: 'REPETITION_TIME_GREATER_THAN',
+    severity: 'warning',
+    reason:
+      "'RepetitionTime' is greater than 100 are you sure it's expressed in seconds?",
+  },
+  3: {
+    key: 'ECHO_TIME_GREATER_THAN',
+    severity: 'warning',
+    reason:
+      "'EchoTime' is greater than 1 are you sure it's expressed in seconds?",
+  },
+  4: {
+    key: 'ECHO_TIME_DIFFERENCE_GREATER_THAN',
+    severity: 'warning',
+    reason:
+      "'EchoTimeDifference' is greater than 1 are you sure it's expressed in seconds?",
+  },
+  5: {
+    key: 'TOTAL_READOUT_TIME_GREATER_THAN',
+    severity: 'warning',
+    reason:
+      "'TotalReadoutTime' is greater than 10 are you sure it's expressed in seconds?",
+  },
+  6: {
+    key: 'ECHO_TIME_NOT_DEFINED',
+    severity: 'warning',
+    reason:
+      "You should define 'EchoTime' for this file. If you don't provide this information field map correction will not be possible.",
+  },
+  7: {
+    key: 'PHASE_ENCODING_DIRECTION_NOT_DEFINED',
+    severity: 'warning',
+    reason:
+      "You should define 'PhaseEncodingDirection' for this file. If you don't provide this information field map correction will not be possible.",
+  },
+  8: {
+    key: 'EFFECTIVE_ECHO_SPACING_NOT_DEFINED',
+    severity: 'warning',
+    reason:
+      "You should define 'EffectiveEchoSpacing' for this file. If you don't provide this information field map correction will not be possible.",
+  },
+  9: {
+    key: 'TOTAL_READOUT_TIME_NOT_DEFINED',
+    severity: 'warning',
+    reason:
+      "You should define 'TotalReadoutTime' for this file. If you don't provide this information field map correction using TOPUP might not be possible.",
+  },
+  10: {
+    key: 'REPETITION_TIME_MUST_DEFINE',
+    severity: 'error',
+    reason: "You have to define 'RepetitionTime' for this file.",
+  },
+  11: {
+    key: 'REPETITION_TIME_UNITS',
+    severity: 'error',
+    reason:
+      "Repetition time was not defined in seconds, milliseconds or microseconds in the scan's header.",
+  },
+  12: {
+    key: 'REPETITION_TIME_MISMATCH',
+    severity: 'error',
+    reason:
+      "Repetition time did not match between the scan's header and the associated JSON metadata file.",
+  },
+  13: {
+    key: 'SLICE_TIMING_NOT_DEFINED',
+    severity: 'warning',
+    reason:
+      "You should define 'SliceTiming' for this file. If you don't provide this information slice time correction will not be possible.",
+  },
+  15: {
+    key: 'ECHO_TIME1-2_NOT_DEFINED',
+    severity: 'error',
+    reason: "You have to define 'EchoTime1' and 'EchoTime2' for this file.",
+  },
+  16: {
+    key: 'ECHO_TIME_MUST_DEFINE',
+    severity: 'error',
+    reason: "You have to define 'EchoTime' for this file.",
+  },
+  17: {
+    key: 'UNITS_MUST_DEFINE',
+    severity: 'error',
+    reason: "You have to define 'Units' for this file.",
+  },
+  18: {
+    key: 'PHASE_ENCODING_DIRECTION_MUST_DEFINE',
+    severity: 'error',
+    reason: "You have to define 'PhaseEncodingDirection' for this file.",
+  },
+  19: {
+    key: 'TOTAL_READOUT_TIME_MUST_DEFINE',
+    severity: 'error',
+    reason: "You have to define 'TotalReadoutTime' for this file.",
+  },
+  20: {
+    key: 'EVENTS_COLUMN_ONSET',
+    severity: 'error',
+    reason: "First column of the events file must be named 'onset'",
+  },
+  21: {
+    key: 'EVENTS_COLUMN_DURATION',
+    severity: 'error',
+    reason: "Second column of the events file must be named 'duration'",
+  },
+  22: {
+    key: 'TSV_EQUAL_ROWS',
+    severity: 'error',
+    reason:
+      'All rows must have the same number of columns as there are headers.',
+  },
+  23: {
+    key: 'TSV_EMPTY_CELL',
+    severity: 'error',
+    reason:
+      'Empty cell in TSV file detected: The proper way of labeling missing values is "n/a".',
+  },
+  24: {
+    key: 'TSV_IMPROPER_NA',
+    severity: 'warning',
+    reason: 'A proper way of labeling missing values is "n/a".',
+  },
+  25: {
+    key: 'EVENTS_TSV_MISSING',
+    severity: 'warning',
+    reason:
+      'Task scans should have a corresponding events.tsv file. If this is a resting state scan you can ignore this warning or rename the task to include the word "rest".',
+  },
+  26: {
+    key: 'NIFTI_HEADER_UNREADABLE',
+    severity: 'error',
+    reason:
+      'We were unable to parse header data from this NIfTI file. Please ensure it is not corrupted or mislabeled.',
+  },
+  27: {
+    key: 'JSON_INVALID',
+    severity: 'error',
+    reason: 'Not a valid JSON file.',
+  },
+  28: {
+    key: 'GZ_NOT_GZIPPED',
+    severity: 'error',
+    reason: 'This file ends in the .gz extension but is not actually gzipped.',
+  },
+  29: {
+    key: 'VOLUME_COUNT_MISMATCH',
+    severity: 'error',
+    reason:
+      'The number of volumes in this scan does not match the number of volumes in the corresponding .bvec and .bval files.',
+  },
+  30: {
+    key: 'BVAL_MULTIPLE_ROWS',
+    severity: 'error',
+    reason: '.bval files should contain exactly one row of volumes.',
+  },
+  31: {
+    key: 'BVEC_NUMBER_ROWS',
+    severity: 'error',
+    reason: '.bvec files should contain exactly three rows of volumes.',
+  },
+  32: {
+    key: 'DWI_MISSING_BVEC',
+    severity: 'error',
+    reason: 'DWI scans should have a corresponding .bvec file.',
+  },
+  33: {
+    key: 'DWI_MISSING_BVAL',
+    severity: 'error',
+    reason: 'DWI scans should have a corresponding .bval file.',
+  },
+  36: {
+    key: 'NIFTI_TOO_SMALL',
+    severity: 'error',
+    reason: 'This file is too small to contain the minimal NIfTI header.',
+  },
+  37: {
+    key: 'INTENDED_FOR',
+    severity: 'error',
+    reason: "'IntendedFor' field needs to point to an existing file.",
+  },
+  38: {
+    key: 'INCONSISTENT_SUBJECTS',
+    severity: 'warning',
+    reason:
+      'Not all subjects contain the same files. Each subject should contain the same number of files with ' +
+      'the same naming unless some files are known to be missing.',
+  },
+  39: {
+    key: 'INCONSISTENT_PARAMETERS',
+    severity: 'warning',
+    reason: 'Not all subjects/sessions/runs have the same scanning parameters.',
+  },
+  40: {
+    key: 'NIFTI_DIMENSION',
+    severity: 'warning',
+    reason:
+      "Nifti file's header field for dimension information blank or too short.",
+  },
+  41: {
+    key: 'NIFTI_UNIT',
+    severity: 'warning',
+    reason:
+      "Nifti file's header field for unit information for x, y, z, and t dimensions empty or too short",
+  },
+  42: {
+    key: 'NIFTI_PIXDIM',
+    severity: 'warning',
+    reason:
+      "Nifti file's header field for pixel dimension information empty or too short.",
+  },
+  43: {
+    key: 'ORPHANED_SYMLINK',
+    severity: 'error',
+    reason:
+      'This file appears to be an orphaned symlink. Make sure it correctly points to its referent.',
+  },
+  44: {
+    key: 'FILE_READ',
+    severity: 'error',
+    reason:
+      'We were unable to read this file. Make sure it is not corrupted, incorrectly named or incorrectly symlinked.',
+  },
+  45: {
+    key: 'SUBJECT_FOLDERS',
+    severity: 'error',
+    reason:
+      'There are no subject folders (labeled "sub-*") in the root of this dataset.',
+  },
+  46: {
+    key: 'BVEC_ROW_LENGTH',
+    severity: 'error',
+    reason:
+      'Each row in a .bvec file should contain the same number of values.',
+  },
+  47: {
+    key: 'B_FILE',
+    severity: 'error',
+    reason:
+      '.bval and .bvec files must be single space delimited and contain only numerical values.',
+  },
+  48: {
+    key: 'PARTICIPANT_ID_COLUMN',
+    severity: 'error',
+    reason:
+      "Participants and phenotype .tsv files must have a 'participant_id' column.",
+  },
+  49: {
+    key: 'PARTICIPANT_ID_MISMATCH',
+    severity: 'error',
+    reason:
+      'Participant labels found in this dataset did not match the values in participant_id column found in the participants.tsv file.',
+  },
+  50: {
+    key: 'TASK_NAME_MUST_DEFINE',
+    severity: 'error',
+    reason: "You have to define 'TaskName' for this file.",
+  },
+  51: {
+    key: 'PHENOTYPE_SUBJECTS_MISSING',
+    severity: 'error',
+    reason:
+      'A phenotype/ .tsv file lists subjects that were not found in the dataset.',
+  },
+  52: {
+    key: 'STIMULUS_FILE_MISSING',
+    severity: 'error',
+    reason: 'A stimulus file was declared but not found in the dataset.',
+  },
+  53: {
+    key: 'NO_T1W',
+    severity: 'ignore',
+    reason: 'Dataset does not contain any T1w scans.',
+  },
+  54: {
+    key: 'BOLD_NOT_4D',
+    severity: 'error',
+    reason: 'Bold scans must be 4 dimensional.',
+  },
+  55: {
+    key: 'JSON_SCHEMA_VALIDATION_ERROR',
+    severity: 'error',
+    reason:
+      'Invalid JSON file. The file is not formatted according the schema.',
+  },
+  56: {
+    key: 'Participants age 89 or higher',
+    severity: 'warning',
+    reason:
+      'As per section 164.514(C) of "The De-identification Standard" under HIPAA guidelines, participants with age 89 or higher should be tagged as 89+. More information can be found at https://www.hhs.gov/hipaa/for-professionals/privacy/special-topics/de-identification/#standard',
+  },
+  57: {
+    key: 'DATASET_DESCRIPTION_JSON_MISSING',
+    severity: 'error',
+    reason:
+      'The compulsory file /dataset_description.json is missing. See Section 8.1 of the BIDS specification.',
+  },
+  58: {
+    key: 'TASK_NAME_CONTAIN_ILLEGAL_CHARACTER',
+    severity: 'error',
+    reason:
+      'Task Name contain an Illegal Character hyphen or underscore. Please edit the filename as per BIDS spec.',
+  },
+  59: {
+    key: 'ACQ_NAME_CONTAIN_ILLEGAL_CHARACTER',
+    severity: 'error',
+    reason:
+      'acq Name contain an Illegal Character hyphen or underscore. Please edit the filename as per BIDS spec.',
+  },
+  60: {
+    key: 'SFORM_AND_QFORM_IN_IMAGE_HEADER_ARE_ZERO',
+    severity: 'error',
+    reason:
+      'sform_code and qform_code in the image header are 0. The image/file will be considered invalid or assumed to be in LAS orientation.',
+  },
+  61: {
+    key: 'QUICK_VALIDATION_FAILED',
+    severity: 'error',
+    reason:
+      'Quick validation failed - the general folder structure does not resemble a BIDS dataset. Have you chosen the right folder (with "sub-*/" subfolders)? Check for structural/naming issues and presence of at least one subject.',
+  },
+  62: {
+    key: 'SUBJECT_VALUE_CONTAINS_ILLEGAL_CHARECTER',
+    severity: 'error',
+    reason:
+      'Sub label contain an Illegal Character hyphen or underscore. Please edit the filename as per BIDS spec.',
+  },
+  63: {
+    key: 'SESSION_VALUE_CONTAINS_ILLEGAL_CHARECTER',
+    severity: 'error',
+    reason:
+      'Ses label contain an Illegal Character hyphen or underscore. Please edit the filename as per BIDS spec.',
+  },
+  64: {
+    key: 'SUBJECT_LABEL_IN_FILENAME_DOESNOT_MATCH_DIRECTORY',
+    severity: 'error',
+    reason:
+      "Subject label in the filename doesn't match with the path of the file. File seems to be saved in incorrect subject directory.",
+  },
+  65: {
+    key: 'SESSION_LABEL_IN_FILENAME_DOESNOT_MATCH_DIRECTORY',
+    severity: 'error',
+    reason:
+      "Session label in the filename doesn't match with the path of the file. File seems to be saved in incorrect session directory.",
+  },
+  66: {
+    key: 'SLICETIMING_VALUES_GREATOR_THAN_REPETITION_TIME',
+    severity: 'error',
+    reason:
+      '"SliceTiming" value/s contains invalid value as it is greater than RepetitionTime.  SliceTiming values should be in seconds not milliseconds (common mistake).',
+  },
+  67: {
+    key: 'NO_VALID_DATA_FOUND_FOR_SUBJECT',
+    severity: 'error',
+    reason: 'No BIDS compatible data found for at least one subject.',
+  },
+  68: {
+    key: 'FILENAME_COLUMN',
+    severity: 'error',
+    reason: "_scans.tsv files must have a 'filename' column.",
+  },
+  70: {
+    key: 'WRONG_NEW_LINE',
+    severity: 'error',
+    reason:
+      "All TSV files must use Line Feed '\\n' characters to denote new lines. This files uses Carriage Return '\\r'.",
+  },
+  71: {
+    key: 'MISSING_TSV_COLUMN_MEG',
+    severity: 'error',
+    reason:
+      "The column names of the channels file must begin with ['name', 'type', 'units']",
+  },
+  72: {
+    key: 'MISSING_TSV_COLUMN_IEEG_CHANNELS',
+    severity: 'error',
+    reason:
+      "The column names of the channels file must begin with ['name', 'type', 'units', 'sampling_frequency', 'low_cutoff', 'high_cutoff', 'notch', 'reference']",
+  },
+  73: {
+    key: 'MISSING_TSV_COLUMN_IEEG_ELECTRODES',
+    severity: 'error',
+    reason:
+      "The column names of the electrodes file must begin with ['name', 'x', 'y', 'z', 'size', 'type']",
+  },
+  74: {
+    key: 'DUPLICATE_NIFTI_FILES',
+    severity: 'error',
+    reason: "Nifti file exist with both '.nii' and '.nii.gz' extensions.",
+  },
+  75: {
+    key: 'NIFTI_PIXDIM4',
+    severity: 'error',
+    reason: "Nifti file's header is missing time dimension information.",
+  },
+  76: {
+    key: 'EFFECTIVEECHOSPACING_TOO_LARGE',
+    severity: 'error',
+    reason: "Abnormally high value of 'EffectiveEchoSpacing'.",
+  },
+  77: {
+    key: 'UNUSED_STIMULUS',
+    severity: 'warning',
+    reason:
+      'There are files in the /stimuli directory that are not utilized in any _events.tsv file.',
+  },
+  78: {
+    key: 'CHANNELS_COLUMN_SFREQ',
+    severity: 'error',
+    reason:
+      "Fourth column of the channels file must be named 'sampling_frequency'",
+  },
+  79: {
+    key: 'CHANNELS_COLUMN_LOWCUT',
+    severity: 'error',
+    reason: "Third column of the channels file must be named 'low_cutoff'",
+  },
+  80: {
+    key: 'CHANNELS_COLUMN_HIGHCUT',
+    severity: 'error',
+    reason: "Third column of the channels file must be named 'high_cutoff'",
+  },
+  81: {
+    key: 'CHANNELS_COLUMN_NOTCH',
+    severity: 'error',
+    reason: "Third column of the channels file must be named 'notch'",
+  },
+  82: {
+    key: 'TABULARFILE_WITHOUT_DATADICTIONARY',
+    severity: 'warning',
+    reason: 'Tabular file does not have accompanying data dictionary.',
+  },
+  83: {
+    key: 'ECHOTIME1_2_DIFFERENCE_UNREASONABLE',
+    severity: 'error',
+    reason:
+      'The value of (EchoTime2 - EchoTime1) should be within the range of 0.0001 - 0.01.',
+  },
+  84: {
+    key: 'ACQTIME_FMT',
+    severity: 'error',
+    reason:
+      'Entries in the "acq_time" column of _scans.tsv should be expressed in the following format YYYY-MM-DDTHH:mm:ss (year, month, day, hour (24h), minute, second; this is equivalent to the RFC3339 “date-time” format. ',
+  },
+  85: {
+    key: 'SUSPICIOUSLY_LONG_EVENT_DESIGN',
+    severity: 'warning',
+    reason:
+      'The onset of the last event is after the total duration of the corresponding scan. This design is suspiciously long. ',
+  },
+  86: {
+    key: 'SUSPICIOUSLY_SHORT_EVENT_DESIGN',
+    severity: 'warning',
+    reason:
+      'The onset of the last event is less than half the total duration of the corresponding scan. This design is suspiciously short. ',
+  },
+  87: {
+    key: 'SLICETIMING_ELEMENTS',
+    severity: 'warning',
+    reason:
+      "The number of elements in the SliceTiming array should match the 'k' dimension of the corresponding nifti volume.",
+  },
+}

--- a/utils/json.js
+++ b/utils/json.js
@@ -1,61 +1,60 @@
-var Issue  = require('./issues').Issue;
-var JSHINT = require('jshint').JSHINT;
+var Issue = require('./issues').Issue
+var JSHINT = require('jshint').JSHINT
 
 module.exports = {
-
-    /**
-     * Parse
-     *
-     * Similar to native JSON.parse but uses
-     * a callback structure, jshint for more
-     * thorough error reporting and error formatting
-     * of the rest of the validator.
-     */
-    parse: function (file, contents, callback) {
-        var jsObj = null;
-        var err   = null;
-        try {
-            jsObj = JSON.parse(contents);
-        }
-        catch (exception) {
-            err = exception;
-        }
-        finally {
-            if (err) {
-                this.jshint(file, contents, function (issues) {
-                    callback(issues, null);
-                });
-            } else {
-                callback([], jsObj);
-            }
-        }
-    },
-
-    /**
-     * JSHint
-     *
-     * Checks known invalid JSON file
-     * content in order to produce a
-     * verbose error message.
-     */
-    jshint: function (file, contents, callback) {
-        var issues = [];
-        if (!JSHINT(contents)) {
-            var out = JSHINT.data();
-            for (var i = 0; out.errors.length > i; ++i) {
-                var error = out.errors[i];
-                if (error) {
-                    issues.push(new Issue({
-                        code:      27,
-                        file:      file,
-                        line:      error.line      ? error.line      : null,
-                        character: error.character ? error.character : null,
-                        reason:    error.reason    ? error.reason    : null,
-                        evidence:  error.evidence  ? error.evidence  : null
-                    }));
-                }
-            }
-        }
-        callback(issues);
+  /**
+   * Parse
+   *
+   * Similar to native JSON.parse but uses
+   * a callback structure, jshint for more
+   * thorough error reporting and error formatting
+   * of the rest of the validator.
+   */
+  parse: function(file, contents, callback) {
+    var jsObj = null
+    var err = null
+    try {
+      jsObj = JSON.parse(contents)
+    } catch (exception) {
+      err = exception
+    } finally {
+      if (err) {
+        this.jshint(file, contents, function(issues) {
+          callback(issues, null)
+        })
+      } else {
+        callback([], jsObj)
+      }
     }
-};
+  },
+
+  /**
+   * JSHint
+   *
+   * Checks known invalid JSON file
+   * content in order to produce a
+   * verbose error message.
+   */
+  jshint: function(file, contents, callback) {
+    var issues = []
+    if (!JSHINT(contents)) {
+      var out = JSHINT.data()
+      for (var i = 0; out.errors.length > i; ++i) {
+        var error = out.errors[i]
+        if (error) {
+          issues.push(
+            new Issue({
+              code: 27,
+              file: file,
+              line: error.line ? error.line : null,
+              character: error.character ? error.character : null,
+              reason: error.reason ? error.reason : null,
+              evidence: error.evidence ? error.evidence : null,
+            }),
+          )
+        }
+      }
+    }
+    callback(issues)
+  },
+}

--- a/utils/modalities.js
+++ b/utils/modalities.js
@@ -1,55 +1,42 @@
 module.exports = {
+  /**
+   * Group
+   *
+   * Takes an array of modalities and looks for
+   * groupings defined in 'modalityGroups' and
+   * replaces any perfectly matched groupings with
+   * the grouping object key.
+   */
+  group: function(modalities) {
+    var modalityGroups = [
+      [['magnitude1', 'magnitude2', 'phase1', 'phase2'], 'fieldmap'],
+      [['magnitude1', 'magnitude2', 'phasediff'], 'fieldmap'],
+      [['magnitude1', 'phasediff'], 'fieldmap'],
+      [['magnitude', 'fieldmap'], 'fieldmap'],
+      [['epi'], 'fieldmap'],
+    ]
 
-	/**
-     * Group
-     *
-     * Takes an array of modalities and looks for
-     * groupings defined in 'modalityGroups' and
-     * replaces any perfectly matched groupings with
-     * the grouping object key.
-     */
-    group: function (modalities) {
-
-        var modalityGroups = [
-            [[
-                'magnitude1',
-                'magnitude2',
-                'phase1',
-                'phase2'
-            ], "fieldmap"],
-            [[
-                'magnitude1',
-                'magnitude2',
-                'phasediff'
-            ], "fieldmap"],
-            [[
-                'magnitude1',
-                'phasediff'
-            ], "fieldmap"],
-            [[
-                'magnitude',
-                'fieldmap'
-            ], "fieldmap"],
-            [['epi'], "fieldmap"]
-        ];
-
-        for (var groupTouple_i = 0; groupTouple_i < modalityGroups.length; groupTouple_i++) {
-            var groupSet = modalityGroups[groupTouple_i][0];
-            var groupName = modalityGroups[groupTouple_i][1];
-            var match = true;
-            for (var i = 0; i < groupSet.length; i++) {
-                if (modalities.indexOf(groupSet[i]) === -1) {
-                    match = false;
-                }
-            }
-            if (match) {
-                modalities.push(groupName);
-                for (var j = 0; j < groupSet.length; j++) {
-                    modalities.splice(modalities.indexOf(groupSet[j]), 1);
-                }
-            }
+    for (
+      var groupTouple_i = 0;
+      groupTouple_i < modalityGroups.length;
+      groupTouple_i++
+    ) {
+      var groupSet = modalityGroups[groupTouple_i][0]
+      var groupName = modalityGroups[groupTouple_i][1]
+      var match = true
+      for (var i = 0; i < groupSet.length; i++) {
+        if (modalities.indexOf(groupSet[i]) === -1) {
+          match = false
         }
-
-        return modalities;
+      }
+      if (match) {
+        modalities.push(groupName)
+        for (var j = 0; j < groupSet.length; j++) {
+          modalities.splice(modalities.indexOf(groupSet[j]), 1)
+        }
+      }
     }
-};
+
+    return modalities
+  },
+}

--- a/utils/options.js
+++ b/utils/options.js
@@ -1,72 +1,70 @@
-var files  = require('./files');
-var json   = require('./json');
+var files = require('./files')
+var json = require('./json')
 
 module.exports = {
-
-    /**
-     * Parse
-     */
-    parse: function (options, callback) {
-        options = options ? options : {};
-        options = {
-            ignoreWarnings:     options.ignoreWarnings     ? true : false,
-            ignoreNiftiHeaders: options.ignoreNiftiHeaders ? true : false,
-            verbose:            options.verbose            ? true : false,
-            bep006:             options.bep006             ? true : false,
-            bep010:             options.bep010             ? true: false,
-            config:             options.config             ? options.config : {}
-        };
-        if (options.config && typeof options.config !== 'boolean') {
-            this.parseConfig(options.config, function (issues, config) {
-                options.config = config;
-                callback(issues, options);
-            });
-        } else {
-            callback(null, options);
-        }
-    },
-
-    /**
-     * Load Config
-     */
-    loadConfig: function (config, callback) {
-        if (typeof config === 'string') {
-            // load file
-            files.readFile({path: config}, function (issue, contents) {
-                if (issue) {
-                    callback([issue], {path: config}, null);
-                } else {
-                    callback(null, {path: config}, contents);
-                }
-            });
-        } else if (typeof config === 'object') {
-            callback(null, {path: 'config'}, JSON.stringify(config));
-        }
-    },
-
-    /**
-     * Parse Config
-     */
-    parseConfig: function (config, callback) {
-        this.loadConfig(config, function (issues, file, contents) {
-            if (issues) {
-                callback(issues, null);
-            } else {
-                json.parse(file, contents, function (issues, jsObj) {
-                    if (issues && issues.length > 0) {
-                        callback(issues, null);
-                    } else {
-                        var parsed = {
-                            "ignore":       jsObj.ignore       ? jsObj.ignore       : [],
-                            "warn":         jsObj.warn         ? jsObj.warn         : [],
-                            "error":        jsObj.error        ? jsObj.error        : [],
-                            "ignoredFiles": jsObj.ignoredFiles ? jsObj.ignoredFiles : []
-                        };
-                        callback(null, parsed);
-                    }
-                });
-            }
-        });
+  /**
+   * Parse
+   */
+  parse: function(options, callback) {
+    options = options ? options : {}
+    options = {
+      ignoreWarnings: options.ignoreWarnings ? true : false,
+      ignoreNiftiHeaders: options.ignoreNiftiHeaders ? true : false,
+      verbose: options.verbose ? true : false,
+      bep006: options.bep006 ? true : false,
+      bep010: options.bep010 ? true : false,
+      config: options.config ? options.config : {},
     }
+    if (options.config && typeof options.config !== 'boolean') {
+      this.parseConfig(options.config, function(issues, config) {
+        options.config = config
+        callback(issues, options)
+      })
+    } else {
+      callback(null, options)
+    }
+  },
 
-};
+  /**
+   * Load Config
+   */
+  loadConfig: function(config, callback) {
+    if (typeof config === 'string') {
+      // load file
+      files.readFile({ path: config }, function(issue, contents) {
+        if (issue) {
+          callback([issue], { path: config }, null)
+        } else {
+          callback(null, { path: config }, contents)
+        }
+      })
+    } else if (typeof config === 'object') {
+      callback(null, { path: 'config' }, JSON.stringify(config))
+    }
+  },
+
+  /**
+   * Parse Config
+   */
+  parseConfig: function(config, callback) {
+    this.loadConfig(config, function(issues, file, contents) {
+      if (issues) {
+        callback(issues, null)
+      } else {
+        json.parse(file, contents, function(issues, jsObj) {
+          if (issues && issues.length > 0) {
+            callback(issues, null)
+          } else {
+            var parsed = {
+              ignore: jsObj.ignore ? jsObj.ignore : [],
+              warn: jsObj.warn ? jsObj.warn : [],
+              error: jsObj.error ? jsObj.error : [],
+              ignoredFiles: jsObj.ignoredFiles ? jsObj.ignoredFiles : [],
+            }
+            callback(null, parsed)
+          }
+        })
+      }
+    })
+  },
+}

--- a/utils/prototype.js
+++ b/utils/prototype.js
@@ -7,19 +7,25 @@
 // String - Ends With (Polyfill based on MDN recommendation)
 if (!String.prototype.endsWith) {
   String.prototype.endsWith = function(searchString, position) {
-      var subjectString = this.toString();
-      if (typeof position !== 'number' || !isFinite(position) || Math.floor(position) !== position || position > subjectString.length) {
-        position = subjectString.length;
-      }
-      position -= searchString.length;
-      var lastIndex = subjectString.indexOf(searchString, position);
-      return lastIndex !== -1 && lastIndex === position;
-  };
+    var subjectString = this.toString()
+    if (
+      typeof position !== 'number' ||
+      !isFinite(position) ||
+      Math.floor(position) !== position ||
+      position > subjectString.length
+    ) {
+      position = subjectString.length
+    }
+    position -= searchString.length
+    var lastIndex = subjectString.indexOf(searchString, position)
+    return lastIndex !== -1 && lastIndex === position
+  }
 }
 
 // String - Includes
 if (!String.prototype.includes) {
-    String.prototype.includes = function() {'use strict';
-        return String.prototype.indexOf.apply(this, arguments) !== -1;
-    };
+  String.prototype.includes = function() {
+    'use strict'
+    return String.prototype.indexOf.apply(this, arguments) !== -1
+  }
 }

--- a/utils/type.js
+++ b/utils/type.js
@@ -5,300 +5,407 @@
  * representing whether the given file path is valid within the
  * BIDS specification requirements.
  */
-var anatSuffixes = ["T1w", "T2w", "T1map", "T2map", "T1rho", "FLAIR", "PD", "PDT2", "inplaneT1", "inplaneT2","angio",
-    "SWImagandphase", "T2star", "FLASH", "PDmap", "photo"];
+var anatSuffixes = [
+  'T1w',
+  'T2w',
+  'T1map',
+  'T2map',
+  'T1rho',
+  'FLAIR',
+  'PD',
+  'PDT2',
+  'inplaneT1',
+  'inplaneT2',
+  'angio',
+  'SWImagandphase',
+  'T2star',
+  'FLASH',
+  'PDmap',
+  'photo',
+]
 
 module.exports = {
+  /**
+   * Is BIDS
+   *
+   * Check if a given path is valid within the
+   * bids spec.
+   */
+  isBIDS: function(path, bep006, bep010) {
+    return (
+      this.isTopLevel(path) ||
+      this.isStimuliData(path) ||
+      this.isSessionLevel(path) ||
+      this.isSubjectLevel(path) ||
+      this.isAnat(path) ||
+      this.isDWI(path) ||
+      this.isFunc(path) ||
+      this.isMeg(path) ||
+      (this.isIEEG(path) && bep010) ||
+      (this.isEeg(path) && bep006) ||
+      this.isBehavioral(path) ||
+      this.isCont(path) ||
+      this.isFieldMap(path) ||
+      this.isPhenotypic(path)
+    )
+  },
 
-    /**
-     * Is BIDS
-     *
-     * Check if a given path is valid within the
-     * bids spec.
-     */
-    isBIDS: function (path, bep006, bep010) {
-        return (
-            this.isTopLevel(path) ||
-            this.isStimuliData(path) ||
-            this.isSessionLevel(path) ||
-            this.isSubjectLevel(path) ||
-            this.isAnat(path) ||
-            this.isDWI(path) ||
-            this.isFunc(path) ||
-            this.isMeg(path) ||
-            (this.isIEEG(path) && bep010) ||
-            (this.isEeg(path) && bep006) ||
-            this.isBehavioral(path) ||
-            this.isCont(path) ||
-            this.isFieldMap(path) ||
-            this.isPhenotypic(path)
-        );
-    },
+  /**
+   * Check if the file has appropriate name for a top level file
+   */
+  isTopLevel: function(path) {
+    var fixedTopLevelNames = [
+      '/README',
+      '/CHANGES',
+      '/dataset_description.json',
+      '/participants.tsv',
+      '/participants.json',
+      '/phasediff.json',
+      '/phase1.json',
+      '/phase2.json',
+      '/fieldmap.json',
+    ]
 
-    /**
-     * Check if the file has appropriate name for a top level file
-     */
-    isTopLevel: function (path) {
-        var fixedTopLevelNames = ["/README", "/CHANGES", "/dataset_description.json", "/participants.tsv",
-            "/participants.json", "/phasediff.json", "/phase1.json", "/phase2.json", "/fieldmap.json"];
+    var funcTopRe = new RegExp(
+      '^\\/(?:ses-[a-zA-Z0-9]+_)?(?:recording-[a-zA-Z0-9]+_)?(?:task-[a-zA-Z0-9]+_)?(?:acq-[a-zA-Z0-9]+_)?(?:rec-[a-zA-Z0-9]+_)?(?:run-[0-9]+_)?(?:echo-[0-9]+_)?' +
+        '(bold.json|sbref.json|events.json|events.tsv|physio.json|stim.json|beh.json)$',
+    )
 
-        var funcTopRe = new RegExp('^\\/(?:ses-[a-zA-Z0-9]+_)?(?:recording-[a-zA-Z0-9]+_)?(?:task-[a-zA-Z0-9]+_)?(?:acq-[a-zA-Z0-9]+_)?(?:rec-[a-zA-Z0-9]+_)?(?:run-[0-9]+_)?(?:echo-[0-9]+_)?'
-            + '(bold.json|sbref.json|events.json|events.tsv|physio.json|stim.json|beh.json)$');
+    var anatTopRe = new RegExp(
+      '^\\/(?:ses-[a-zA-Z0-9]+_)?(?:acq-[a-zA-Z0-9]+_)?(?:rec-[a-zA-Z0-9]+_)?(?:run-[0-9]+_)?' +
+        '(' +
+        anatSuffixes.join('|') +
+        ').json$',
+    )
 
-        var anatTopRe = new RegExp('^\\/(?:ses-[a-zA-Z0-9]+_)?(?:acq-[a-zA-Z0-9]+_)?(?:rec-[a-zA-Z0-9]+_)?(?:run-[0-9]+_)?'
-            + '(' + anatSuffixes.join("|") + ').json$');
+    var dwiTopRe = new RegExp(
+      '^\\/(?:ses-[a-zA-Z0-9]+_)?(?:acq-[a-zA-Z0-9]+_)?(?:rec-[a-zA-Z0-9]+_)?(?:run-[0-9]+_)?' +
+        'dwi.(?:json|bval|bvec)$',
+    )
 
-        var dwiTopRe = new RegExp('^\\/(?:ses-[a-zA-Z0-9]+_)?(?:acq-[a-zA-Z0-9]+_)?(?:rec-[a-zA-Z0-9]+_)?(?:run-[0-9]+_)?'
-            + 'dwi.(?:json|bval|bvec)$');
+    var multiDirFieldmapRe = new RegExp('^\\/(?:dir-[a-zA-Z0-9]+)_epi.json$')
 
-        var multiDirFieldmapRe = new RegExp('^\\/(?:dir-[a-zA-Z0-9]+)_epi.json$');
+    var megTopRe = new RegExp(
+      '^\\/(?:ses-[a-zA-Z0-9]+_)?task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_proc-[a-zA-Z0-9]+)?' +
+        '(_meg.json|_channels.tsv|_photo.jpg|_coordsystem.json)$',
+    )
 
-        var megTopRe = new RegExp('^\\/(?:ses-[a-zA-Z0-9]+_)?task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_proc-[a-zA-Z0-9]+)?'
-            + '(_meg.json|_channels.tsv|_photo.jpg|_coordsystem.json)$');
+    var ieegTopRe = new RegExp(
+      '^\\/(?:ses-[a-zA-Z0-9]+_)?task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_proc-[a-zA-Z0-9]+)?' +
+        '(_ieeg.json|_channels.tsv|_electrodes.tsv|_photo.jpg|_coordsystem.json)$',
+    )
+    var eegTopRe = new RegExp(
+      '^\\/(?:ses-[a-zA-Z0-9]+_)?task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_proc-[a-zA-Z0-9]+)?' +
+        '(_eeg.json|_channels.tsv|_photo.jpg|_coordsystem.json)$',
+    )
 
-        var ieegTopRe = new RegExp('^\\/(?:ses-[a-zA-Z0-9]+_)?task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_proc-[a-zA-Z0-9]+)?'
-            + '(_ieeg.json|_channels.tsv|_electrodes.tsv|_photo.jpg|_coordsystem.json)$');
-        var eegTopRe = new RegExp('^\\/(?:ses-[a-zA-Z0-9]+_)?task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_proc-[a-zA-Z0-9]+)?'
-            + '(_eeg.json|_channels.tsv|_photo.jpg|_coordsystem.json)$');
+    var otherTopFiles = new RegExp(
+      '^\\/(?:ses-[a-zA-Z0-9]+_)?(?:recording-[a-zA-Z0-9]+_)?(?:task-[a-zA-Z0-9]+_)?(?:acq-[a-zA-Z0-9]+_)?(?:rec-[a-zA-Z0-9]+_)?(?:run-[0-9]+_)?' +
+        '(physio.json|stim.json)$',
+    )
 
-        var otherTopFiles = new RegExp('^\\/(?:ses-[a-zA-Z0-9]+_)?(?:recording-[a-zA-Z0-9]+_)?(?:task-[a-zA-Z0-9]+_)?(?:acq-[a-zA-Z0-9]+_)?(?:rec-[a-zA-Z0-9]+_)?(?:run-[0-9]+_)?'
-            + '(physio.json|stim.json)$');
+    return (
+      fixedTopLevelNames.indexOf(path) != -1 ||
+      funcTopRe.test(path) ||
+      dwiTopRe.test(path) ||
+      anatTopRe.test(path) ||
+      multiDirFieldmapRe.test(path) ||
+      otherTopFiles.test(path) ||
+      megTopRe.test(path) ||
+      eegTopRe.test(path) ||
+      ieegTopRe.test(path)
+    )
+  },
 
-        return (fixedTopLevelNames.indexOf(path) != -1 || funcTopRe.test(path) || dwiTopRe.test(path) ||
-        anatTopRe.test(path) || multiDirFieldmapRe.test(path) || otherTopFiles.test(path) || megTopRe.test(path) || eegTopRe.test(path) || ieegTopRe.test(path));
-    },
+  /**
+   * Check if file is appropriate associated data.
+   */
+  isAssociatedData: function(path) {
+    var associatedData = new RegExp(
+      '^\\/(?:code|derivatives|sourcedata|stimuli|[.]git)\\/(?:.*)$',
+    )
+    return associatedData.test(path)
+  },
 
-    /**
-     * Check if file is appropriate associated data.
-     */
-    isAssociatedData: function (path) {
-        var associatedData = new RegExp('^\\/(?:code|derivatives|sourcedata|stimuli|[.]git)\\/(?:.*)$');
-        return associatedData.test(path);
-    },
+  isStimuliData: function(path) {
+    var stimuliDataRe = new RegExp('^\\/(?:stimuli)\\/(?:.*)$')
+    return stimuliDataRe.test(path)
+  },
 
-    isStimuliData: function (path) {
-        var stimuliDataRe = new RegExp('^\\/(?:stimuli)\\/(?:.*)$');
-        return stimuliDataRe.test(path);
-    },
+  /**
+   * Check if file is phenotypic data.
+   */
+  isPhenotypic: function(path) {
+    var phenotypicData = new RegExp('^\\/(?:phenotype)\\/(?:.*.tsv|.*.json)$')
+    return phenotypicData.test(path)
+  },
 
-    /**
-     * Check if file is phenotypic data.
-     */
-    isPhenotypic: function (path) {
-        var phenotypicData = new RegExp('^\\/(?:phenotype)\\/(?:.*.tsv|.*.json)$');
-        return phenotypicData.test(path);
-    },
+  /**
+   * Check if the file has appropriate name for a session level
+   */
+  isSessionLevel: function(path) {
+    var scansRe = new RegExp(
+      '^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)' +
+        '\\/)?\\1(_\\2)?(_scans.tsv|_scans.json)$',
+    )
 
-    /**
-     * Check if the file has appropriate name for a session level
-     */
-    isSessionLevel: function (path) {
-        var scansRe = new RegExp('^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)' +
-            '\\/)?\\1(_\\2)?(_scans.tsv|_scans.json)$');
+    var funcSesRe = new RegExp(
+      '^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)' +
+        '\\/)?\\1(_\\2)?_task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_echo-[0-9]+)?' +
+        '(_bold.json|_sbref.json|_events.json|_events.tsv|_physio.json|_stim.json)$',
+    )
 
-        var funcSesRe = new RegExp('^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)' +
-            '\\/)?\\1(_\\2)?_task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_echo-[0-9]+)?'
-            + '(_bold.json|_sbref.json|_events.json|_events.tsv|_physio.json|_stim.json)$');
+    var anatSesRe = new RegExp(
+      '^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)' +
+        '\\/)?\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+_)?' +
+        '(' +
+        anatSuffixes.join('|') +
+        ').json$',
+    )
 
-        var anatSesRe = new RegExp('^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)' +
-            '\\/)?\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+_)?'
-            + '(' + anatSuffixes.join("|") + ').json$');
+    var dwiSesRe = new RegExp(
+      '^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)' +
+        '\\/)?\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_)?' +
+        'dwi.(?:json|bval|bvec)$',
+    )
 
-        var dwiSesRe = new RegExp('^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)' +
-            '\\/)?\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_)?'
-            + 'dwi.(?:json|bval|bvec)$');
+    var megSesRe = new RegExp(
+      '^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)' +
+        '\\/)?\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_proc-[a-zA-Z0-9]+)?' +
+        '(_events.tsv|_channels.tsv|_meg.json|_coordsystem.json|_photo.jpg|_headshape.pos)$',
+    )
 
-        var megSesRe = new RegExp('^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)' +
-            '\\/)?\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_proc-[a-zA-Z0-9]+)?'
-            + '(_events.tsv|_channels.tsv|_meg.json|_coordsystem.json|_photo.jpg|_headshape.pos)$');
+    var eegSesRe = new RegExp(
+      '^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)' +
+        '\\/)?\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_proc-[a-zA-Z0-9]+)?' +
+        '(_events.tsv|_channels.tsv|_eeg.json|_coordsystem.json|_photo.jpg)$',
+    )
 
-        var eegSesRe = new RegExp('^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)' +
-            '\\/)?\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_proc-[a-zA-Z0-9]+)?'
-            + '(_events.tsv|_channels.tsv|_eeg.json|_coordsystem.json|_photo.jpg)$');
+    var ieegSesRe = new RegExp(
+      '^\\/(sub-[a-zA-Z0-9]+)' +
+        '\\/(?:(ses-[a-zA-Z0-9]+)' +
+        '\\/)?\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_proc-[a-zA-Z0-9]+)?(?:_space-[a-zA-Z0-9]+)?' +
+        '(_events.tsv|_channels.tsv|_electrodes.tsv|_ieeg.json|_coordsystem.json|_photo.jpg|_headshape.pos)$',
+    )
 
-        var ieegSesRe = new RegExp('^\\/(sub-[a-zA-Z0-9]+)' +
-            '\\/(?:(ses-[a-zA-Z0-9]+)' +
-            '\\/)?\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_proc-[a-zA-Z0-9]+)?(?:_space-[a-zA-Z0-9]+)?'
-            + '(_events.tsv|_channels.tsv|_electrodes.tsv|_ieeg.json|_coordsystem.json|_photo.jpg|_headshape.pos)$');
+    return (
+      conditionalMatch(scansRe, path) ||
+      conditionalMatch(funcSesRe, path) ||
+      conditionalMatch(anatSesRe, path) ||
+      conditionalMatch(dwiSesRe, path) ||
+      conditionalMatch(megSesRe, path) ||
+      conditionalMatch(eegSesRe, path) ||
+      conditionalMatch(ieegSesRe, path)
+    )
+  },
 
-        return conditionalMatch(scansRe, path) || conditionalMatch(funcSesRe, path) ||
-            conditionalMatch(anatSesRe, path) || conditionalMatch(dwiSesRe, path) ||
-            conditionalMatch(megSesRe, path) || conditionalMatch(eegSesRe, path) ||
-            conditionalMatch(ieegSesRe, path);
-    },
+  /**
+   * Check if the file has appropriate name for a subject level
+   */
+  isSubjectLevel: function(path) {
+    var scansRe = new RegExp(
+      '^\\/(sub-[a-zA-Z0-9]+)' + '\\/\\1(_sessions.tsv|_sessions.json)$',
+    )
+    return scansRe.test(path)
+  },
 
-    /**
-     * Check if the file has appropriate name for a subject level
-     */
-    isSubjectLevel: function (path) {
-        var scansRe = new RegExp('^\\/(sub-[a-zA-Z0-9]+)' +
-            '\\/\\1(_sessions.tsv|_sessions.json)$');
-        return scansRe.test(path);
-    },
+  /**
+   * Check if the file has a name appropriate for an anatomical scan
+   */
+  isAnat: function(path) {
+    var anatRe = new RegExp(
+      '^\\/(sub-[a-zA-Z0-9]+)' +
+        '\\/(?:(ses-[a-zA-Z0-9]+)' +
+        '\\/)?anat' +
+        '\\/\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?_(?:' +
+        anatSuffixes.join('|') +
+        ').(nii.gz|nii|json)$',
+    )
 
-    /**
-     * Check if the file has a name appropriate for an anatomical scan
-     */
-    isAnat: function (path) {
-        var anatRe = new RegExp('^\\/(sub-[a-zA-Z0-9]+)' +
-            '\\/(?:(ses-[a-zA-Z0-9]+)' +
-            '\\/)?anat' +
-            '\\/\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?_(?:'
-            + anatSuffixes.join("|")
-            + ').(nii.gz|nii|json)$');
+    var anatDefacemaskRe = new RegExp(
+      '^\\/(sub-[a-zA-Z0-9]+)' +
+        '\\/(?:(ses-[a-zA-Z0-9]+)' +
+        '\\/)?anat' +
+        '\\/\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_mod-(' +
+        anatSuffixes.join('|') +
+        '))?_defacemask.(nii.gz|nii)$',
+    )
+    return (
+      conditionalMatch(anatRe, path) || conditionalMatch(anatDefacemaskRe, path)
+    )
+  },
 
-        var anatDefacemaskRe = new RegExp('^\\/(sub-[a-zA-Z0-9]+)' +
-            '\\/(?:(ses-[a-zA-Z0-9]+)' +
-            '\\/)?anat' +
-            '\\/\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_mod-('
-            + anatSuffixes.join("|")
-            + '))?_defacemask.(nii.gz|nii)$');
-        return conditionalMatch(anatRe, path) || conditionalMatch(anatDefacemaskRe, path);
-    },
+  /**
+   * Check if the file has a name appropriate for a diffusion scan
+   */
+  isDWI: function(path) {
+    var suffixes = ['dwi', 'sbref']
+    var anatRe = new RegExp(
+      '^\\/(sub-[a-zA-Z0-9]+)' +
+        '\\/(?:(ses-[a-zA-Z0-9]+)' +
+        '\\/)?dwi' +
+        '\\/\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?_(?:' +
+        suffixes.join('|') +
+        ').(nii.gz|nii|json|bvec|bval)$',
+    )
+    return conditionalMatch(anatRe, path)
+  },
 
-    /**
-     * Check if the file has a name appropriate for a diffusion scan
-     */
-    isDWI: function (path) {
-        var suffixes = ["dwi", "sbref"];
-        var anatRe = new RegExp('^\\/(sub-[a-zA-Z0-9]+)' +
-            '\\/(?:(ses-[a-zA-Z0-9]+)' +
-            '\\/)?dwi' +
-            '\\/\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?_(?:'
-            + suffixes.join("|")
-            + ').(nii.gz|nii|json|bvec|bval)$');
-        return conditionalMatch(anatRe, path);
-    },
+  /**
+   * Check if the file has a name appropriate for a fieldmap scan
+   */
+  isFieldMap: function(path) {
+    var suffixes = [
+      'phasediff',
+      'phase1',
+      'phase2',
+      'magnitude1',
+      'magnitude2',
+      'magnitude',
+      'fieldmap',
+      'epi',
+    ]
+    var anatRe = new RegExp(
+      '^\\/(sub-[a-zA-Z0-9]+)' +
+        '\\/(?:(ses-[a-zA-Z0-9]+)' +
+        '\\/)?fmap' +
+        '\\/\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_dir-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?_(?:' +
+        suffixes.join('|') +
+        ').(nii.gz|nii|json)$',
+    )
+    return conditionalMatch(anatRe, path)
+  },
 
-    /**
-     * Check if the file has a name appropriate for a fieldmap scan
-     */
-    isFieldMap: function (path) {
-        var suffixes = ["phasediff", "phase1", "phase2", "magnitude1", "magnitude2", "magnitude", "fieldmap", "epi"];
-        var anatRe = new RegExp('^\\/(sub-[a-zA-Z0-9]+)' +
-            '\\/(?:(ses-[a-zA-Z0-9]+)' +
-            '\\/)?fmap' +
-            '\\/\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_dir-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?_(?:'
-            + suffixes.join("|")
-            + ').(nii.gz|nii|json)$');
-        return conditionalMatch(anatRe, path);
-    },
+  isFieldMapMainNii: function(path) {
+    var suffixes = ['phasediff', 'phase1', 'phase2', 'fieldmap', 'epi']
+    var anatRe = new RegExp(
+      '^\\/(sub-[a-zA-Z0-9]+)' +
+        '\\/(?:(ses-[a-zA-Z0-9]+)' +
+        '\\/)?fmap' +
+        '\\/\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_dir-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?_(?:' +
+        suffixes.join('|') +
+        ').(nii.gz|nii)$',
+    )
+    return conditionalMatch(anatRe, path)
+  },
 
-    isFieldMapMainNii: function (path) {
-        var suffixes = ["phasediff", "phase1", "phase2", "fieldmap", "epi"];
-        var anatRe = new RegExp('^\\/(sub-[a-zA-Z0-9]+)' +
-            '\\/(?:(ses-[a-zA-Z0-9]+)' +
-            '\\/)?fmap' +
-            '\\/\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_dir-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?_(?:'
-            + suffixes.join("|")
-            + ').(nii.gz|nii)$');
-        return conditionalMatch(anatRe, path);
-    },
+  /**
+   * Check if the file has a name appropriate for a functional scan
+   */
+  isFunc: function(path) {
+    var funcRe = new RegExp(
+      '^\\/(sub-[a-zA-Z0-9]+)' +
+        '\\/(?:(ses-[a-zA-Z0-9]+)' +
+        '\\/)?func' +
+        '\\/\\1(_\\2)?_task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_echo-[0-9]+)?' +
+        '(?:_bold.nii.gz|_bold.nii|_bold.json|_sbref.nii.gz|_sbref.nii|_sbref.json|_events.json|_events.tsv|_physio.tsv.gz|_stim.tsv.gz|_physio.json|_stim.json|_defacemask.nii.gz|_defacemask.nii)$',
+    )
+    return conditionalMatch(funcRe, path)
+  },
 
-    /**
-     * Check if the file has a name appropriate for a functional scan
-     */
-    isFunc: function (path) {
-        var funcRe = new RegExp('^\\/(sub-[a-zA-Z0-9]+)' +
-            '\\/(?:(ses-[a-zA-Z0-9]+)' +
-            '\\/)?func' +
-            '\\/\\1(_\\2)?_task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_echo-[0-9]+)?'
-            + '(?:_bold.nii.gz|_bold.nii|_bold.json|_sbref.nii.gz|_sbref.nii|_sbref.json|_events.json|_events.tsv|_physio.tsv.gz|_stim.tsv.gz|_physio.json|_stim.json|_defacemask.nii.gz|_defacemask.nii)$');
-        return conditionalMatch(funcRe, path);
-    },
+  isMeg: function(path) {
+    var MegRe = new RegExp(
+      '^\\/(sub-[a-zA-Z0-9]+)' +
+        '\\/(?:(ses-[a-zA-Z0-9]+)' +
+        '\\/)?meg' +
+        '\\/\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_proc-[a-zA-Z0-9]+)?(?:_part-[0-9]+)?' +
+        '(_meg(.fif|.fif.gz|.ds\\/.*|\\/.*)|(_events.tsv|_channels.tsv|_meg.json|_coordsystem.json|_photo.jpg|_headshape.pos))$',
+    )
+    return conditionalMatch(MegRe, path)
+  },
 
-    isMeg: function(path) {
-        var MegRe = new RegExp('^\\/(sub-[a-zA-Z0-9]+)' +
-            '\\/(?:(ses-[a-zA-Z0-9]+)' +
-            '\\/)?meg' +
-            '\\/\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_proc-[a-zA-Z0-9]+)?(?:_part-[0-9]+)?' +
-            '(_meg(.fif|.fif.gz|.ds\\/.*|\\/.*)|(_events.tsv|_channels.tsv|_meg.json|_coordsystem.json|_photo.jpg|_headshape.pos))$');
-        return conditionalMatch(MegRe, path);
-    },
+  isEeg: function(path) {
+    var EegRe = new RegExp(
+      '^\\/(sub-[a-zA-Z0-9]+)' +
+        '\\/(?:(ses-[a-zA-Z0-9]+)' +
+        '\\/)?eeg' +
+        '\\/\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_proc-[a-zA-Z0-9]+)?(?:_part-[0-9]+)?' +
+        '(_eeg.(vhdr|vmrk|eeg|edf|bdf|set|fdt|cnt)|(_events.tsv|_electrodes.tsv|_channels.tsv|_eeg.json|_coordsystem.json|_photo.jpg))$',
+    )
+    return conditionalMatch(EegRe, path)
+  },
 
-    isEeg: function(path) {
-        var EegRe = new RegExp('^\\/(sub-[a-zA-Z0-9]+)' +
-            '\\/(?:(ses-[a-zA-Z0-9]+)' +
-            '\\/)?eeg' +
-            '\\/\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_proc-[a-zA-Z0-9]+)?(?:_part-[0-9]+)?' +
-            '(_eeg.(vhdr|vmrk|eeg|edf|bdf|set|fdt|cnt)|(_events.tsv|_electrodes.tsv|_channels.tsv|_eeg.json|_coordsystem.json|_photo.jpg))$');
-        return conditionalMatch(EegRe, path);
-    },
+  isIEEG: function(path) {
+    var IEEGRe = new RegExp(
+      '^\\/(sub-[a-zA-Z0-9]+)' +
+        '\\/(?:(ses-[a-zA-Z0-9]+)' +
+        '\\/)?ieeg' +
+        '\\/\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_proc-[a-zA-Z0-9]+)?(?:_part-[0-9]+)?(?:_space-[a-zA-Z0-9]+)?' +
+        '(_ieeg.(edf|vhdr|vmrk|dat)|(_events.tsv|_channels.tsv|_electrodes.tsv|_ieeg.json|_coordsystem.json|_photo.jpg))$',
+    )
+    return conditionalMatch(IEEGRe, path)
+  },
 
-    isIEEG: function(path) {
-        var IEEGRe = new RegExp('^\\/(sub-[a-zA-Z0-9]+)' +
-            '\\/(?:(ses-[a-zA-Z0-9]+)' +
-            '\\/)?ieeg' +
-            '\\/\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_proc-[a-zA-Z0-9]+)?(?:_part-[0-9]+)?(?:_space-[a-zA-Z0-9]+)?' +
-            '(_ieeg.(edf|vhdr|vmrk|dat)|(_events.tsv|_channels.tsv|_electrodes.tsv|_ieeg.json|_coordsystem.json|_photo.jpg))$');
-        return conditionalMatch(IEEGRe, path);
-    },
+  isBehavioral: function(path) {
+    var funcBeh = new RegExp(
+      '^\\/(sub-[a-zA-Z0-9]+)' +
+        '\\/(?:(ses-[a-zA-Z0-9]+)' +
+        '\\/)?beh' +
+        '\\/\\1(_\\2)?_task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?' +
+        '(?:_beh.json|_beh.tsv|_events.json|_events.tsv|_physio.tsv.gz|_stim.tsv.gz|_physio.json|_stim.json)$',
+    )
+    return conditionalMatch(funcBeh, path)
+  },
 
-    isBehavioral: function(path) {
-        var funcBeh = new RegExp('^\\/(sub-[a-zA-Z0-9]+)' +
-            '\\/(?:(ses-[a-zA-Z0-9]+)' +
-            '\\/)?beh' +
-            '\\/\\1(_\\2)?_task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?'
-            + '(?:_beh.json|_beh.tsv|_events.json|_events.tsv|_physio.tsv.gz|_stim.tsv.gz|_physio.json|_stim.json)$');
-        return conditionalMatch(funcBeh, path);
-    },
+  isFuncBold: function(path) {
+    var funcRe = new RegExp(
+      '^\\/(sub-[a-zA-Z0-9]+)' +
+        '\\/(?:(ses-[a-zA-Z0-9]+)' +
+        '\\/)?func' +
+        '\\/\\1(_\\2)?_task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_echo-[0-9]+)?' +
+        '(?:_bold.nii.gz|_bold.nii|_sbref.nii.gz|_sbref.nii)$',
+    )
+    return conditionalMatch(funcRe, path)
+  },
 
-    isFuncBold: function (path) {
-        var funcRe = new RegExp('^\\/(sub-[a-zA-Z0-9]+)' +
-            '\\/(?:(ses-[a-zA-Z0-9]+)' +
-            '\\/)?func' +
-            '\\/\\1(_\\2)?_task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_echo-[0-9]+)?'
-            + '(?:_bold.nii.gz|_bold.nii|_sbref.nii.gz|_sbref.nii)$');
-        return conditionalMatch(funcRe, path);
-    },
+  isCont: function(path) {
+    var contRe = new RegExp(
+      '^\\/(sub-[a-zA-Z0-9]+)' +
+        '\\/(?:(ses-[a-zA-Z0-9]+)' +
+        '\\/)?(?:func|beh)' +
+        '\\/\\1(_\\2)?_task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?' +
+        '(?:_recording-[a-zA-Z0-9]+)?' +
+        '(?:_physio.tsv.gz|_stim.tsv.gz|_physio.json|_stim.json)$',
+    )
+    return conditionalMatch(contRe, path)
+  },
 
-    isCont: function (path) {
-        var contRe = new RegExp('^\\/(sub-[a-zA-Z0-9]+)' +
-            '\\/(?:(ses-[a-zA-Z0-9]+)' +
-            '\\/)?(?:func|beh)' +
-            '\\/\\1(_\\2)?_task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?' +
-            '(?:_recording-[a-zA-Z0-9]+)?'
-            + '(?:_physio.tsv.gz|_stim.tsv.gz|_physio.json|_stim.json)$');
-        return conditionalMatch(contRe, path);
-    },
+  isNumber: function(n) {
+    return !isNaN(parseFloat(n)) && isFinite(n)
+  },
 
-    isNumber: function (n) {
-        return !isNaN(parseFloat(n)) && isFinite(n);
-    },
+  /**
+   * Get Path Values
+   *
+   * Takes a file path and returns and values
+   * found for the following path keys.
+   * sub-
+   * ses-
+   */
+  getPathValues: function(path) {
+    var values = {},
+      match
 
+    // capture subject
+    match = /^\/sub-([a-zA-Z0-9]+)/.exec(path)
+    values.sub = match && match[1] ? match[1] : null
 
-    /**
-     * Get Path Values
-     *
-     * Takes a file path and returns and values
-     * found for the following path keys.
-     * sub-
-     * ses-
-     */
-    getPathValues: function (path) {
-        var values = {}, match;
+    // capture session
+    match = /^\/sub-[a-zA-Z0-9]+\/ses-([a-zA-Z0-9]+)/.exec(path)
+    values.ses = match && match[1] ? match[1] : null
 
-        // capture subject
-        match = (/^\/sub-([a-zA-Z0-9]+)/).exec(path);
-        values.sub = match && match[1] ? match[1] : null;
+    return values
+  },
+}
 
-        // capture session
-        match = (/^\/sub-[a-zA-Z0-9]+\/ses-([a-zA-Z0-9]+)/).exec(path);
-        values.ses = match && match[1] ? match[1] : null;
+function conditionalMatch(expression, path) {
+  var match = expression.exec(path)
 
-        return values;
+  // we need to do this because JS does not support conditional groups
+  if (match) {
+    if ((match[2] && match[3]) || !match[2]) {
+      return true
     }
-
-};
-
-function conditionalMatch (expression, path) {
-    var match = expression.exec(path);
-
-        // we need to do this because JS does not support conditional groups
-        if (match){
-            if ((match[2] && match[3]) || !match[2]) {
-                return true;
-            }
-        }
-        return false;
+  }
+  return false
 }

--- a/validators/bids.js
+++ b/validators/bids.js
@@ -1,624 +1,764 @@
-var async  = require('async');
-var fs     = require('fs');
-var path   = require('path');
-var utils  = require('../utils');
-var Issue  = utils.issues.Issue;
+var async = require('async')
+var fs = require('fs')
+var path = require('path')
+var utils = require('../utils')
+var Issue = utils.issues.Issue
 
+var TSV = require('./tsv')
+var json = require('./json')
+var NIFTI = require('./nii')
+var bval = require('./bval')
+var bvec = require('./bvec')
+var Events = require('./events')
+var session = require('./session')
+var checkAnyDataPresent = require('./checkAnyDataPresent')
+var headerFields = require('./headerFields')
 
-var TSV    = require('./tsv');
-var json   = require('./json');
-var NIFTI  = require('./nii');
-var bval   = require('./bval');
-var bvec   = require('./bvec');
-var Events = require('./events');
-var session = require('./session');
-var checkAnyDataPresent = require('./checkAnyDataPresent');
-var headerFields = require('./headerFields');
-
-var BIDS;
+var BIDS
 
 BIDS = {
+  options: {},
+  issues: [],
 
-    options: {},
-    issues: [],
-
-    /**
-     * Start
-     *
-     * Takes either a filelist array or
-     * a path to a BIDS directory and an
-     * options object and starts
-     * the validation process and
-     * returns the errors and warnings as
-     * arguments to the callback.
-     */
-    start: function (dir, options, callback) {
-        var self = BIDS;
-        utils.options.parse(options, function (issues, options) {
-            if (issues && issues.length > 0) {
-                // option parsing issues
-                callback({config: issues});
+  /**
+   * Start
+   *
+   * Takes either a filelist array or
+   * a path to a BIDS directory and an
+   * options object and starts
+   * the validation process and
+   * returns the errors and warnings as
+   * arguments to the callback.
+   */
+  start: function(dir, options, callback) {
+    var self = BIDS
+    utils.options.parse(options, function(issues, options) {
+      if (issues && issues.length > 0) {
+        // option parsing issues
+        callback({ config: issues })
+      } else {
+        self.options = options
+        BIDS.reset()
+        utils.files.readDir(dir, function(files) {
+          self.quickTest(files, function(couldBeBIDS) {
+            if (couldBeBIDS) {
+              self.fullTest(files, callback)
             } else {
-                self.options = options;
-                BIDS.reset();
-                utils.files.readDir(dir, function (files) {
-                    self.quickTest(files, function (couldBeBIDS) {
-                        if (couldBeBIDS) {
-                            self.fullTest(files, callback);
-                        } else {
-                            // Return an error immediately if quickTest fails
-                            var issue = self.quickTestError(dir);
-                            var summary = {
-                                sessions: [],
-                                subjects: [],
-                                tasks: [],
-                                modalities: [],
-                                totalFiles: Object.keys(files).length,
-                                size: 0
-                            };
-                            callback(utils.issues.format([issue], summary, options));
-                        }
-                    });
-                });
+              // Return an error immediately if quickTest fails
+              var issue = self.quickTestError(dir)
+              var summary = {
+                sessions: [],
+                subjects: [],
+                tasks: [],
+                modalities: [],
+                totalFiles: Object.keys(files).length,
+                size: 0,
+              }
+              callback(utils.issues.format([issue], summary, options))
             }
-        });
-    },
+          })
+        })
+      }
+    })
+  },
 
-    /*
+  /*
      * Generates an error for quickTest failures
      */
-    quickTestError: function (dir) {
-        var filename;
-        if (typeof window === 'undefined') {
-            // For Node, grab the path from the dir string
-            filename = path.basename(dir);
-        } else {
-            // Browser side we need to look it up more carefully
-            if (dir.length && 'webkitRelativePath' in dir[0]) {
-                var wrp = dir[0].webkitRelativePath;
-                while (wrp.indexOf(path.sep) !== -1) {
-                    wrp = path.dirname(wrp);
-                }
-                filename = wrp;
-            } else {
-                // Fallback for non-standard webkitRelativePath
-                filename = 'uploaded-directory';
-            }
+  quickTestError: function(dir) {
+    var filename
+    if (typeof window === 'undefined') {
+      // For Node, grab the path from the dir string
+      filename = path.basename(dir)
+    } else {
+      // Browser side we need to look it up more carefully
+      if (dir.length && 'webkitRelativePath' in dir[0]) {
+        var wrp = dir[0].webkitRelativePath
+        while (wrp.indexOf(path.sep) !== -1) {
+          wrp = path.dirname(wrp)
         }
-        var issue = new Issue({
-            code: 61,
-            file: {
-                name: filename,
-                path: path.join('.', filename),
-                relativePath: path.join('', filename)
-            }
-        });
-        return issue;
-    },
+        filename = wrp
+      } else {
+        // Fallback for non-standard webkitRelativePath
+        filename = 'uploaded-directory'
+      }
+    }
+    var issue = new Issue({
+      code: 61,
+      file: {
+        name: filename,
+        path: path.join('.', filename),
+        relativePath: path.join('', filename),
+      },
+    })
+    return issue
+  },
 
-    /**
-     * Quick Test
-     *
-     * A quick test to see if it could be a BIDS
-     * dataset based on structure/naming. If it
-     * could be it will trigger the full validation
-     * otherwise it will throw a callback with a
-     * generic error.
-     */
-    quickTest: function (fileList, callback) {
-        var couldBeBIDS = false;
-        for (var key in fileList) {
-            if (fileList.hasOwnProperty(key)) {
-                var file = fileList[key];
-                var path = file.relativePath;
-                if (path) {
-                    path = path.split('/');
-                    path = path.reverse();
+  /**
+   * Quick Test
+   *
+   * A quick test to see if it could be a BIDS
+   * dataset based on structure/naming. If it
+   * could be it will trigger the full validation
+   * otherwise it will throw a callback with a
+   * generic error.
+   */
+  quickTest: function(fileList, callback) {
+    var couldBeBIDS = false
+    for (var key in fileList) {
+      if (fileList.hasOwnProperty(key)) {
+        var file = fileList[key]
+        var path = file.relativePath
+        if (path) {
+          path = path.split('/')
+          path = path.reverse()
 
-                    var isCorrectModality = false;
-                    // MRI
-                    if (path[0].includes('.nii') && ['anat', 'func', 'dwi'].indexOf(path[1]) !=-1) {isCorrectModality = true;}
-                    // MEG
-                    else if (path[0].includes('.json') && ['meg'].indexOf(path[1]) !=-1) {isCorrectModality = true;}
-                    // EEG
-                    else if (path[0].includes('.json') && (['eeg'].indexOf(path[1]) !=-1)  && BIDS.options.bep006) {isCorrectModality = true;}
-                    // iEEG
-                    else if (path[0].includes('.json') && (['ieeg'].indexOf(path[1]) !=-1) && BIDS.options.bep010) { isCorrectModality = true;}
+          var isCorrectModality = false
+          // MRI
+          if (
+            path[0].includes('.nii') &&
+            ['anat', 'func', 'dwi'].indexOf(path[1]) != -1
+          ) {
+            isCorrectModality = true
+          }
+          // MEG
+          else if (
+            path[0].includes('.json') &&
+            ['meg'].indexOf(path[1]) != -1
+          ) {
+            isCorrectModality = true
+          }
+          // EEG
+          else if (
+            path[0].includes('.json') &&
+            ['eeg'].indexOf(path[1]) != -1 &&
+            BIDS.options.bep006
+          ) {
+            isCorrectModality = true
+          }
+          // iEEG
+          else if (
+            path[0].includes('.json') &&
+            ['ieeg'].indexOf(path[1]) != -1 &&
+            BIDS.options.bep010
+          ) {
+            isCorrectModality = true
+          }
 
-                    if (path[2] && (path[2].indexOf('ses-') == 0 || path[2].indexOf('sub-') == 0) && isCorrectModality){
-                        couldBeBIDS = true;
-                        break;
-                    }
-                }
-            }
+          if (
+            path[2] &&
+            (path[2].indexOf('ses-') == 0 || path[2].indexOf('sub-') == 0) &&
+            isCorrectModality
+          ) {
+            couldBeBIDS = true
+            break
+          }
         }
-        callback(couldBeBIDS);
-    },
-
-    /**
-     * Full Test
-     *
-     * Takes on an array of files and starts
-     * the validation process for a BIDS
-     * package.
-     */
-    fullTest: function (fileList, callback) {
-        var self = this;
-
-        var jsonContentsDict = {},
-            bContentsDict = {},
-            events = [],
-            stimuli = {
-                events: [],
-                directory: [],
-            },
-            niftis = [],
-            ephys = [],
-            headers = [],
-            participants = null,
-            phenotypeParticipants = [],
-            hasSubjectDir = false;
-        var hasDatasetDescription = false;
-
-        var summary = {
-            sessions: [],
-            subjects: [],
-            tasks: [],
-            modalities: [],
-            totalFiles: Object.keys(fileList).length,
-            size: 0
-        };
-
-
-        // collect file directory statistics
-        async.eachOfLimit(fileList, 200, function(file) {
-            // collect file stats
-            if (typeof window !== 'undefined') {
-                if (file.size) {
-                    summary.size += file.size;
-                }
-            } else {
-                if (!file.stats) {
-                    try {
-                        file.stats = fs.statSync(file.path);
-                    } catch (err) {
-                        file.stats = {size: 0};
-                    }
-                }
-                summary.size += file.stats.size;
-            }
-        });
-
-        // remove ignored files from list:
-        Object.keys(fileList).forEach(function(key) {
-            if (fileList[key].ignore) {
-                delete fileList[key];
-            }
-        });
-
-
-        // var subses_mismatch = false;
-        self.subIDsesIDmismatchtest(fileList);
-
-
-        // check for illegal character in task name and acq name
-
-        var task_re = /sub-(.*?)_task-[a-zA-Z0-9]*[_-][a-zA-Z0-9]*(?:_acq-[a-zA-Z0-9-]*)?(?:_run-\d+)?_/g;
-        var acq_re = /sub-(.*?)(_task-\w+.\w+)?(_acq-[a-zA-Z0-9]*[_-][a-zA-Z0-9]*)(?:_run-\d+)?_/g;
-
-        var sub_re = /sub-[a-zA-Z0-9]*[_-][a-zA-Z0-9]*_/g;   // illegal character in sub
-        var ses_re = /ses-[a-zA-Z0-9]*[_-][a-zA-Z0-9]*?_(.*?)/g; //illegal character in ses
-
-        var illegalchar_regex_list = [
-            [task_re, 58, "task name contains illegal character:"],
-            [acq_re, 59, "acq name contains illegal character:"],
-            [sub_re, 62, "sub name contains illegal character:" ],
-            [ses_re, 63, "ses name contains illegal character:" ]
-        ];
-
-
-        async.eachOfLimit(fileList, 200, function (file) {
-            var completename = file.relativePath;
-            if(!(completename.startsWith('/derivatives') || completename.startsWith('/code') || completename.startsWith('/sourcedata'))) {
-                for (var re_index = 0; re_index < illegalchar_regex_list.length; re_index++) {
-                    var err_regex = illegalchar_regex_list[re_index][0];
-                    var err_code = illegalchar_regex_list[re_index][1];
-                    var err_evidence = illegalchar_regex_list[re_index][2];
-
-                    if (err_regex.exec(completename)) {
-                        self.issues.push(new Issue({
-                            file: file,
-                            code: err_code,
-                            evidence: err_evidence + completename
-                        }));
-                    }
-                }
-            }
-        });
-
-
-        // validate individual files
-        async.eachOfLimit(fileList, 200, function (file, key, cb) {
-            const path = file.relativePath;
-            const pathParts = path.split('_');
-            const suffix = pathParts[pathParts.length - 1];
-
-            // Make RegExp for detecting modalities from data file extensions
-            var dataExtRE = new RegExp (['^.*\\.(',
-                                         'nii|nii\\.gz|', // MRI
-                                         'fif|fif\\.gz|sqd|con|kdf|chn|trg|raw|raw\\.mhf|', // MEG
-                                         'eeg|vhdr|vmrk|edf|cnt|bdf|set|fdt|dat|nwb|tdat|tidx|tmet', // EEG/iEEG
-                                         ')$'].join(''));
-
-            // ignore associated data
-            if (utils.type.isStimuliData(file.relativePath)) {
-                stimuli.directory.push(file);
-                process.nextTick(cb);
-            }
-
-            // validate path naming
-            else if (!utils.type.isBIDS(file.relativePath, BIDS.options.bep006, BIDS.options.bep010)) {
-                self.issues.push(new Issue({
-                    file: file,
-                    evidence: file.name,
-                    code: 1
-                }));
-                process.nextTick(cb);
-            }
-
-            // check modality by data file extension ...
-            // and capture data files for later sanity checks (when available)
-            else if (dataExtRE.test(file.name)) {
-
-                // capture nifties for later validation
-                if (file.name.endsWith('.nii') || file.name.endsWith('.nii.gz')) {niftis.push(file);}
-
-            // collect modality summary
-            const modality = suffix.slice(0, suffix.indexOf('.'));
-            if (summary.modalities.indexOf(modality) === -1) {
-                summary.modalities.push(modality);
-            }
-
-                process.nextTick(cb);
-                }
-
-            // capture ieeg files for summary
-            else if (['edf', 'vhdr', 'vmrk', 'dat', 'cnt', 'bdf', 'set', 'nwb', 'tdat', 'tidx', 'tmet'].includes(file.name.split('.').pop())) {
-                ephys.push(file);
-
-                process.nextTick(cb);
-            }
-
-            // validate tsv
-            else if (file.name && file.name.endsWith('.tsv')) {            
-                // Generate name for corresponding data dictionary file
-                //console.log("Check for data dictionary for " + file.path);
-                let dict_path = file.relativePath.replace(".tsv", ".json");
-                let exists = false;
-                let potentialDicts = utils.files.potentialLocations(dict_path);
-                // Need to check for .json file at all levels of heirarchy
-                //console.log("Potential data dictionaries:" + utils.files.potentialLocations(dict_path));
-                // Get list of fileList keys
-                let idxs = Object.keys(fileList);
-                for (let i of idxs) {
-                    if (potentialDicts.indexOf(fileList[i].relativePath) > -1) {
-                        exists = true;
-                        break;
-                    }
-                }
-
-                // Check if data dictionary file exists
-                if (!exists) {  // Can't use fs.exists because there's no file system in browser implementations
-                    //console.log("Missing data dictionary found");
-                    self.issues.push(new Issue({
-                        code: 82,
-                        file: file
-                    }));                    
-                }
-                utils.files.readFile(file, function (issue, contents) {
-                    if (issue) {
-                        self.issues.push(issue);
-                        process.nextTick(cb);
-                        return;
-                    }
-                    if (file.name.endsWith('_events.tsv')) {
-                        events.push({
-                            file: file,
-                            path: file.relativePath,
-                            contents: contents
-                        });
-                    }
-                    TSV.TSV(file, contents, fileList, function (issues, participantList, stimFiles) {
-                        if (participantList) {
-                            if (file.name.endsWith('participants.tsv')) {
-                                participants = {
-                                    list: participantList,
-                                    file: file
-                                };
-                            } else if (file.relativePath.includes('phenotype/')) {
-                                phenotypeParticipants.push({
-                                    list: participantList,
-                                    file: file
-                                });
-                            }
-                        }
-                        if (stimFiles.length) {
-                            // add unique new events to the stimuli.events array
-                            stimuli.events = [... new Set([...stimuli.events, ...stimFiles])];
-                        }
-                        self.issues = self.issues.concat(issues);
-                        process.nextTick(cb);
-                    });
-                });
-            }
-
-            // validate bvec
-            else if (file.name && file.name.endsWith('.bvec')) {
-                utils.files.readFile(file, function (issue, contents) {
-                    if (issue) {
-                        self.issues.push(issue);
-                        process.nextTick(cb);
-                        return;
-                    }
-                    bContentsDict[file.relativePath] = contents;
-                    bvec(file, contents, function (issues) {
-                        self.issues = self.issues.concat(issues);
-                        process.nextTick(cb);
-                    });
-                });
-            }
-
-            // validate bval
-            else if (file.name && file.name.endsWith('.bval')) {
-                utils.files.readFile(file, function (issue, contents) {
-                    if (issue) {
-                        self.issues.push(issue);
-                        process.nextTick(cb);
-                        return;
-                    }
-                    bContentsDict[file.relativePath] = contents;
-                    bval(file, contents, function (issues) {
-                        self.issues = self.issues.concat(issues);
-                        process.nextTick(cb);
-                    });
-                });
-            }
-
-            // validate json
-            else if (file.name && file.name.endsWith('.json')) {
-                utils.files.readFile(file, function (issue, contents) {
-                    if (issue) {
-                        self.issues.push(issue);
-                        process.nextTick(cb);
-                        return;
-                    }
-                    json(file, contents, function (issues, jsObj) {
-                        self.issues = self.issues.concat(issues);
-
-                        // abort further tests if schema test does not pass
-                        for (var i = 0; i < issues.length; i++) {
-                            if (issues[i].severity === 'error') {
-                                process.nextTick(cb);
-                                return;
-                            }
-                        }
-
-                        jsonContentsDict[file.relativePath] = jsObj;
-
-                        // collect task summary
-                        if (file.name.indexOf('task') > -1) {
-                            var task = jsObj ? jsObj.TaskName : null;
-                            if (task && summary.tasks.indexOf(task) === -1) {
-                                summary.tasks.push(task);
-                            }
-                        }
-                        process.nextTick(cb);
-                    });
-                });
-            } else {
-                process.nextTick(cb);
-            }
-
-            // check for subject directory presence
-            if (path.startsWith('/sub-')) {
-                hasSubjectDir = true;
-            }
-
-            // check for dataset_description.json presence
-            if (path === '/dataset_description.json') {
-                hasDatasetDescription = true;
-            }
-
-            // collect sessions & subjects
-            if (!utils.type.isStimuliData(file.relativePath) && utils.type.isBIDS(file.relativePath, BIDS.options.bep006, BIDS.options.bep010)) {
-                var pathValues = utils.type.getPathValues(file.relativePath);
-
-                if (pathValues.sub && summary.subjects.indexOf(pathValues.sub) === -1) {
-                    summary.subjects.push(pathValues.sub);
-                }
-                if (pathValues.ses && summary.sessions.indexOf(pathValues.ses) === -1) {
-                    summary.sessions.push(pathValues.ses);
-                }
-            }
-
-        }, function () {
-            // check if same file with .nii and .nii.gz extensions is present
-            var niftiCounts = niftis
-            .map(function(val) {return {count: 1, val: val.name.split('.')[0]};})
-            .reduce(function(a, b) {
-              a[b.val] = (a[b.val] || 0) + b.count;
-              return a;}, {});
-
-            var duplicates = Object.keys(niftiCounts).filter(function(a) {return niftiCounts[a] > 1;});
-            if (duplicates.length !== 0) {
-                for (var key in duplicates) {
-                    var duplicateFiles = niftis.filter(function(a) {return a.name.split('.')[0] === duplicates[key];});
-                    for (var file in duplicateFiles) {
-                        self.issues.push(new Issue({
-                                code: 74,
-                                file: duplicateFiles[file]
-                            }));
-                    }
-                }
-            }
-
-            async.eachOfLimit(niftis, 200, function (file, key, cb) {
-                if (self.options.ignoreNiftiHeaders) {
-                    NIFTI(null, file, jsonContentsDict, bContentsDict, fileList, events, function (issues) {
-                        self.issues = self.issues.concat(issues);
-                        process.nextTick(cb);
-                    });
-                } else {
-                    utils.files.readNiftiHeader(file, function (header) {
-                        // check if header could be read
-                        if (header && header.hasOwnProperty('error')) {
-                            self.issues.push(header.error);
-                            process.nextTick(cb);
-                        } else {
-                            headers.push([file, header]);
-                            NIFTI(header, file, jsonContentsDict, bContentsDict, fileList, events, function (issues) {
-                                self.issues = self.issues.concat(issues);
-                                process.nextTick(cb);
-                            });
-                        }
-                    });
-                }
-
-            }, function () {
-                if (!hasSubjectDir) {
-                    self.issues.push(new Issue({code: 45}));
-                }
-                if (!hasDatasetDescription) {
-                    self.issues.push(new Issue({code: 57}));
-                }
-                // check if participants file match found subjects
-                if (participants) {
-                    var participantsFromFile = participants.list.sort();
-                    var participantsFromFolders = summary.subjects.sort();
-                    if (!utils.array.equals(participantsFromFolders, participantsFromFile, true)) {
-                        self.issues.push(new Issue({
-                            code: 49,
-                            evidence: "participants.tsv: " + participantsFromFile.join(', ') + " folder structure: " + participantsFromFolders.join(', '),
-                            file: participants.file
-                        }));
-                    }
-                }
-
-                // check if dataset contains T1w
-                if (summary.modalities.indexOf('T1w') < 0) {
-                    self.issues.push(new Issue({
-                        code: 53
-                    }));
-                }
-
-                //check for equal number of participants from ./phenotype/*.tsv and participants in dataset
-                TSV.checkphenotype(phenotypeParticipants, summary, self.issues);
-
-                // validate nii header fields
-                self.issues = self.issues.concat(headerFields(headers));
-
-                // Events validation
-                Events.validateEvents(events, stimuli, headers, jsonContentsDict, self.issues);
-
-                // validation session files
-                self.issues = self.issues.concat(session(fileList));
-
-                self.issues = self.issues.concat(checkAnyDataPresent(fileList, summary.subjects));
-                summary.modalities = utils.modalities.group(summary.modalities);
-                var issues = utils.issues.format(self.issues, summary, self.options);
-                callback(issues, summary);
-            });
-        });
-    },
-
-    /**
-     * subid and sesid mismatch test. Generates error if ses-id and sub-id are different for any file, Takes a file list and return issues
-     */
-    subIDsesIDmismatchtest: function(fileList){
-        var self = this;
-        var subses_mismatch = false;
-
-        /**
-         * getPathandFileValues
-         * Takes a file path and returns values
-         * found following keys for both path and file keys.
-         * sub-
-         * ses-
-         *
-         *
-         */
-        function getPathandFileValues(path){
-            var values = {}, match;
-            var file_name ={}, unmat;
-
-            // capture subject
-            match = (/^\/sub-([a-zA-Z0-9]+)/).exec(path);
-            values.sub = match && match[1] ? match[1] : null;
-
-            // capture session
-            match = (/^\/sub-[a-zA-Z0-9]+\/ses-([a-zA-Z0-9]+)/).exec(path);
-            values.ses = match && match[1] ? match[1] : null;
-
-            //capture session and subject id from filename to find if files are in
-            // correct sub/ses directory
-            var filename = path.replace(/^.*[\\/]/, '');
-
-            // capture sub from file name
-            unmat = (/^sub-([a-zA-Z0-9]+)/).exec(filename);
-            file_name.sub = unmat && unmat[1] ? unmat[1] : null;
-
-
-            // capture session from file name
-            unmat = (/^sub-[a-zA-Z0-9]+_ses-([a-zA-Z0-9]+)/).exec(filename);
-            file_name.ses = unmat && unmat[1] ? unmat[1] : null;
-
-            return [values,file_name];
-        }
-
-
-        // validates if sub/ses-id in filename matches with ses/sub directory file is saved
-        async.eachOfLimit(fileList, 200, function (file) {
-            var values = getPathandFileValues(file.relativePath);
-
-            var pathValues = values[0];
-            var fileValues = values[1];
-            // console.log(path, '/n' ,values);
-
-            if (fileValues.sub !== null || fileValues.ses !== null) {
-                if (fileValues.sub !== pathValues.sub) {
-                    // console.log("before call  ",subses_mismatch);
-                    subses_mismatch = true;
-                    self.issues.push(new Issue({
-                        code: 64,
-                        evidence: "File: " + file.relativePath + " is saved in incorrect subject directory as per sub-id in filename.",
-                        file: file
-                    }));
-                }
-
-                if (fileValues.ses !== pathValues.ses) {
-                    subses_mismatch = true;
-                    self.issues.push(new Issue({
-                        code: 65,
-                        evidence: "File: " + file.relativePath + " is saved in incorrect session directory as per ses-id in filename.",
-                        file: file
-                    }));
-                }
-            }
-
-        });
-        return subses_mismatch;
-
-    },
-
-    /**
-     * Reset
-     *
-     * Resets the in object data back to original values.
-     */
-    reset: function () {
-        this.issues = [];
+      }
+    }
+    callback(couldBeBIDS)
+  },
+
+  /**
+   * Full Test
+   *
+   * Takes on an array of files and starts
+   * the validation process for a BIDS
+   * package.
+   */
+  fullTest: function(fileList, callback) {
+    var self = this
+
+    var jsonContentsDict = {},
+      bContentsDict = {},
+      events = [],
+      stimuli = {
+        events: [],
+        directory: [],
+      },
+      niftis = [],
+      ephys = [],
+      headers = [],
+      participants = null,
+      phenotypeParticipants = [],
+      hasSubjectDir = false
+    var hasDatasetDescription = false
+
+    var summary = {
+      sessions: [],
+      subjects: [],
+      tasks: [],
+      modalities: [],
+      totalFiles: Object.keys(fileList).length,
+      size: 0,
     }
 
-};
+    // collect file directory statistics
+    async.eachOfLimit(fileList, 200, function(file) {
+      // collect file stats
+      if (typeof window !== 'undefined') {
+        if (file.size) {
+          summary.size += file.size
+        }
+      } else {
+        if (!file.stats) {
+          try {
+            file.stats = fs.statSync(file.path)
+          } catch (err) {
+            file.stats = { size: 0 }
+          }
+        }
+        summary.size += file.stats.size
+      }
+    })
 
-module.exports = BIDS;
+    // remove ignored files from list:
+    Object.keys(fileList).forEach(function(key) {
+      if (fileList[key].ignore) {
+        delete fileList[key]
+      }
+    })
+
+    // var subses_mismatch = false;
+    self.subIDsesIDmismatchtest(fileList)
+
+    // check for illegal character in task name and acq name
+
+    var task_re = /sub-(.*?)_task-[a-zA-Z0-9]*[_-][a-zA-Z0-9]*(?:_acq-[a-zA-Z0-9-]*)?(?:_run-\d+)?_/g
+    var acq_re = /sub-(.*?)(_task-\w+.\w+)?(_acq-[a-zA-Z0-9]*[_-][a-zA-Z0-9]*)(?:_run-\d+)?_/g
+
+    var sub_re = /sub-[a-zA-Z0-9]*[_-][a-zA-Z0-9]*_/g // illegal character in sub
+    var ses_re = /ses-[a-zA-Z0-9]*[_-][a-zA-Z0-9]*?_(.*?)/g //illegal character in ses
+
+    var illegalchar_regex_list = [
+      [task_re, 58, 'task name contains illegal character:'],
+      [acq_re, 59, 'acq name contains illegal character:'],
+      [sub_re, 62, 'sub name contains illegal character:'],
+      [ses_re, 63, 'ses name contains illegal character:'],
+    ]
+
+    async.eachOfLimit(fileList, 200, function(file) {
+      var completename = file.relativePath
+      if (
+        !(
+          completename.startsWith('/derivatives') ||
+          completename.startsWith('/code') ||
+          completename.startsWith('/sourcedata')
+        )
+      ) {
+        for (
+          var re_index = 0;
+          re_index < illegalchar_regex_list.length;
+          re_index++
+        ) {
+          var err_regex = illegalchar_regex_list[re_index][0]
+          var err_code = illegalchar_regex_list[re_index][1]
+          var err_evidence = illegalchar_regex_list[re_index][2]
+
+          if (err_regex.exec(completename)) {
+            self.issues.push(
+              new Issue({
+                file: file,
+                code: err_code,
+                evidence: err_evidence + completename,
+              }),
+            )
+          }
+        }
+      }
+    })
+
+    // validate individual files
+    async.eachOfLimit(
+      fileList,
+      200,
+      function(file, key, cb) {
+        const path = file.relativePath
+        const pathParts = path.split('_')
+        const suffix = pathParts[pathParts.length - 1]
+
+        // Make RegExp for detecting modalities from data file extensions
+        var dataExtRE = new RegExp(
+          [
+            '^.*\\.(',
+            'nii|nii\\.gz|', // MRI
+            'fif|fif\\.gz|sqd|con|kdf|chn|trg|raw|raw\\.mhf|', // MEG
+            'eeg|vhdr|vmrk|edf|cnt|bdf|set|fdt|dat|nwb|tdat|tidx|tmet', // EEG/iEEG
+            ')$',
+          ].join(''),
+        )
+
+        // ignore associated data
+        if (utils.type.isStimuliData(file.relativePath)) {
+          stimuli.directory.push(file)
+          process.nextTick(cb)
+        }
+
+        // validate path naming
+        else if (
+          !utils.type.isBIDS(
+            file.relativePath,
+            BIDS.options.bep006,
+            BIDS.options.bep010,
+          )
+        ) {
+          self.issues.push(
+            new Issue({
+              file: file,
+              evidence: file.name,
+              code: 1,
+            }),
+          )
+          process.nextTick(cb)
+        }
+
+        // check modality by data file extension ...
+        // and capture data files for later sanity checks (when available)
+        else if (dataExtRE.test(file.name)) {
+          // capture nifties for later validation
+          if (file.name.endsWith('.nii') || file.name.endsWith('.nii.gz')) {
+            niftis.push(file)
+          }
+
+          // collect modality summary
+          const modality = suffix.slice(0, suffix.indexOf('.'))
+          if (summary.modalities.indexOf(modality) === -1) {
+            summary.modalities.push(modality)
+          }
+
+          process.nextTick(cb)
+        }
+
+        // capture ieeg files for summary
+        else if (
+          [
+            'edf',
+            'vhdr',
+            'vmrk',
+            'dat',
+            'cnt',
+            'bdf',
+            'set',
+            'nwb',
+            'tdat',
+            'tidx',
+            'tmet',
+          ].includes(file.name.split('.').pop())
+        ) {
+          ephys.push(file)
+
+          process.nextTick(cb)
+        }
+
+        // validate tsv
+        else if (file.name && file.name.endsWith('.tsv')) {
+          // Generate name for corresponding data dictionary file
+          //console.log("Check for data dictionary for " + file.path);
+          let dict_path = file.relativePath.replace('.tsv', '.json')
+          let exists = false
+          let potentialDicts = utils.files.potentialLocations(dict_path)
+          // Need to check for .json file at all levels of heirarchy
+          //console.log("Potential data dictionaries:" + utils.files.potentialLocations(dict_path));
+          // Get list of fileList keys
+          let idxs = Object.keys(fileList)
+          for (let i of idxs) {
+            if (potentialDicts.indexOf(fileList[i].relativePath) > -1) {
+              exists = true
+              break
+            }
+          }
+
+          // Check if data dictionary file exists
+          if (!exists) {
+            // Can't use fs.exists because there's no file system in browser implementations
+            //console.log("Missing data dictionary found");
+            self.issues.push(
+              new Issue({
+                code: 82,
+                file: file,
+              }),
+            )
+          }
+          utils.files.readFile(file, function(issue, contents) {
+            if (issue) {
+              self.issues.push(issue)
+              process.nextTick(cb)
+              return
+            }
+            if (file.name.endsWith('_events.tsv')) {
+              events.push({
+                file: file,
+                path: file.relativePath,
+                contents: contents,
+              })
+            }
+            TSV.TSV(file, contents, fileList, function(
+              issues,
+              participantList,
+              stimFiles,
+            ) {
+              if (participantList) {
+                if (file.name.endsWith('participants.tsv')) {
+                  participants = {
+                    list: participantList,
+                    file: file,
+                  }
+                } else if (file.relativePath.includes('phenotype/')) {
+                  phenotypeParticipants.push({
+                    list: participantList,
+                    file: file,
+                  })
+                }
+              }
+              if (stimFiles.length) {
+                // add unique new events to the stimuli.events array
+                stimuli.events = [...new Set([...stimuli.events, ...stimFiles])]
+              }
+              self.issues = self.issues.concat(issues)
+              process.nextTick(cb)
+            })
+          })
+        }
+
+        // validate bvec
+        else if (file.name && file.name.endsWith('.bvec')) {
+          utils.files.readFile(file, function(issue, contents) {
+            if (issue) {
+              self.issues.push(issue)
+              process.nextTick(cb)
+              return
+            }
+            bContentsDict[file.relativePath] = contents
+            bvec(file, contents, function(issues) {
+              self.issues = self.issues.concat(issues)
+              process.nextTick(cb)
+            })
+          })
+        }
+
+        // validate bval
+        else if (file.name && file.name.endsWith('.bval')) {
+          utils.files.readFile(file, function(issue, contents) {
+            if (issue) {
+              self.issues.push(issue)
+              process.nextTick(cb)
+              return
+            }
+            bContentsDict[file.relativePath] = contents
+            bval(file, contents, function(issues) {
+              self.issues = self.issues.concat(issues)
+              process.nextTick(cb)
+            })
+          })
+        }
+
+        // validate json
+        else if (file.name && file.name.endsWith('.json')) {
+          utils.files.readFile(file, function(issue, contents) {
+            if (issue) {
+              self.issues.push(issue)
+              process.nextTick(cb)
+              return
+            }
+            json(file, contents, function(issues, jsObj) {
+              self.issues = self.issues.concat(issues)
+
+              // abort further tests if schema test does not pass
+              for (var i = 0; i < issues.length; i++) {
+                if (issues[i].severity === 'error') {
+                  process.nextTick(cb)
+                  return
+                }
+              }
+
+              jsonContentsDict[file.relativePath] = jsObj
+
+              // collect task summary
+              if (file.name.indexOf('task') > -1) {
+                var task = jsObj ? jsObj.TaskName : null
+                if (task && summary.tasks.indexOf(task) === -1) {
+                  summary.tasks.push(task)
+                }
+              }
+              process.nextTick(cb)
+            })
+          })
+        } else {
+          process.nextTick(cb)
+        }
+
+        // check for subject directory presence
+        if (path.startsWith('/sub-')) {
+          hasSubjectDir = true
+        }
+
+        // check for dataset_description.json presence
+        if (path === '/dataset_description.json') {
+          hasDatasetDescription = true
+        }
+
+        // collect sessions & subjects
+        if (
+          !utils.type.isStimuliData(file.relativePath) &&
+          utils.type.isBIDS(
+            file.relativePath,
+            BIDS.options.bep006,
+            BIDS.options.bep010,
+          )
+        ) {
+          var pathValues = utils.type.getPathValues(file.relativePath)
+
+          if (
+            pathValues.sub &&
+            summary.subjects.indexOf(pathValues.sub) === -1
+          ) {
+            summary.subjects.push(pathValues.sub)
+          }
+          if (
+            pathValues.ses &&
+            summary.sessions.indexOf(pathValues.ses) === -1
+          ) {
+            summary.sessions.push(pathValues.ses)
+          }
+        }
+      },
+      function() {
+        // check if same file with .nii and .nii.gz extensions is present
+        var niftiCounts = niftis
+          .map(function(val) {
+            return { count: 1, val: val.name.split('.')[0] }
+          })
+          .reduce(function(a, b) {
+            a[b.val] = (a[b.val] || 0) + b.count
+            return a
+          }, {})
+
+        var duplicates = Object.keys(niftiCounts).filter(function(a) {
+          return niftiCounts[a] > 1
+        })
+        if (duplicates.length !== 0) {
+          for (var key in duplicates) {
+            var duplicateFiles = niftis.filter(function(a) {
+              return a.name.split('.')[0] === duplicates[key]
+            })
+            for (var file in duplicateFiles) {
+              self.issues.push(
+                new Issue({
+                  code: 74,
+                  file: duplicateFiles[file],
+                }),
+              )
+            }
+          }
+        }
+
+        async.eachOfLimit(
+          niftis,
+          200,
+          function(file, key, cb) {
+            if (self.options.ignoreNiftiHeaders) {
+              NIFTI(
+                null,
+                file,
+                jsonContentsDict,
+                bContentsDict,
+                fileList,
+                events,
+                function(issues) {
+                  self.issues = self.issues.concat(issues)
+                  process.nextTick(cb)
+                },
+              )
+            } else {
+              utils.files.readNiftiHeader(file, function(header) {
+                // check if header could be read
+                if (header && header.hasOwnProperty('error')) {
+                  self.issues.push(header.error)
+                  process.nextTick(cb)
+                } else {
+                  headers.push([file, header])
+                  NIFTI(
+                    header,
+                    file,
+                    jsonContentsDict,
+                    bContentsDict,
+                    fileList,
+                    events,
+                    function(issues) {
+                      self.issues = self.issues.concat(issues)
+                      process.nextTick(cb)
+                    },
+                  )
+                }
+              })
+            }
+          },
+          function() {
+            if (!hasSubjectDir) {
+              self.issues.push(new Issue({ code: 45 }))
+            }
+            if (!hasDatasetDescription) {
+              self.issues.push(new Issue({ code: 57 }))
+            }
+            // check if participants file match found subjects
+            if (participants) {
+              var participantsFromFile = participants.list.sort()
+              var participantsFromFolders = summary.subjects.sort()
+              if (
+                !utils.array.equals(
+                  participantsFromFolders,
+                  participantsFromFile,
+                  true,
+                )
+              ) {
+                self.issues.push(
+                  new Issue({
+                    code: 49,
+                    evidence:
+                      'participants.tsv: ' +
+                      participantsFromFile.join(', ') +
+                      ' folder structure: ' +
+                      participantsFromFolders.join(', '),
+                    file: participants.file,
+                  }),
+                )
+              }
+            }
+
+            // check if dataset contains T1w
+            if (summary.modalities.indexOf('T1w') < 0) {
+              self.issues.push(
+                new Issue({
+                  code: 53,
+                }),
+              )
+            }
+
+            //check for equal number of participants from ./phenotype/*.tsv and participants in dataset
+            TSV.checkphenotype(phenotypeParticipants, summary, self.issues)
+
+            // validate nii header fields
+            self.issues = self.issues.concat(headerFields(headers))
+
+            // Events validation
+            Events.validateEvents(
+              events,
+              stimuli,
+              headers,
+              jsonContentsDict,
+              self.issues,
+            )
+
+            // validation session files
+            self.issues = self.issues.concat(session(fileList))
+
+            self.issues = self.issues.concat(
+              checkAnyDataPresent(fileList, summary.subjects),
+            )
+            summary.modalities = utils.modalities.group(summary.modalities)
+            var issues = utils.issues.format(self.issues, summary, self.options)
+            callback(issues, summary)
+          },
+        )
+      },
+    )
+  },
+
+  /**
+   * subid and sesid mismatch test. Generates error if ses-id and sub-id are different for any file, Takes a file list and return issues
+   */
+  subIDsesIDmismatchtest: function(fileList) {
+    var self = this
+    var subses_mismatch = false
+
+    /**
+     * getPathandFileValues
+     * Takes a file path and returns values
+     * found following keys for both path and file keys.
+     * sub-
+     * ses-
+     *
+     *
+     */
+    function getPathandFileValues(path) {
+      var values = {},
+        match
+      var file_name = {},
+        unmat
+
+      // capture subject
+      match = /^\/sub-([a-zA-Z0-9]+)/.exec(path)
+      values.sub = match && match[1] ? match[1] : null
+
+      // capture session
+      match = /^\/sub-[a-zA-Z0-9]+\/ses-([a-zA-Z0-9]+)/.exec(path)
+      values.ses = match && match[1] ? match[1] : null
+
+      //capture session and subject id from filename to find if files are in
+      // correct sub/ses directory
+      var filename = path.replace(/^.*[\\/]/, '')
+
+      // capture sub from file name
+      unmat = /^sub-([a-zA-Z0-9]+)/.exec(filename)
+      file_name.sub = unmat && unmat[1] ? unmat[1] : null
+
+      // capture session from file name
+      unmat = /^sub-[a-zA-Z0-9]+_ses-([a-zA-Z0-9]+)/.exec(filename)
+      file_name.ses = unmat && unmat[1] ? unmat[1] : null
+
+      return [values, file_name]
+    }
+
+    // validates if sub/ses-id in filename matches with ses/sub directory file is saved
+    async.eachOfLimit(fileList, 200, function(file) {
+      var values = getPathandFileValues(file.relativePath)
+
+      var pathValues = values[0]
+      var fileValues = values[1]
+      // console.log(path, '/n' ,values);
+
+      if (fileValues.sub !== null || fileValues.ses !== null) {
+        if (fileValues.sub !== pathValues.sub) {
+          // console.log("before call  ",subses_mismatch);
+          subses_mismatch = true
+          self.issues.push(
+            new Issue({
+              code: 64,
+              evidence:
+                'File: ' +
+                file.relativePath +
+                ' is saved in incorrect subject directory as per sub-id in filename.',
+              file: file,
+            }),
+          )
+        }
+
+        if (fileValues.ses !== pathValues.ses) {
+          subses_mismatch = true
+          self.issues.push(
+            new Issue({
+              code: 65,
+              evidence:
+                'File: ' +
+                file.relativePath +
+                ' is saved in incorrect session directory as per ses-id in filename.',
+              file: file,
+            }),
+          )
+        }
+      }
+    })
+    return subses_mismatch
+  },
+
+  /**
+   * Reset
+   *
+   * Resets the in object data back to original values.
+   */
+  reset: function() {
+    this.issues = []
+  },
+}
+
+module.exports = BIDS

--- a/validators/bval.js
+++ b/validators/bval.js
@@ -1,5 +1,5 @@
-var Issue = require('../utils').issues.Issue;
-var type  = require('../utils').type;
+var Issue = require('../utils').issues.Issue
+var type = require('../utils').type
 
 /**
  * bval
@@ -9,32 +9,35 @@ var type  = require('../utils').type;
  * with any issues it finds while validating
  * against the BIDS specification.
  */
-module.exports = function bval (file, contents, callback) {
+module.exports = function bval(file, contents, callback) {
+  var issues = []
 
-    var issues = [];
+  if (contents.replace(/^\s+|\s+$/g, '').split('\n').length !== 1) {
+    issues.push(
+      new Issue({
+        code: 30,
+        file: file,
+      }),
+    )
+  }
 
-    if (contents.replace(/^\s+|\s+$/g, '').split('\n').length !== 1) {
-        issues.push(new Issue({
-            code: 30,
-            file: file
-        }));
+  // check for proper separator and value type
+  var row = contents.replace(/^\s+|\s+$/g, '').split(' ')
+  var invalidValue = false
+  for (var j = 0; j < row.length; j++) {
+    var value = row[j]
+    if (!type.isNumber(value)) {
+      invalidValue = true
     }
+  }
+  if (invalidValue) {
+    issues.push(
+      new Issue({
+        code: 47,
+        file: file,
+      }),
+    )
+  }
 
-    // check for proper separator and value type
-    var row = contents.replace(/^\s+|\s+$/g, '').split(' ');
-    var invalidValue = false;
-    for (var j = 0; j < row.length; j++) {
-        var value = row[j];
-        if (!type.isNumber(value)) {
-            invalidValue = true;
-        }
-    }
-    if (invalidValue) {
-        issues.push(new Issue({
-            code: 47,
-            file: file
-        }));
-    }
-
-    callback(issues);
-};
+  callback(issues)
+}

--- a/validators/bvec.js
+++ b/validators/bvec.js
@@ -1,5 +1,5 @@
-var Issue = require('../utils').issues.Issue;
-var type  = require('../utils').type;
+var Issue = require('../utils').issues.Issue
+var type = require('../utils').type
 
 /**
  * bvec
@@ -9,46 +9,57 @@ var type  = require('../utils').type;
  * with any issues it finds while validating
  * against the BIDS specification.
  */
-module.exports = function bvec (file, contents, callback) {
+module.exports = function bvec(file, contents, callback) {
+  var issues = []
 
-    var issues = [];
+  if (contents.replace(/^\s+|\s+$/g, '').split('\n').length !== 3) {
+    issues.push(
+      new Issue({
+        code: 31,
+        file: file,
+      }),
+    )
+  }
 
-    if (contents.replace(/^\s+|\s+$/g, '').split('\n').length !== 3) {
-        issues.push(new Issue({
-            code: 31,
-            file: file
-        }));
+  var rows = contents.replace(/^\s+|\s+$/g, '').split('\n')
+  var inconsistentRows,
+    rowLength,
+    invalidValue = false
+  for (var i = 0; i < rows.length; i++) {
+    var row = rows[i].replace(/^\s+|\s+$/g, '').split(' ')
+    if (!rowLength) {
+      rowLength = row.length
     }
 
-    var rows = contents.replace(/^\s+|\s+$/g, '').split('\n');
-    var inconsistentRows, rowLength, invalidValue = false;
-    for (var i = 0; i < rows.length; i++) {
-        var row = rows[i].replace(/^\s+|\s+$/g, '').split(' ');
-        if (!rowLength) {rowLength = row.length;}
-
-        // check for consistent row length
-        if (rowLength !== row.length) {inconsistentRows = true;}
-
-        // check for proper separator and value type
-        for (var j = 0; j < row.length; j++) {
-            var value = row[j];
-            if (!type.isNumber(value)) {
-                invalidValue = true;
-            }
-        }
-    }
-    if (inconsistentRows) {
-        issues.push(new Issue({
-            code: 46,
-            file: file
-        }));
-    }
-    if (invalidValue) {
-        issues.push(new Issue({
-            code: 47,
-            file: file
-        }));
+    // check for consistent row length
+    if (rowLength !== row.length) {
+      inconsistentRows = true
     }
 
-    callback(issues);
-};
+    // check for proper separator and value type
+    for (var j = 0; j < row.length; j++) {
+      var value = row[j]
+      if (!type.isNumber(value)) {
+        invalidValue = true
+      }
+    }
+  }
+  if (inconsistentRows) {
+    issues.push(
+      new Issue({
+        code: 46,
+        file: file,
+      }),
+    )
+  }
+  if (invalidValue) {
+    issues.push(
+      new Issue({
+        code: 47,
+        file: file,
+      }),
+    )
+  }
+
+  callback(issues)
+}

--- a/validators/checkAnyDataPresent.js
+++ b/validators/checkAnyDataPresent.js
@@ -1,22 +1,22 @@
-var utils = require('../utils');
-var Issue = utils.issues.Issue;
+var utils = require('../utils')
+var Issue = utils.issues.Issue
 
 function addIfNotPresent(folderSubjects, subject) {
-    if (folderSubjects.indexOf(subject) == -1) {
-        folderSubjects.push(subject);
-    }
+  if (folderSubjects.indexOf(subject) == -1) {
+    folderSubjects.push(subject)
+  }
 }
 
 function getFolderSubjects(fileList) {
-    var folderSubjects = [];
-    for (var key in fileList) {
-        var file = fileList[key];
-        var match = file.relativePath.match(/sub-(.*?)(?=\/)/);
-        if (match) {
-            addIfNotPresent(folderSubjects, match[1]);
-        }
+  var folderSubjects = []
+  for (var key in fileList) {
+    var file = fileList[key]
+    var match = file.relativePath.match(/sub-(.*?)(?=\/)/)
+    if (match) {
+      addIfNotPresent(folderSubjects, match[1])
     }
-    return folderSubjects;
+  }
+  return folderSubjects
 }
 
 /**
@@ -24,29 +24,34 @@ function getFolderSubjects(fileList) {
  *
  * Takes a list of files and participants with valid data. Checks if they match.
  */
-var checkAnyDataPresent = function checkAnyDataPresent(fileList, summarySubjects) {
-    var issues = [];
-    var folderSubjects = getFolderSubjects(fileList);
+var checkAnyDataPresent = function checkAnyDataPresent(
+  fileList,
+  summarySubjects,
+) {
+  var issues = []
+  var folderSubjects = getFolderSubjects(fileList)
 
-    var subjectsWithoutAnyValidData = folderSubjects.filter(function (i) {
-        return summarySubjects.indexOf(i) < 0;
-    });
+  var subjectsWithoutAnyValidData = folderSubjects.filter(function(i) {
+    return summarySubjects.indexOf(i) < 0
+  })
 
-    for (var i = 0; i < subjectsWithoutAnyValidData.length; i++) {
-        var missingSubject = subjectsWithoutAnyValidData[i];
-        var subFolder = "/sub-" + missingSubject;
-        issues.push(new Issue({
-            file: {
-                relativePath: subFolder,
-                webkitRelativePath: subFolder,
-                name: subFolder,
-                path: subFolder
-            },
-            reason: "No BIDS compatible data found for subject " + missingSubject,
-            code: 67
-        }));
-    }
-    return issues;
-};
+  for (var i = 0; i < subjectsWithoutAnyValidData.length; i++) {
+    var missingSubject = subjectsWithoutAnyValidData[i]
+    var subFolder = '/sub-' + missingSubject
+    issues.push(
+      new Issue({
+        file: {
+          relativePath: subFolder,
+          webkitRelativePath: subFolder,
+          name: subFolder,
+          path: subFolder,
+        },
+        reason: 'No BIDS compatible data found for subject ' + missingSubject,
+        code: 67,
+      }),
+    )
+  }
+  return issues
+}
 
-module.exports = checkAnyDataPresent;
+module.exports = checkAnyDataPresent

--- a/validators/events.js
+++ b/validators/events.js
@@ -1,97 +1,117 @@
 /* eslint-disable no-unused-vars */
-const async = require('async');
-const utils = require('../utils');
-const Issue = utils.issues.Issue;
+const async = require('async')
+const utils = require('../utils')
+const Issue = utils.issues.Issue
 
-const validateEvents = function(events, stimuli, headers, jsonContents, issues) {
-    // check that all stimuli files present in /stimuli are included in an _events.tsv file
-    checkStimuli(stimuli, issues);
+const validateEvents = function(
+  events,
+  stimuli,
+  headers,
+  jsonContents,
+  issues,
+) {
+  // check that all stimuli files present in /stimuli are included in an _events.tsv file
+  checkStimuli(stimuli, issues)
 
-    // check the events file for suspiciously long or short durations
-    checkDesignLength(events, headers, jsonContents, issues);
-};
+  // check the events file for suspiciously long or short durations
+  checkDesignLength(events, headers, jsonContents, issues)
+}
 
-const checkStimuli = function (stimuli, issues) {
-    const stimuliFromEvents = stimuli.events;
-    const stimuliFromDirectory = stimuli.directory;
-    if (stimuliFromDirectory) {
-        const unusedStimuli = stimuliFromDirectory.filter(function(stimuli) {
-            return stimuliFromEvents.indexOf(stimuli.relativePath) < 0;
-        });
-        for (let key in unusedStimuli) {
-            const stimulus = unusedStimuli[key];
-            issues.push(new Issue({
-                code: 77,
-                file: stimulus,
-            }));
-        }
+const checkStimuli = function(stimuli, issues) {
+  const stimuliFromEvents = stimuli.events
+  const stimuliFromDirectory = stimuli.directory
+  if (stimuliFromDirectory) {
+    const unusedStimuli = stimuliFromDirectory.filter(function(stimuli) {
+      return stimuliFromEvents.indexOf(stimuli.relativePath) < 0
+    })
+    for (let key in unusedStimuli) {
+      const stimulus = unusedStimuli[key]
+      issues.push(
+        new Issue({
+          code: 77,
+          file: stimulus,
+        }),
+      )
     }
-    return;
-};
+  }
+  return
+}
 
 const checkDesignLength = function(events, headers, jsonContents, issues) {
-    // get all headers associated with task data
-    var taskHeaders = headers.filter(header => {
-        const file = header[0];
-        return file.relativePath.includes('_task-');
-    });
+  // get all headers associated with task data
+  var taskHeaders = headers.filter(header => {
+    const file = header[0]
+    return file.relativePath.includes('_task-')
+  })
 
-    // loop through headers with files that are tasks
-    async.eachOfLimit(taskHeaders, 200, (taskHeader) => {
+  // loop through headers with files that are tasks
+  async.eachOfLimit(taskHeaders, 200, taskHeader => {
+    // extract the fourth element of 'dim' field of header - this is the
+    // number of volumes that were obtained during scan (numVols)
+    const file = taskHeader[0]
+    const header = taskHeader[1]
+    const dim = header.dim
+    const numVols = dim[4]
 
-        // extract the fourth element of 'dim' field of header - this is the
-        // number of volumes that were obtained during scan (numVols)
-        const file = taskHeader[0];
-        const header = taskHeader[1];
-        const dim = header.dim;
-        const numVols = dim[4];
+    // get the json sidecar dictionary associated with that nifti scan
+    const potentialSidecars = utils.files.potentialLocations(
+      file.relativePath.replace('.gz', '').replace('.nii', '.json'),
+    )
+    const mergedDictionary = utils.files.generateMergedSidecarDict(
+      potentialSidecars,
+      jsonContents,
+    )
 
-        // get the json sidecar dictionary associated with that nifti scan
-        const potentialSidecars = utils.files.potentialLocations(file.relativePath.replace(".gz", "").replace(".nii", ".json"));
-        const mergedDictionary  = utils.files.generateMergedSidecarDict(potentialSidecars, jsonContents);
+    // extract the 'RepetitionTime' field from said sidecar (TR)
+    const TR = mergedDictionary.RepetitionTime
 
-        // extract the 'RepetitionTime' field from said sidecar (TR)
-        const TR = mergedDictionary.RepetitionTime;
+    // calculate max reasonable scan time (TR * numVols = longDurationThreshold)
+    const longDurationThreshold = Math.floor(TR * numVols)
 
-        // calculate max reasonable scan time (TR * numVols = longDurationThreshold)
-        const longDurationThreshold = Math.floor(TR * numVols);
+    // calculate min reasonable scan time (.5 * TR * numVols = shortDurationThreshold)
+    const shortDurationThreshold = Math.floor(0.5 * longDurationThreshold)
 
-        // calculate min reasonable scan time (.5 * TR * numVols = shortDurationThreshold)
-        const shortDurationThreshold = Math.floor(.5 * longDurationThreshold);
+    // get the _events.tsv associated with this task scan
+    const potentialEvents = utils.files.potentialLocations(
+      file.relativePath.replace('.gz', '').replace('bold.nii', 'events.tsv'),
+    )
+    const associatedEvents = events.filter(
+      event => potentialEvents.indexOf(event.path) > -1,
+    )
 
-        // get the _events.tsv associated with this task scan
-        const potentialEvents = utils.files.potentialLocations(file.relativePath.replace(".gz", "").replace("bold.nii", "events.tsv"));
-        const associatedEvents = events.filter(event => potentialEvents.indexOf(event.path) > -1);
+    // loop through all events associated with this task scan
+    for (let event of associatedEvents) {
+      // get all non-empty rows
+      const rows = event.contents
+        .split('\n')
+        .filter(row => !(!row || /^\s*$/.test(row)))
 
-        // loop through all events associated with this task scan
-        for (let event of associatedEvents) {
-            // get all non-empty rows
-            const rows = event.contents.split('\n').filter(row => !(!row || /^\s*$/.test(row)));
+      // get the 'onset' field of the last event (lastEventOnset)
+      const lastEventOnset = rows[rows.length - 1].split('\t')[0]
 
-            // get the 'onset' field of the last event (lastEventOnset)
-            const lastEventOnset = rows[rows.length -1].split('\t')[0];
+      // check if lastEventOnset > longDurationThreshold - append issue if so
+      if (lastEventOnset > longDurationThreshold) {
+        issues.push(
+          new Issue({
+            file: event.file,
+            code: 85,
+          }),
+        )
+      }
 
-            // check if lastEventOnset > longDurationThreshold - append issue if so
-            if (lastEventOnset > longDurationThreshold) {
-                issues.push(new Issue({
-                    file: event.file,
-                    code: 85
-                }));
-            }
-
-            // check if the lastEventOnset < shortDurationThreshold - append issue if so
-            if (lastEventOnset < shortDurationThreshold) {
-                issues.push(new Issue({
-                    file: event.file,
-                    code: 86
-                }));
-            }
-
-   
-        }
-    });
-};
+      // check if the lastEventOnset < shortDurationThreshold - append issue if so
+      if (lastEventOnset < shortDurationThreshold) {
+        issues.push(
+          new Issue({
+            file: event.file,
+            code: 86,
+          }),
+        )
+      }
+    }
+  })
+}
 
 module.exports = {
-    validateEvents: validateEvents,
-};
+  validateEvents: validateEvents,
+}

--- a/validators/headerFields.js
+++ b/validators/headerFields.js
@@ -1,5 +1,5 @@
-var utils = require('../utils');
-var Issue = utils.issues.Issue;
+var utils = require('../utils')
+var Issue = utils.issues.Issue
 
 /**
  * dimensions and resolution
@@ -13,40 +13,39 @@ var Issue = utils.issues.Issue;
  */
 
 var headerFields = function headerFields(headers) {
-    var finalIssues = [];
-    var allIssues39Dict = {};
-    var fields = ['dim', 'pixdim'];
+  var finalIssues = []
+  var allIssues39Dict = {}
+  var fields = ['dim', 'pixdim']
 
-    /* turn a list of dicts into a dict of lists */
-    for (var i = 0; i < fields.length; i++) {
-        var field = fields[i];
-        var issues = headerField(headers, field);
-        for (var file in issues) {
-            if (issues[file].code == 39) {
-                if (allIssues39Dict.hasOwnProperty(file)) {
-                    allIssues39Dict[file].push(issues[file]);
-                } else {
-                    allIssues39Dict[file] = [issues[file]];
-                }
-            } else {
-                finalIssues.push(issues[file]);
-            }
+  /* turn a list of dicts into a dict of lists */
+  for (var i = 0; i < fields.length; i++) {
+    var field = fields[i]
+    var issues = headerField(headers, field)
+    for (var file in issues) {
+      if (issues[file].code == 39) {
+        if (allIssues39Dict.hasOwnProperty(file)) {
+          allIssues39Dict[file].push(issues[file])
+        } else {
+          allIssues39Dict[file] = [issues[file]]
         }
+      } else {
+        finalIssues.push(issues[file])
+      }
     }
+  }
 
-
-    for (file in allIssues39Dict){
-        var firstIssue = allIssues39Dict[file][0];
-        var evidence = '';
-        for (var issue in allIssues39Dict[file]){
-            evidence = evidence + ' ' + allIssues39Dict[file][issue].reason;
-        }
-        firstIssue.reason = evidence;
-        finalIssues.push(firstIssue);
+  for (file in allIssues39Dict) {
+    var firstIssue = allIssues39Dict[file][0]
+    var evidence = ''
+    for (var issue in allIssues39Dict[file]) {
+      evidence = evidence + ' ' + allIssues39Dict[file][issue].reason
     }
+    firstIssue.reason = evidence
+    finalIssues.push(firstIssue)
+  }
 
-    return finalIssues;
-};
+  return finalIssues
+}
 
 /**
  * Key to headerField working is the fact that we take and array of values
@@ -58,142 +57,171 @@ var headerFields = function headerFields(headers) {
  */
 
 var headerField = function headerField(headers, field) {
-    var nifti_types = {};
-    var issues = {};
-    for (var header_index = 0; header_index < headers.length; header_index++) {
-        var badField = false;
-        var field_value;
-        var file = headers[header_index][0];
-        var filename;
-        var header = headers[header_index][1];
-        var match;
-        var path = file.relativePath;
-        var subject;
+  var nifti_types = {}
+  var issues = {}
+  for (var header_index = 0; header_index < headers.length; header_index++) {
+    var badField = false
+    var field_value
+    var file = headers[header_index][0]
+    var filename
+    var header = headers[header_index][1]
+    var match
+    var path = file.relativePath
+    var subject
 
-
-        if (field === 'dim') {
-            if ((typeof header[field]) === 'undefined' || header[field] === null || header[field].length < header[field][0]) {
-                issues[file.relativePath] = new Issue({
-                        file: file,
-                        code: 40
-                });
-                continue;
-            } else if (file.name.indexOf('_bold') > -1 && (header[field][0] !== 4 || header[field].length !== 5)) {
-                issues[file.relativePath] = new Issue({
-                    file: file,
-                    code: 54,
-                    evidence: 'header field "dim" = ' + header[field]
-                });
-                continue;
-            }
-            field_value = header[field].slice(1, header[field][0]+1).toString();
-        } else if (field === 'pixdim') {
-            if ((typeof header['xyzt_units']) === 'undefined' || header['xyzt_units'] === null || header['xyzt_units'].length < 4) {
-                issues[file.relativePath] = new Issue({
-                        file: file,
-                        code: 41
-                });
-                badField = true;
-            }
-            if ((typeof header['pixdim']) === 'undefined' || header['pixdim'] === null || header['pixdim'].length < 4) {
-                issues[file.relativePath] = new Issue({
-                        file: file,
-                        code: 42
-                });
-                badField = true;
-            }
-            if (header['qform_code']===0 && header['sform_code']===0) {
-                issues[file.relativePath] = new Issue({
-                        file: file,
-                        code: 60
-                });
-                badField = true;
-            }
-            if (badField === true) {
-                continue;
-            }
-            field_value = [];
-            var pix_dim = header[field].slice(1,5);
-            var units = header['xyzt_units'].slice(0,4);
-            for (var i = 0; i < pix_dim.length; i++) {
-                field_value.push('' + pix_dim[i].toFixed(2) + units[i]);
-            }
-            field_value = field_value.toString();
-        } else {
-            console.warn("Checks against header field: " + field + " are currently unsupported.");
-            return;
-        }
-
-        if (!file || (typeof window != 'undefined' && !file.webkitRelativePath)) {
-            continue;
-        }
-
-        //match the subject identifier up to the '/' in the full path to a file.
-        match = path.match(/sub-(.*?)(?=\/)/);
-        if (match === null) {
-            continue;
-        } else {
-            subject = match[0];
-        }
-        // files are prepended with subject name, the following two commands
-        // remove the subject from the file name to allow filenames to be more
-        // easily compared
-        filename = path.substring(path.match(subject).index + subject.length);
-        filename = filename.replace(subject, '<sub>');
-
-        // generalize the run number so we can compare counts across all runs
-        match = filename.match(/run-\d+/);
-        if (match !== null) {
-            filename = filename.replace(match[0], '<run>');
-        }
-
-        if (!nifti_types.hasOwnProperty(filename)) {
-            nifti_types[filename] = {};
-            nifti_types[filename][field_value] = {'count': 1, 'files': [file]};
-        } else {
-            if (!nifti_types[filename].hasOwnProperty(field_value)) {
-                nifti_types[filename][field_value] = {'count': 1, 'files': [file]};
-            } else {
-                nifti_types[filename][field_value].count += 1;
-                nifti_types[filename][field_value].files.push(file);
-            }
-        }
+    if (field === 'dim') {
+      if (
+        typeof header[field] === 'undefined' ||
+        header[field] === null ||
+        header[field].length < header[field][0]
+      ) {
+        issues[file.relativePath] = new Issue({
+          file: file,
+          code: 40,
+        })
+        continue
+      } else if (
+        file.name.indexOf('_bold') > -1 &&
+        (header[field][0] !== 4 || header[field].length !== 5)
+      ) {
+        issues[file.relativePath] = new Issue({
+          file: file,
+          code: 54,
+          evidence: 'header field "dim" = ' + header[field],
+        })
+        continue
+      }
+      field_value = header[field].slice(1, header[field][0] + 1).toString()
+    } else if (field === 'pixdim') {
+      if (
+        typeof header['xyzt_units'] === 'undefined' ||
+        header['xyzt_units'] === null ||
+        header['xyzt_units'].length < 4
+      ) {
+        issues[file.relativePath] = new Issue({
+          file: file,
+          code: 41,
+        })
+        badField = true
+      }
+      if (
+        typeof header['pixdim'] === 'undefined' ||
+        header['pixdim'] === null ||
+        header['pixdim'].length < 4
+      ) {
+        issues[file.relativePath] = new Issue({
+          file: file,
+          code: 42,
+        })
+        badField = true
+      }
+      if (header['qform_code'] === 0 && header['sform_code'] === 0) {
+        issues[file.relativePath] = new Issue({
+          file: file,
+          code: 60,
+        })
+        badField = true
+      }
+      if (badField === true) {
+        continue
+      }
+      field_value = []
+      var pix_dim = header[field].slice(1, 5)
+      var units = header['xyzt_units'].slice(0, 4)
+      for (var i = 0; i < pix_dim.length; i++) {
+        field_value.push('' + pix_dim[i].toFixed(2) + units[i])
+      }
+      field_value = field_value.toString()
+    } else {
+      console.warn(
+        'Checks against header field: ' + field + ' are currently unsupported.',
+      )
+      return
     }
-    for (var nifti_key in nifti_types) {
-        var nifti_type = nifti_types[nifti_key];
-        var max_field_value = Object.keys(nifti_type)[0];
-        for (var field_value_key in nifti_type) {
-            field_value = nifti_type[field_value_key];
-            if (field_value.count > nifti_type[max_field_value].count) {
-                max_field_value = field_value_key;
-            }
-        }
-        for (field_value_key in nifti_type) {
-            field_value = nifti_type[field_value_key];
-            if (max_field_value !== field_value_key && headerFieldCompare(max_field_value, field_value_key)) {
-                for (var nifti_file_index = 0; nifti_file_index < field_value.files.length; nifti_file_index++) {
-                    var nifti_file = field_value.files[nifti_file_index];
-                    var evidence;
-                    if (field === 'dim') {
-                        evidence = "The most common set of dimensions is: " +
-                                  max_field_value + " (voxels), This file has the dimensions: " +
-                                  field_value_key + " (voxels).";
-                    } else if (field === 'pixdim') {
-                        evidence = "The most common resolution is: " +
-                                  max_field_value.replace(/,/g, ' x ') + ", This file has the resolution: " +
-                                  field_value_key.replace(/,/g, ' x ') + ".";
-                    }
-                        issues[nifti_file.relativePath] = new Issue({
-                            file: nifti_file,
-                            reason: evidence,
-                            code: 39
-                        });
-                }
-            }
-        }
+
+    if (!file || (typeof window != 'undefined' && !file.webkitRelativePath)) {
+      continue
     }
-    return issues;
-};
+
+    //match the subject identifier up to the '/' in the full path to a file.
+    match = path.match(/sub-(.*?)(?=\/)/)
+    if (match === null) {
+      continue
+    } else {
+      subject = match[0]
+    }
+    // files are prepended with subject name, the following two commands
+    // remove the subject from the file name to allow filenames to be more
+    // easily compared
+    filename = path.substring(path.match(subject).index + subject.length)
+    filename = filename.replace(subject, '<sub>')
+
+    // generalize the run number so we can compare counts across all runs
+    match = filename.match(/run-\d+/)
+    if (match !== null) {
+      filename = filename.replace(match[0], '<run>')
+    }
+
+    if (!nifti_types.hasOwnProperty(filename)) {
+      nifti_types[filename] = {}
+      nifti_types[filename][field_value] = { count: 1, files: [file] }
+    } else {
+      if (!nifti_types[filename].hasOwnProperty(field_value)) {
+        nifti_types[filename][field_value] = { count: 1, files: [file] }
+      } else {
+        nifti_types[filename][field_value].count += 1
+        nifti_types[filename][field_value].files.push(file)
+      }
+    }
+  }
+  for (var nifti_key in nifti_types) {
+    var nifti_type = nifti_types[nifti_key]
+    var max_field_value = Object.keys(nifti_type)[0]
+    for (var field_value_key in nifti_type) {
+      field_value = nifti_type[field_value_key]
+      if (field_value.count > nifti_type[max_field_value].count) {
+        max_field_value = field_value_key
+      }
+    }
+    for (field_value_key in nifti_type) {
+      field_value = nifti_type[field_value_key]
+      if (
+        max_field_value !== field_value_key &&
+        headerFieldCompare(max_field_value, field_value_key)
+      ) {
+        for (
+          var nifti_file_index = 0;
+          nifti_file_index < field_value.files.length;
+          nifti_file_index++
+        ) {
+          var nifti_file = field_value.files[nifti_file_index]
+          var evidence
+          if (field === 'dim') {
+            evidence =
+              'The most common set of dimensions is: ' +
+              max_field_value +
+              ' (voxels), This file has the dimensions: ' +
+              field_value_key +
+              ' (voxels).'
+          } else if (field === 'pixdim') {
+            evidence =
+              'The most common resolution is: ' +
+              max_field_value.replace(/,/g, ' x ') +
+              ', This file has the resolution: ' +
+              field_value_key.replace(/,/g, ' x ') +
+              '.'
+          }
+          issues[nifti_file.relativePath] = new Issue({
+            file: nifti_file,
+            reason: evidence,
+            code: 39,
+          })
+        }
+      }
+    }
+  }
+  return issues
+}
 
 /**
  * if elements of the two arrays differ by less than one we won't raise a
@@ -202,23 +230,25 @@ var headerField = function headerField(headers, field) {
  * the two headers are signifigantly different
  */
 function headerFieldCompare(header1, header2) {
-    var hdr1 = header1.split(',');
-    var hdr2 = header2.split(',');
-    if (hdr1.length !== hdr2.length) {return true;}
-    for (var i = 0; i < hdr1.length; i++) {
-        var hdr1_val = Number(hdr1[i].match(/-?\d*\.?\d*/));
-        var hdr2_val  = Number(hdr2[i].match(/-?\d*\.?\d*/));
-        // Matching alphas with * will return '' on headers without units
-        var hdr1_unit = hdr1[i].match(/[A-Za-z]*$/)[0];
-        var hdr2_unit = hdr2[i].match(/[A-Za-z]*$/)[0];
-        if (Math.abs(hdr1_val - hdr2_val) > .00001) {
-            return true;
-        }
-        if (hdr1_unit !== hdr2_unit) {
-            return true;
-        }
+  var hdr1 = header1.split(',')
+  var hdr2 = header2.split(',')
+  if (hdr1.length !== hdr2.length) {
+    return true
+  }
+  for (var i = 0; i < hdr1.length; i++) {
+    var hdr1_val = Number(hdr1[i].match(/-?\d*\.?\d*/))
+    var hdr2_val = Number(hdr2[i].match(/-?\d*\.?\d*/))
+    // Matching alphas with * will return '' on headers without units
+    var hdr1_unit = hdr1[i].match(/[A-Za-z]*$/)[0]
+    var hdr2_unit = hdr2[i].match(/[A-Za-z]*$/)[0]
+    if (Math.abs(hdr1_val - hdr2_val) > 0.00001) {
+      return true
     }
-    return false;
+    if (hdr1_unit !== hdr2_unit) {
+      return true
+    }
+  }
+  return false
 }
 
-module.exports = headerFields;
+module.exports = headerFields

--- a/validators/index.js
+++ b/validators/index.js
@@ -1,27 +1,27 @@
 // dependencies ------------------------------------------------------
 
-var TSV    = require('./tsv');
-var JSON   = require('./json');
-var NIFTI  = require('./nii');
-var BIDS   = require('./bids').start;
-var Events = require('./events');
-var bval   = require('./bval');
-var bvec   = require('./bvec');
-var utils  = require('../utils');
+var TSV = require('./tsv')
+var JSON = require('./json')
+var NIFTI = require('./nii')
+var BIDS = require('./bids').start
+var Events = require('./events')
+var bval = require('./bval')
+var bvec = require('./bvec')
+var utils = require('../utils')
 
 // public api --------------------------------------------------------
 
 var validate = {
-	BIDS: BIDS,
-	JSON: JSON,
-	TSV: TSV,
-	NIFTI: NIFTI,
-	Events: Events,
-	bval: bval,
-	bvec: bvec,
-	reformat: utils.issues.reformat
-};
+  BIDS: BIDS,
+  JSON: JSON,
+  TSV: TSV,
+  NIFTI: NIFTI,
+  Events: Events,
+  bval: bval,
+  bvec: bvec,
+  reformat: utils.issues.reformat,
+}
 
 // exports -----------------------------------------------------------
 
-module.exports = validate;
+module.exports = validate

--- a/validators/json.js
+++ b/validators/json.js
@@ -1,8 +1,8 @@
-var utils = require('../utils');
-var Ajv = require('ajv');
-var ajv = new Ajv({allErrors: true});
-ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-06.json'));
-var Issue = utils.issues.Issue;
+var utils = require('../utils')
+var Ajv = require('ajv')
+var ajv = new Ajv({ allErrors: true })
+ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-06.json'))
+var Issue = utils.issues.Issue
 
 /**
  * JSON
@@ -12,89 +12,116 @@ var Issue = utils.issues.Issue;
  * it finds while validating against the BIDS
  * specification.
  */
-module.exports = function (file, contents, callback) {
+module.exports = function(file, contents, callback) {
+  // primary flow --------------------------------------------------------------------
 
-// primary flow --------------------------------------------------------------------
+  var issues = []
 
-    var issues = [];
-
-    utils.json.parse(file, contents, function (pissues, jsObj) {
-        issues = pissues;
-        if (jsObj) {issues = issues.concat(checkUnits(file, jsObj));}
-        callback(issues, jsObj);
-    });
-
-};
+  utils.json.parse(file, contents, function(pissues, jsObj) {
+    issues = pissues
+    if (jsObj) {
+      issues = issues.concat(checkUnits(file, jsObj))
+    }
+    callback(issues, jsObj)
+  })
+}
 
 // individual checks ---------------------------------------------------------------
 
-function checkUnits (file, sidecar) {
-    var issues = [];
-    var schema = null;
+function checkUnits(file, sidecar) {
+  var issues = []
+  var schema = null
 
-    if (file.name) {
-        if (file.name.endsWith("participants.json")) {
-            schema = require('./schemas/data_dictionary.json');
-        } else if (file.name.endsWith("bold.json") || file.name.endsWith("sbref.json")) {
-            schema = require('./schemas/bold.json');
-        } else if (file.relativePath === "/dataset_description.json") {
-            schema = require('./schemas/dataset_description.json');
-        } else if (file.name.endsWith("meg.json")) {
-            schema = require('./schemas/meg.json');
-        } else if (file.name.endsWith("ieeg.json")) {
-            schema = require('./schemas/ieeg.json');
-        } else if (file.relativePath.includes('/meg/') && file.name.endsWith("coordsystem.json")) {
-            schema = require('./schemas/coordsystem_meg.json');
-        } else if (file.relativePath.includes('/ieeg/') && file.name.endsWith("coordsystem.json")) {
-            schema = require('./schemas/coordsystem_ieeg.json');
-        } else if (file.name.endsWith("eeg.json")) {
-            schema = require('./schemas/eeg.json');
+  if (file.name) {
+    if (file.name.endsWith('participants.json')) {
+      schema = require('./schemas/data_dictionary.json')
+    } else if (
+      file.name.endsWith('bold.json') ||
+      file.name.endsWith('sbref.json')
+    ) {
+      schema = require('./schemas/bold.json')
+    } else if (file.relativePath === '/dataset_description.json') {
+      schema = require('./schemas/dataset_description.json')
+    } else if (file.name.endsWith('meg.json')) {
+      schema = require('./schemas/meg.json')
+    } else if (file.name.endsWith('ieeg.json')) {
+      schema = require('./schemas/ieeg.json')
+    } else if (
+      file.relativePath.includes('/meg/') &&
+      file.name.endsWith('coordsystem.json')
+    ) {
+      schema = require('./schemas/coordsystem_meg.json')
+    } else if (
+      file.relativePath.includes('/ieeg/') &&
+      file.name.endsWith('coordsystem.json')
+    ) {
+      schema = require('./schemas/coordsystem_ieeg.json')
+    } else if (file.name.endsWith('eeg.json')) {
+      schema = require('./schemas/eeg.json')
+    }
+    if (schema) {
+      var validate = ajv.compile(schema)
+      var valid = validate(sidecar)
+      if (!valid) {
+        for (var i = 0; i < validate.errors.length; i++) {
+          issues.push(
+            new Issue({
+              file: file,
+              code: 55,
+              evidence:
+                validate.errors[i].dataPath + ' ' + validate.errors[i].message,
+            }),
+          )
         }
-        if (schema) {
-            var validate = ajv.compile(schema);
-            var valid = validate(sidecar);
-            if (!valid) {
-                for (var i = 0; i < validate.errors.length; i++) {
-                    issues.push(new Issue({
-                        file: file,
-                        code: 55,
-                        evidence: validate.errors[i].dataPath + ' ' + validate.errors[i].message
-                    }));
-                }
-            }
-        }
+      }
     }
+  }
 
-
-    if (sidecar.hasOwnProperty('RepetitionTime') && sidecar["RepetitionTime"] > 100) {
-        issues.push(new Issue({
-            file: file,
-            code: 2
-        }));
-    }
-    if (sidecar.hasOwnProperty('EchoTime') && sidecar["EchoTime"] > 1) {
-        issues.push(new Issue({
-            file: file,
-            code: 3
-        }));
-    }
-    if (sidecar.hasOwnProperty('EchoTime1') && sidecar["EchoTime1"] > 1) {
-        issues.push(new Issue({
-            file: file,
-            code: 4
-        }));
-    }
-    if (sidecar.hasOwnProperty('EchoTime2') && sidecar["EchoTime2"] > 1) {
-        issues.push(new Issue({
-            file: file,
-            code: 4
-        }));
-    }
-    if (sidecar.hasOwnProperty('TotalReadoutTime') && sidecar["TotalReadoutTime"] > 10) {
-        issues.push(new Issue({
-            file: file,
-            code: 5
-        }));
-    }
-    return issues;
+  if (
+    sidecar.hasOwnProperty('RepetitionTime') &&
+    sidecar['RepetitionTime'] > 100
+  ) {
+    issues.push(
+      new Issue({
+        file: file,
+        code: 2,
+      }),
+    )
+  }
+  if (sidecar.hasOwnProperty('EchoTime') && sidecar['EchoTime'] > 1) {
+    issues.push(
+      new Issue({
+        file: file,
+        code: 3,
+      }),
+    )
+  }
+  if (sidecar.hasOwnProperty('EchoTime1') && sidecar['EchoTime1'] > 1) {
+    issues.push(
+      new Issue({
+        file: file,
+        code: 4,
+      }),
+    )
+  }
+  if (sidecar.hasOwnProperty('EchoTime2') && sidecar['EchoTime2'] > 1) {
+    issues.push(
+      new Issue({
+        file: file,
+        code: 4,
+      }),
+    )
+  }
+  if (
+    sidecar.hasOwnProperty('TotalReadoutTime') &&
+    sidecar['TotalReadoutTime'] > 10
+  ) {
+    issues.push(
+      new Issue({
+        file: file,
+        code: 5,
+      }),
+    )
+  }
+  return issues
 }

--- a/validators/nii.js
+++ b/validators/nii.js
@@ -1,5 +1,5 @@
-var utils = require('../utils');
-var Issue = utils.issues.Issue;
+var utils = require('../utils')
+var Issue = utils.issues.Issue
 
 /**
  * NIFTI
@@ -9,326 +9,503 @@ var Issue = utils.issues.Issue;
  * it finds while validating against the BIDS
  * specification.
  */
-module.exports = function NIFTI (header, file, jsonContentsDict, bContentsDict, fileList, events, callback) {
-    var path = file.relativePath;
-    var issues = [];
-    var potentialSidecars = utils.files.potentialLocations(path.replace(".gz", "").replace(".nii", ".json"));
-    var potentialEvents   = utils.files.potentialLocations(path.replace(".gz", "").replace("bold.nii", "events.tsv"));
-    var mergedDictionary  = utils.files.generateMergedSidecarDict(potentialSidecars, jsonContentsDict);
-    var sidecarMessage    = "It can be included one of the following locations: " + potentialSidecars.join(", ");
-    var eventsMessage     = "It can be included one of the following locations: " + potentialEvents.join(", ");
+module.exports = function NIFTI(
+  header,
+  file,
+  jsonContentsDict,
+  bContentsDict,
+  fileList,
+  events,
+  callback,
+) {
+  var path = file.relativePath
+  var issues = []
+  var potentialSidecars = utils.files.potentialLocations(
+    path.replace('.gz', '').replace('.nii', '.json'),
+  )
+  var potentialEvents = utils.files.potentialLocations(
+    path.replace('.gz', '').replace('bold.nii', 'events.tsv'),
+  )
+  var mergedDictionary = utils.files.generateMergedSidecarDict(
+    potentialSidecars,
+    jsonContentsDict,
+  )
+  var sidecarMessage =
+    'It can be included one of the following locations: ' +
+    potentialSidecars.join(', ')
+  var eventsMessage =
+    'It can be included one of the following locations: ' +
+    potentialEvents.join(', ')
 
-    if (path.includes('_dwi.nii')) {
-        var potentialBvecs = utils.files.potentialLocations(path.replace(".gz", "").replace(".nii", ".bvec"));
-        var potentialBvals = utils.files.potentialLocations(path.replace(".gz", "").replace(".nii", ".bval"));
-        var bvec = utils.files.getBFileContent(potentialBvecs, bContentsDict);
-        var bval = utils.files.getBFileContent(potentialBvals, bContentsDict);
-        var bvecMessage = "It can be included in one of the following locations: " + potentialBvecs.join(", ");
-        var bvalMessage = "It can be included in one of the following locations: " + potentialBvals.join(", ");
+  if (path.includes('_dwi.nii')) {
+    var potentialBvecs = utils.files.potentialLocations(
+      path.replace('.gz', '').replace('.nii', '.bvec'),
+    )
+    var potentialBvals = utils.files.potentialLocations(
+      path.replace('.gz', '').replace('.nii', '.bval'),
+    )
+    var bvec = utils.files.getBFileContent(potentialBvecs, bContentsDict)
+    var bval = utils.files.getBFileContent(potentialBvals, bContentsDict)
+    var bvecMessage =
+      'It can be included in one of the following locations: ' +
+      potentialBvecs.join(', ')
+    var bvalMessage =
+      'It can be included in one of the following locations: ' +
+      potentialBvals.join(', ')
 
-        if (!bvec) {
-            issues.push(new Issue({
-                code: 32,
-                file: file,
-                reason: '_dwi scans should have a corresponding .bvec file. ' + bvecMessage
-            }));
-        }
-        if (!bval) {
-            issues.push(new Issue({
-                code: 33,
-                file: file,
-                reason: '_dwi scans should have a corresponding .bval file. ' + bvalMessage
-            }));
-        }
+    if (!bvec) {
+      issues.push(
+        new Issue({
+          code: 32,
+          file: file,
+          reason:
+            '_dwi scans should have a corresponding .bvec file. ' + bvecMessage,
+        }),
+      )
+    }
+    if (!bval) {
+      issues.push(
+        new Issue({
+          code: 33,
+          file: file,
+          reason:
+            '_dwi scans should have a corresponding .bval file. ' + bvalMessage,
+        }),
+      )
+    }
 
-        if (bval && bvec && header){
-        /*
+    if (bval && bvec && header) {
+      /*
         bvec length ==3 is checked at bvec.spec.js hence following if loop doesnot have else block
         */
-            if (bvec.replace(/^\s+|\s+$/g, '').split('\n').length === 3){
-              var volumes = [
-                  bvec.split('\n')[0].replace(/^\s+|\s+$/g, '').split(' ').length, // bvec row 1 length
-                  bvec.split('\n')[1].replace(/^\s+|\s+$/g, '').split(' ').length, // bvec row 2 length
-                  bvec.split('\n')[2].replace(/^\s+|\s+$/g, '').split(' ').length, // bvec row 3 length
-                  bval.replace(/^\s+|\s+$/g, '').split(' ').length,                // bval row length
-                  header.dim[4]                                                    // header 4th dimension
-              ];
+      if (bvec.replace(/^\s+|\s+$/g, '').split('\n').length === 3) {
+        var volumes = [
+          bvec
+            .split('\n')[0]
+            .replace(/^\s+|\s+$/g, '')
+            .split(' ').length, // bvec row 1 length
+          bvec
+            .split('\n')[1]
+            .replace(/^\s+|\s+$/g, '')
+            .split(' ').length, // bvec row 2 length
+          bvec
+            .split('\n')[2]
+            .replace(/^\s+|\s+$/g, '')
+            .split(' ').length, // bvec row 3 length
+          bval.replace(/^\s+|\s+$/g, '').split(' ').length, // bval row length
+          header.dim[4], // header 4th dimension
+        ]
 
-              if (!volumes.every(function(v) { return v === volumes[0]; })) {
-                  issues.push(new Issue({
-                      code: 29,
-                      file: file
-                  }));
-              }
-            }
-          }
+        if (
+          !volumes.every(function(v) {
+            return v === volumes[0]
+          })
+        ) {
+          issues.push(
+            new Issue({
+              code: 29,
+              file: file,
+            }),
+          )
+        }
+      }
     }
+  }
 
-    if (missingEvents(path, potentialEvents, events)) {
-        issues.push(new Issue({
-            code: 25,
+  if (missingEvents(path, potentialEvents, events)) {
+    issues.push(
+      new Issue({
+        code: 25,
+        file: file,
+        reason:
+          'Task scans should have a corresponding events.tsv file. ' +
+          eventsMessage,
+      }),
+    )
+  }
+
+  if (header) {
+    // Define repetition time from header and coerce to seconds.
+    var repetitionTime = header.pixdim[4]
+    var repetitionUnit =
+      header.xyzt_units && header.xyzt_units[3] ? header.xyzt_units[3] : null
+    if (repetitionUnit === 'ms') {
+      repetitionTime = repetitionTime / 1000
+      repetitionUnit = 's'
+    }
+    if (repetitionUnit === 'us') {
+      repetitionTime = repetitionTime / 1000000
+      repetitionUnit = 's'
+    }
+  }
+
+  if (!mergedDictionary.invalid) {
+    // task scan checks
+    if (
+      path.includes('_task-') &&
+      !path.includes('_defacemask.nii') &&
+      !path.includes('_sbref.nii')
+    ) {
+      if (!mergedDictionary.hasOwnProperty('TaskName')) {
+        issues.push(
+          new Issue({
             file: file,
-            reason: 'Task scans should have a corresponding events.tsv file. ' + eventsMessage
-        }));
+            code: 50,
+            reason:
+              "You have to define 'TaskName' for this file. " + sidecarMessage,
+          }),
+        )
+      }
     }
 
-    if (header) {
-        // Define repetition time from header and coerce to seconds.
-        var repetitionTime = header.pixdim[4];
-        var repetitionUnit = header.xyzt_units && header.xyzt_units[3] ? header.xyzt_units[3] : null;
-        if (repetitionUnit === 'ms') {repetitionTime = repetitionTime / 1000;    repetitionUnit = 's';}
-        if (repetitionUnit === 'us') {repetitionTime = repetitionTime / 1000000; repetitionUnit = 's';}
+    // field map checks
+    if (
+      path.includes('_bold.nii') ||
+      path.includes('_sbref.nii') ||
+      path.includes('_dwi.nii')
+    ) {
+      if (!mergedDictionary.hasOwnProperty('EchoTime')) {
+        issues.push(
+          new Issue({
+            file: file,
+            code: 6,
+            reason:
+              "You should define 'EchoTime' for this file. If you don't provide this information field map correction will not be possible. " +
+              sidecarMessage,
+          }),
+        )
+      }
+      if (!mergedDictionary.hasOwnProperty('PhaseEncodingDirection')) {
+        issues.push(
+          new Issue({
+            file: file,
+            code: 7,
+            reason:
+              "You should define 'PhaseEncodingDirection' for this file. If you don't provide this information field map correction will not be possible. " +
+              sidecarMessage,
+          }),
+        )
+      }
+      if (!mergedDictionary.hasOwnProperty('EffectiveEchoSpacing')) {
+        issues.push(
+          new Issue({
+            file: file,
+            code: 8,
+            reason:
+              "You should define 'EffectiveEchoSpacing' for this file. If you don't provide this information field map correction will not be possible. " +
+              sidecarMessage,
+          }),
+        )
+      }
+    }
+    if (path.includes('_dwi.nii')) {
+      if (!mergedDictionary.hasOwnProperty('TotalReadoutTime')) {
+        issues.push(
+          new Issue({
+            file: file,
+            code: 9,
+            reason:
+              "You should define 'TotalReadoutTime' for this file. If you don't provide this information field map correction using TOPUP might not be possible. " +
+              sidecarMessage,
+          }),
+        )
+      }
     }
 
-    if (!mergedDictionary.invalid) {
-
-        // task scan checks
-        if (path.includes('_task-') && !path.includes('_defacemask.nii') && !path.includes('_sbref.nii')) {
-            if (!mergedDictionary.hasOwnProperty('TaskName')) {
-                issues.push(new Issue({
-                    file: file,
-                    code: 50,
-                    reason: "You have to define 'TaskName' for this file. " + sidecarMessage
-                }));
-            }
+    // we don't need slice timing or repetition time for SBref
+    if (path.includes('_bold.nii')) {
+      if (!mergedDictionary.hasOwnProperty('RepetitionTime')) {
+        issues.push(
+          new Issue({
+            file: file,
+            code: 10,
+            reason:
+              "You have to define 'RepetitionTime' for this file. " +
+              sidecarMessage,
+          }),
+        )
+      } else if (
+        header &&
+        mergedDictionary.EffectiveEchoSpacing &&
+        mergedDictionary.PhaseEncodingDirection
+      ) {
+        var axes = { i: 0, j: 1, k: 2 }
+        if (
+          mergedDictionary.EffectiveEchoSpacing *
+            header.dim[axes[mergedDictionary.PhaseEncodingDirection[0]]] >
+          mergedDictionary.RepetitionTime
+        ) {
+          issues.push(
+            new Issue({
+              file: file,
+              code: 76,
+              reason:
+                "Abnormally high value of 'EffectiveEchoSpacing' (" +
+                mergedDictionary.EffectiveEchoSpacing +
+                ' seconds).',
+            }),
+          )
         }
+      }
 
-        // field map checks
-        if (path.includes("_bold.nii") || path.includes("_sbref.nii") || path.includes("_dwi.nii")) {
-            if (!mergedDictionary.hasOwnProperty('EchoTime')) {
-                issues.push(new Issue({
-                    file: file,
-                    code: 6,
-                    reason: "You should define 'EchoTime' for this file. If you don't provide this information field map correction will not be possible. " + sidecarMessage
-                }));
-            }
-            if (!mergedDictionary.hasOwnProperty('PhaseEncodingDirection')) {
-                issues.push(new Issue({
-                    file: file,
-                    code: 7,
-                    reason: "You should define 'PhaseEncodingDirection' for this file. If you don't provide this information field map correction will not be possible. " + sidecarMessage
-                }));
-            }
-            if (!mergedDictionary.hasOwnProperty('EffectiveEchoSpacing')) {
-                issues.push(new Issue({
-                    file: file,
-                    code: 8,
-                    reason: "You should define 'EffectiveEchoSpacing' for this file. If you don't provide this information field map correction will not be possible. " + sidecarMessage
-                }));
-            }
+      if (typeof repetitionTime === 'undefined' && header) {
+        issues.push(
+          new Issue({
+            file: file,
+            code: 75,
+          }),
+        )
+      } else if (mergedDictionary.RepetitionTime && header) {
+        if (repetitionUnit !== 's') {
+          issues.push(
+            new Issue({
+              file: file,
+              code: 11,
+            }),
+          )
+        } else {
+          var niftiTR = Number(repetitionTime.toFixed(3))
+          var jsonTR = Number(mergedDictionary.RepetitionTime.toFixed(3))
+          if (niftiTR !== jsonTR) {
+            issues.push(
+              new Issue({
+                file: file,
+                code: 12,
+                reason:
+                  'Repetition time defined in the JSON (' +
+                  jsonTR +
+                  ' sec.) did not match the one defined in the NIFTI header (' +
+                  niftiTR +
+                  ' sec.)',
+              }),
+            )
+          }
         }
-        if (path.includes("_dwi.nii")) {
-            if (!mergedDictionary.hasOwnProperty('TotalReadoutTime')) {
-                issues.push(new Issue({
-                    file: file,
-                    code: 9,
-                    reason: "You should define 'TotalReadoutTime' for this file. If you don't provide this information field map correction using TOPUP might not be possible. " + sidecarMessage
-                }));
-            }
+      }
+
+      // check that slice timing is defined
+      if (!mergedDictionary.hasOwnProperty('SliceTiming')) {
+        issues.push(
+          new Issue({
+            file: file,
+            code: 13,
+            reason:
+              "You should define 'SliceTiming' for this file. If you don't provide this information slice time correction will not be possible. " +
+              sidecarMessage,
+          }),
+        )
+      }
+
+      // check that slice timing has the proper length
+      if (
+        header &&
+        mergedDictionary.hasOwnProperty('SliceTiming') &&
+        mergedDictionary['SliceTiming'].constructor === Array
+      ) {
+        var sliceTimingArray = mergedDictionary['SliceTiming']
+        var kDim = header.dim[3]
+        if (sliceTimingArray.length !== kDim) {
+          issues.push(
+            new Issue({
+              file: file,
+              code: 87,
+              evidence:
+                'SliceTiming array is of length ' +
+                sliceTimingArray.length +
+                " and the value of the 'k' dimension is " +
+                kDim +
+                ' for the corresponding nifti header.',
+            }),
+          )
         }
+      }
 
-        // we don't need slice timing or repetition time for SBref
-        if (path.includes("_bold.nii")) {
-            if (!mergedDictionary.hasOwnProperty('RepetitionTime')) {
-                issues.push(new Issue({
-                    file: file,
-                    code: 10,
-                    reason: "You have to define 'RepetitionTime' for this file. " + sidecarMessage
-                }));
-            } else if (header && mergedDictionary.EffectiveEchoSpacing && mergedDictionary.PhaseEncodingDirection) {
-                var axes = { i:0, j:1, k:2 };
-                if (mergedDictionary.EffectiveEchoSpacing * header.dim[axes[mergedDictionary.PhaseEncodingDirection[0]]] > mergedDictionary.RepetitionTime){
-                    issues.push(new Issue({
-                        file: file,
-                        code: 76,
-                        reason: "Abnormally high value of 'EffectiveEchoSpacing' (" + mergedDictionary.EffectiveEchoSpacing + " seconds)."
-                    }));
-                }
-            }
-
-            if (typeof repetitionTime === 'undefined' && header) {
-                issues.push(new Issue({
-                    file: file,
-                    code: 75
-                }));
-            }
-            else if (mergedDictionary.RepetitionTime && header) {
-                if (repetitionUnit !== 's') {
-                    issues.push(new Issue({
-                        file: file,
-                        code: 11
-                    }));
-                } else {
-                    var niftiTR = Number((repetitionTime).toFixed(3));
-                    var jsonTR = Number((mergedDictionary.RepetitionTime).toFixed(3));
-                    if (niftiTR !== jsonTR) {
-                        issues.push(new Issue({
-                            file: file,
-                            code: 12,
-                            reason: "Repetition time defined in the JSON (" + jsonTR + " sec.) did not match the one defined in the NIFTI header (" + niftiTR + " sec.)"
-                        }));
-                    }
-                }
-            }
-
-            // check that slice timing is defined
-            if (!mergedDictionary.hasOwnProperty('SliceTiming')) {
-                issues.push(new Issue({
-                    file: file,
-                    code: 13,
-                    reason: "You should define 'SliceTiming' for this file. If you don't provide this information slice time correction will not be possible. " + sidecarMessage
-                }));
-            }
-
-            // check that slice timing has the proper length
-            if (header && mergedDictionary.hasOwnProperty('SliceTiming') && mergedDictionary["SliceTiming"].constructor === Array) {
-                var sliceTimingArray = mergedDictionary['SliceTiming'];
-                var kDim = header.dim[3];
-                if (sliceTimingArray.length !== kDim) {
-                    issues.push(new Issue({
-                        file: file,
-                        code: 87,
-                        evidence: "SliceTiming array is of length " + sliceTimingArray.length + " and the value of the 'k' dimension is " + kDim + " for the corresponding nifti header."
-                    }));
-                }
-            }
-
-            // check that slice timing values are greater than repetition time
-            if (mergedDictionary.hasOwnProperty('SliceTiming') && mergedDictionary["SliceTiming"].constructor === Array) {
-                var SliceTimingArray = mergedDictionary["SliceTiming"];
-                var valuesGreaterThanRepetitionTime = sliceTimingGreaterThanRepetitionTime(SliceTimingArray, mergedDictionary['RepetitionTime']);
-                if (valuesGreaterThanRepetitionTime.length > 0){
-                    issues.push(new Issue({
-                        file: file,
-                        code: 66,
-                        evidence: valuesGreaterThanRepetitionTime
-                    }));
-                }
-            }
+      // check that slice timing values are greater than repetition time
+      if (
+        mergedDictionary.hasOwnProperty('SliceTiming') &&
+        mergedDictionary['SliceTiming'].constructor === Array
+      ) {
+        var SliceTimingArray = mergedDictionary['SliceTiming']
+        var valuesGreaterThanRepetitionTime = sliceTimingGreaterThanRepetitionTime(
+          SliceTimingArray,
+          mergedDictionary['RepetitionTime'],
+        )
+        if (valuesGreaterThanRepetitionTime.length > 0) {
+          issues.push(
+            new Issue({
+              file: file,
+              code: 66,
+              evidence: valuesGreaterThanRepetitionTime,
+            }),
+          )
         }
-        else if (path.includes("_phasediff.nii")){
-            if (!mergedDictionary.hasOwnProperty('EchoTime1') || !mergedDictionary.hasOwnProperty('EchoTime2')) {
-                issues.push(new Issue({
-                    file: file,
-                    code: 15,
-                    reason: "You have to define 'EchoTime1' and 'EchoTime2' for this file. " + sidecarMessage
-                }));
-            }
-            if (mergedDictionary.hasOwnProperty('EchoTime1') && mergedDictionary.hasOwnProperty('EchoTime2')) {
-                const echoTimeDifference = mergedDictionary['EchoTime2'] - mergedDictionary['EchoTime1'];
-                if (echoTimeDifference < 0.0001 || echoTimeDifference > 0.01) {
-                    issues.push(new Issue({
-                        file: file,
-                        code: 83,
-                        reason: "The value of (EchoTime2 - EchoTime1) should be within the range of 0.0001 - 0.01. " + sidecarMessage
-                    }));
-                }
-            }
-        } else if (path.includes("_phase1.nii") || path.includes("_phase2.nii")){
-            if (!mergedDictionary.hasOwnProperty('EchoTime')) {
-                issues.push(new Issue({
-                    file: file,
-                    code:16,
-                    reason: "You have to define 'EchoTime' for this file. " + sidecarMessage
-                }));
-            }
-        } else if (path.includes("_fieldmap.nii")){
-            if (!mergedDictionary.hasOwnProperty('Units')) {
-                issues.push(new Issue({
-                    file: file,
-                    code: 17,
-                    reason: "You have to define 'Units' for this file. " + sidecarMessage
-                }));
-            }
-        } else if (path.includes("_epi.nii")){
-            if (!mergedDictionary.hasOwnProperty('PhaseEncodingDirection')) {
-                issues.push(new Issue({
-                    file: file,
-                    code: 18,
-                    reason: "You have to define 'PhaseEncodingDirection' for this file. " + sidecarMessage
-                }));
-            }
-            if (!mergedDictionary.hasOwnProperty('TotalReadoutTime')) {
-                issues.push(new Issue({
-                    file: file,
-                    code: 19,
-                    reason: "You have to define 'TotalReadoutTime' for this file. " + sidecarMessage
-                }));
-            }
+      }
+    } else if (path.includes('_phasediff.nii')) {
+      if (
+        !mergedDictionary.hasOwnProperty('EchoTime1') ||
+        !mergedDictionary.hasOwnProperty('EchoTime2')
+      ) {
+        issues.push(
+          new Issue({
+            file: file,
+            code: 15,
+            reason:
+              "You have to define 'EchoTime1' and 'EchoTime2' for this file. " +
+              sidecarMessage,
+          }),
+        )
+      }
+      if (
+        mergedDictionary.hasOwnProperty('EchoTime1') &&
+        mergedDictionary.hasOwnProperty('EchoTime2')
+      ) {
+        const echoTimeDifference =
+          mergedDictionary['EchoTime2'] - mergedDictionary['EchoTime1']
+        if (echoTimeDifference < 0.0001 || echoTimeDifference > 0.01) {
+          issues.push(
+            new Issue({
+              file: file,
+              code: 83,
+              reason:
+                'The value of (EchoTime2 - EchoTime1) should be within the range of 0.0001 - 0.01. ' +
+                sidecarMessage,
+            }),
+          )
         }
-
-        if (utils.type.isFieldMapMainNii(path) && mergedDictionary.hasOwnProperty('IntendedFor')) {
-            var intendedFor = typeof mergedDictionary['IntendedFor'] == "string" ? [mergedDictionary['IntendedFor']] : mergedDictionary['IntendedFor'];
-
-            for (var key = 0; key < intendedFor.length; key++) {
-                var intendedForFile = intendedFor[key];
-                checkIfIntendedExists(intendedForFile, fileList, issues, file);
-            }
-        }
+      }
+    } else if (path.includes('_phase1.nii') || path.includes('_phase2.nii')) {
+      if (!mergedDictionary.hasOwnProperty('EchoTime')) {
+        issues.push(
+          new Issue({
+            file: file,
+            code: 16,
+            reason:
+              "You have to define 'EchoTime' for this file. " + sidecarMessage,
+          }),
+        )
+      }
+    } else if (path.includes('_fieldmap.nii')) {
+      if (!mergedDictionary.hasOwnProperty('Units')) {
+        issues.push(
+          new Issue({
+            file: file,
+            code: 17,
+            reason:
+              "You have to define 'Units' for this file. " + sidecarMessage,
+          }),
+        )
+      }
+    } else if (path.includes('_epi.nii')) {
+      if (!mergedDictionary.hasOwnProperty('PhaseEncodingDirection')) {
+        issues.push(
+          new Issue({
+            file: file,
+            code: 18,
+            reason:
+              "You have to define 'PhaseEncodingDirection' for this file. " +
+              sidecarMessage,
+          }),
+        )
+      }
+      if (!mergedDictionary.hasOwnProperty('TotalReadoutTime')) {
+        issues.push(
+          new Issue({
+            file: file,
+            code: 19,
+            reason:
+              "You have to define 'TotalReadoutTime' for this file. " +
+              sidecarMessage,
+          }),
+        )
+      }
     }
 
-    callback(issues);
-};
+    if (
+      utils.type.isFieldMapMainNii(path) &&
+      mergedDictionary.hasOwnProperty('IntendedFor')
+    ) {
+      var intendedFor =
+        typeof mergedDictionary['IntendedFor'] == 'string'
+          ? [mergedDictionary['IntendedFor']]
+          : mergedDictionary['IntendedFor']
 
-function missingEvents(path, potentialEvents, events) {
-    var hasEvent = false,
-        isRest   = false;
-
-    // check if is a rest file
-    var pathParts = path.split('/');
-    var filenameParts  = pathParts[pathParts.length - 1].split('_');
-    for (var i = 0; i < filenameParts.length; i++) {
-        var part = filenameParts[i];
-        if (part.toLowerCase().indexOf('task') === 0 && part.indexOf('rest') > -1) {
-            isRest = true;
-        }
+      for (var key = 0; key < intendedFor.length; key++) {
+        var intendedForFile = intendedFor[key]
+        checkIfIntendedExists(intendedForFile, fileList, issues, file)
+      }
     }
+  }
 
-    // check for event file
-    for (var j = 0; j < potentialEvents.length; j++) {
-        var event = potentialEvents[j];
-        if (events.find(e => e.path == event)) {
-            hasEvent = true;
-        }
-    }
-
-    return !isRest && path.includes('_bold.nii') && !hasEvent;
+  callback(issues)
 }
 
+function missingEvents(path, potentialEvents, events) {
+  var hasEvent = false,
+    isRest = false
+
+  // check if is a rest file
+  var pathParts = path.split('/')
+  var filenameParts = pathParts[pathParts.length - 1].split('_')
+  for (var i = 0; i < filenameParts.length; i++) {
+    var part = filenameParts[i]
+    if (part.toLowerCase().indexOf('task') === 0 && part.indexOf('rest') > -1) {
+      isRest = true
+    }
+  }
+
+  // check for event file
+  for (var j = 0; j < potentialEvents.length; j++) {
+    var event = potentialEvents[j]
+    if (events.find(e => e.path == event)) {
+      hasEvent = true
+    }
+  }
+
+  return !isRest && path.includes('_bold.nii') && !hasEvent
+}
 
 /**
  * Function to check each SoliceTime from SliceTiming Array
  *
  */
 
-function sliceTimingGreaterThanRepetitionTime(array, repetitionTime){
-    var invalid_timesArray = [];
-    for (var t = 0; t < array.length; t++){
-        if (array[t] > repetitionTime){
-            invalid_timesArray.push(array[t]);
-        }
+function sliceTimingGreaterThanRepetitionTime(array, repetitionTime) {
+  var invalid_timesArray = []
+  for (var t = 0; t < array.length; t++) {
+    if (array[t] > repetitionTime) {
+      invalid_timesArray.push(array[t])
     }
-    return invalid_timesArray;
+  }
+  return invalid_timesArray
 }
 
 function checkIfIntendedExists(intendedForFile, fileList, issues, file) {
-    var intendedForFileFull = "/" + file.relativePath.split("/")[1] + "/" + intendedForFile;
-    var onTheList = false;
+  var intendedForFileFull =
+    '/' + file.relativePath.split('/')[1] + '/' + intendedForFile
+  var onTheList = false
 
-    for (var key2 in fileList) {
-        var filePath = fileList[key2].relativePath;
-        if (filePath === intendedForFileFull) {
-            onTheList = true;
-        }
+  for (var key2 in fileList) {
+    var filePath = fileList[key2].relativePath
+    if (filePath === intendedForFileFull) {
+      onTheList = true
     }
-    if (!onTheList) {
-        issues.push(new Issue({
-            file: file,
-            code: 37,
-            reason: "'IntendedFor' property of this fieldmap  ('" + file.relativePath +
-            "') does not point to an existing file('" + intendedForFile + "'). Please mind that this value should not include subject level directory " +
-            "('/" + file.relativePath.split("/")[1] + "/').",
-            evidence: intendedForFile
-        }));
-    }
+  }
+  if (!onTheList) {
+    issues.push(
+      new Issue({
+        file: file,
+        code: 37,
+        reason:
+          "'IntendedFor' property of this fieldmap  ('" +
+          file.relativePath +
+          "') does not point to an existing file('" +
+          intendedForFile +
+          "'). Please mind that this value should not include subject level directory " +
+          "('/" +
+          file.relativePath.split('/')[1] +
+          "/').",
+        evidence: intendedForFile,
+      }),
+    )
+  }
 }

--- a/validators/session.js
+++ b/validators/session.js
@@ -1,5 +1,5 @@
-var utils = require('../utils');
-var Issue = utils.issues.Issue;
+var utils = require('../utils')
+var Issue = utils.issues.Issue
 
 /**
  * session
@@ -9,70 +9,80 @@ var Issue = utils.issues.Issue;
  * files from the set.
  */
 var session = function missingSessionFiles(fileList) {
-    var subjects = {};
-    var issues = [];
-    for (var key in fileList) {
-        var file = fileList[key];
-        var filename;
+  var subjects = {}
+  var issues = []
+  for (var key in fileList) {
+    var file = fileList[key]
+    var filename
 
-        if (!file || (typeof window != 'undefined' && !file.webkitRelativePath)) {
-            continue;
-        }
-
-        var path = file.relativePath;
-        if (!utils.type.isBIDS(path) || utils.type.isStimuliData(path)) {
-            continue;
-        }
-        var subject;
-        //match the subject identifier up to the '/' in the full path to a file.
-        var match = path.match(/sub-(.*?)(?=\/)/);
-        if (match === null) {
-            continue;
-        } else {
-            subject = match[0];
-        }
-        // initialize an empty array if we haven't seen this subject before
-        if (typeof(subjects[subject]) === 'undefined') {
-            subjects[subject] = [];
-        }
-        // files are prepended with subject name, the following two commands
-        // remove the subject from the file name to allow filenames to be more
-        // easily compared
-        filename = path.substring(path.match(subject).index + subject.length);
-        filename = filename.replace(subject, '<sub>');
-        subjects[subject].push(filename);
+    if (!file || (typeof window != 'undefined' && !file.webkitRelativePath)) {
+      continue
     }
 
-    var subject_files = [];
-
-    for (var subjKey in subjects) {
-        subject = subjects[subjKey];
-        for (var i = 0; i < subject.length; i++) {
-            file = subject[i];
-            if (subject_files.indexOf(file) < 0) {
-                subject_files.push(file);
-            }
-        }
+    var path = file.relativePath
+    if (!utils.type.isBIDS(path) || utils.type.isStimuliData(path)) {
+      continue
     }
-
-    var subjectKeys = Object.keys(subjects).sort();
-    for (var j = 0; j < subjectKeys.length; j++) {
-        subject = subjectKeys[j];
-        for (var set_file = 0; set_file < subject_files.length; set_file++) {
-            if (subjects[subject].indexOf(subject_files[set_file]) === -1) {
-                var fileThatsMissing = '/' + subject + subject_files[set_file].replace('<sub>', subject);
-                issues.push(new Issue({
-                    file: {relativePath: fileThatsMissing,
-                           webkitRelativePath: fileThatsMissing,
-                           name: fileThatsMissing.substr(fileThatsMissing.lastIndexOf('/') + 1),
-                           path: fileThatsMissing},
-                    reason: "This file is missing for subject " + subject + ", but is present for at least one other subject.",
-                    code: 38
-                }));
-            }
-        }
+    var subject
+    //match the subject identifier up to the '/' in the full path to a file.
+    var match = path.match(/sub-(.*?)(?=\/)/)
+    if (match === null) {
+      continue
+    } else {
+      subject = match[0]
     }
-    return issues;
-};
+    // initialize an empty array if we haven't seen this subject before
+    if (typeof subjects[subject] === 'undefined') {
+      subjects[subject] = []
+    }
+    // files are prepended with subject name, the following two commands
+    // remove the subject from the file name to allow filenames to be more
+    // easily compared
+    filename = path.substring(path.match(subject).index + subject.length)
+    filename = filename.replace(subject, '<sub>')
+    subjects[subject].push(filename)
+  }
 
-module.exports = session;
+  var subject_files = []
+
+  for (var subjKey in subjects) {
+    subject = subjects[subjKey]
+    for (var i = 0; i < subject.length; i++) {
+      file = subject[i]
+      if (subject_files.indexOf(file) < 0) {
+        subject_files.push(file)
+      }
+    }
+  }
+
+  var subjectKeys = Object.keys(subjects).sort()
+  for (var j = 0; j < subjectKeys.length; j++) {
+    subject = subjectKeys[j]
+    for (var set_file = 0; set_file < subject_files.length; set_file++) {
+      if (subjects[subject].indexOf(subject_files[set_file]) === -1) {
+        var fileThatsMissing =
+          '/' + subject + subject_files[set_file].replace('<sub>', subject)
+        issues.push(
+          new Issue({
+            file: {
+              relativePath: fileThatsMissing,
+              webkitRelativePath: fileThatsMissing,
+              name: fileThatsMissing.substr(
+                fileThatsMissing.lastIndexOf('/') + 1,
+              ),
+              path: fileThatsMissing,
+            },
+            reason:
+              'This file is missing for subject ' +
+              subject +
+              ', but is present for at least one other subject.',
+            code: 38,
+          }),
+        )
+      }
+    }
+  }
+  return issues
+}
+
+module.exports = session

--- a/validators/tsv.js
+++ b/validators/tsv.js
@@ -1,9 +1,9 @@
 /* eslint-disable no-unused-vars */
-var Issue = require('../utils').issues.Issue;
-var files = require('../utils/files');
-var utils  = require('../utils');
-var dateIsValid = require('date-fns/isValid');
-var parseDate = require('date-fns/parse');
+var Issue = require('../utils').issues.Issue
+var files = require('../utils/files')
+var utils = require('../utils')
+var dateIsValid = require('date-fns/isValid')
+var parseDate = require('date-fns/parse')
 /**
  * TSV
  *
@@ -12,272 +12,336 @@ var parseDate = require('date-fns/parse');
  * it finds while validating against the BIDS
  * specification.
  */
-var TSV = function TSV (file, contents, fileList, callback) {
+var TSV = function TSV(file, contents, fileList, callback) {
+  var issues = []
+  var stimPaths = []
+  if (contents.includes('\r') && !contents.includes('\n')) {
+    issues.push(
+      new Issue({
+        file: file,
+        evidence: contents,
+        code: 70,
+      }),
+    )
+    callback(issues, null)
+    return
+  }
 
-    var issues = [];
-    var stimPaths = [];
-    if ((contents.includes('\r')) && (!contents.includes('\n'))) {
-        issues.push(new Issue({
+  var rows = contents.split('\n')
+  var headers = rows[0].split('\t')
+
+  // generic checks -----------------------------------------------------------
+
+  var columnMismatch = false
+  var emptyCells = false
+  var NACells = false
+  // iterate rows
+  for (var i = 0; i < rows.length; i++) {
+    var row = rows[i]
+    if (columnMismatch && emptyCells && NACells) {
+      break
+    }
+
+    // skip empty rows
+    if (!row || /^\s*$/.test(row)) {
+      continue
+    }
+
+    var values = row.split('\t')
+
+    // check for different length rows
+    if (values.length !== headers.length && !columnMismatch) {
+      columnMismatch = true
+      issues.push(
+        new Issue({
+          file: file,
+          evidence: row,
+          line: i + 1,
+          code: 22,
+        }),
+      )
+    }
+
+    // iterate values
+    for (var j = 0; j < values.length; j++) {
+      var value = values[j]
+      if (columnMismatch && emptyCells && NACells) {
+        break
+      }
+
+      if (value === '' && !emptyCells) {
+        emptyCells = true
+        // empty cell should raise an error
+        issues.push(
+          new Issue({
             file: file,
-            evidence: contents,
-            code: 70
-        }));
-        callback(issues, null);
-        return;
+            evidence: row,
+            line: i + 1,
+            character: 'at column # ' + (j + 1),
+            code: 23,
+          }),
+        )
+      } else if (
+        (value === 'NA' ||
+          value === 'na' ||
+          value === 'nan' ||
+          value === 'NaN') &&
+        !NACells
+      ) {
+        NACells = true
+        // check if missing value is properly labeled as 'n/a'
+        issues.push(
+          new Issue({
+            file: file,
+            evidence: row,
+            line: i + 1,
+            character: 'at column # ' + (j + 1),
+            code: 24,
+          }),
+        )
+      }
+    }
+  }
+
+  // specific file checks -----------------------------------------------------
+  var checkheader = function checkheader(headername, idx, file, code) {
+    if (headers[idx] !== headername) {
+      issues.push(
+        new Issue({
+          file: file,
+          evidence: headers,
+          line: 1,
+          character: rows[0].indexOf(headers[idx]),
+          code: code,
+        }),
+      )
+    }
+  }
+
+  // events.tsv
+  if (file.name.endsWith('_events.tsv')) {
+    if (headers.length == 0 || headers[0] !== 'onset') {
+      issues.push(
+        new Issue({
+          file: file,
+          evidence: headers,
+          line: 1,
+          code: 20,
+        }),
+      )
+    }
+    if (headers.length == 1 || headers[1].trim() !== 'duration') {
+      issues.push(
+        new Issue({
+          file: file,
+          evidence: headers,
+          line: 1,
+          code: 21,
+        }),
+      )
     }
 
-    var rows = contents.split('\n');
-    var headers = rows[0].split('\t');
+    // create full dataset path list
+    var pathList = []
+    for (var f in fileList) {
+      pathList.push(fileList[f].relativePath)
+    }
 
-// generic checks -----------------------------------------------------------
+    // check for stimuli file
+    var stimFiles = []
+    if (headers.indexOf('stim_file') > -1) {
+      for (var k = 0; k < rows.length; k++) {
+        var stimFile = rows[k].split('\t')[headers.indexOf('stim_file')]
+        var stimPath = '/stimuli/' + stimFile
+        if (
+          stimFile &&
+          stimFile !== 'n/a' &&
+          stimFile !== 'stim_file' &&
+          stimFiles.indexOf(stimFile) == -1
+        ) {
+          stimFiles.push(stimFile)
+          stimPaths.push(stimPath)
+          if (pathList.indexOf(stimPath) == -1) {
+            issues.push(
+              new Issue({
+                file: file,
+                evidence: stimFile,
+                reason:
+                  'A stimulus file (' +
+                  stimFile +
+                  ') was declared but not found in /stimuli.',
+                line: k + 1,
+                character: rows[k].indexOf(stimFile),
+                code: 52,
+              }),
+            )
+          }
+        }
+      }
+    }
+  }
 
-    var columnMismatch = false;
-    var emptyCells     = false;
-    var NACells        = false;
-    // iterate rows
-    for (var i = 0; i < rows.length; i++) {
-        var row = rows[i];
-        if (columnMismatch && emptyCells && NACells) {break;}
-
+  // participants.tsv
+  var participants = null
+  if (
+    file.name === 'participants.tsv' ||
+    file.relativePath.includes('phenotype/')
+  ) {
+    var participantIdColumn = headers.indexOf('participant_id')
+    if (participantIdColumn === -1) {
+      issues.push(
+        new Issue({
+          file: file,
+          evidence: headers.join('\t'),
+          line: 1,
+          code: 48,
+        }),
+      )
+    } else {
+      participants = []
+      for (var l = 1; l < rows.length; l++) {
+        row = rows[l].split('\t')
         // skip empty rows
-        if (!row || /^\s*$/.test(row)) {continue;}
-
-        var values = row.split('\t');
-
-        // check for different length rows
-        if (values.length !== headers.length && !columnMismatch) {
-            columnMismatch = true;
-            issues.push(new Issue({
-                file: file,
-                evidence: row,
-                line: i + 1,
-                code: 22
-            }));
+        if (!row || /^\s*$/.test(row)) {
+          continue
         }
-
-        // iterate values
-        for (var j = 0; j < values.length; j++) {
-            var value = values[j];
-            if (columnMismatch && emptyCells && NACells) {break;}
-
-            if (value === "" && !emptyCells) {
-                emptyCells = true;
-                // empty cell should raise an error
-                issues.push(new Issue({
-                    file: file,
-                    evidence: row,
-                    line: i + 1,
-                    character: "at column # " + (j+1),
-                    code: 23
-                }));
-            } else if ((value === "NA" || value === "na" || value === "nan" || value === "NaN") && !NACells) {
-                NACells = true;
-                // check if missing value is properly labeled as 'n/a'
-                issues.push(new Issue({
-                    file: file,
-                    evidence: row,
-                    line: i + 1,
-                    character: "at column # " + (j+1),
-                    code: 24
-                }));
-            }
-        }
+        participants.push(row[participantIdColumn].replace('sub-', ''))
+      }
     }
+  }
 
-// specific file checks -----------------------------------------------------
-    var checkheader = function checkheader (headername, idx, file, code) {
-        if (headers[idx] !== headername){
-            issues.push(new Issue({
-                file: file,
-                evidence: headers,
-                line: 1,
-                character: rows[0].indexOf(headers[idx]),
-                code: code
-            }));
-        }
-    };
+  // channels.tsv
+  if (
+    file.relativePath.includes('/meg/') &&
+    file.name.endsWith('_channels.tsv')
+  ) {
+    checkheader('name', 0, file, 71)
+    checkheader('type', 1, file, 71)
+    checkheader('units', 2, file, 71)
+  }
 
-    // events.tsv
-    if (file.name.endsWith('_events.tsv')) {
-        if ((headers.length == 0) || (headers[0] !== "onset")){
-            issues.push(new Issue({
-                file: file,
-                evidence: headers,
-                line: 1,
-                code: 20
-            }));
-        }
-        if ((headers.length == 1) || (headers[1].trim() !== "duration")){
-            issues.push(new Issue({
-                file: file,
-                evidence: headers,
-                line: 1,
-                code: 21
-            }));
-        }
+  if (
+    file.relativePath.includes('/ieeg/') &&
+    file.name.endsWith('_channels.tsv')
+  ) {
+    checkheader('name', 0, file, 72)
+    checkheader('type', 1, file, 72)
+    checkheader('units', 2, file, 72)
+    checkheader('sampling_frequency', 3, file, 72)
+    checkheader('low_cutoff', 4, file, 72)
+    checkheader('high_cutoff', 5, file, 72)
+    checkheader('notch', 6, file, 72)
+    checkheader('reference', 7, file, 72)
+  }
 
-        // create full dataset path list
-        var pathList = [];
-        for (var f in fileList) {
-            pathList.push(fileList[f].relativePath);
-        }
-
-        // check for stimuli file
-        var stimFiles = [];
-        if (headers.indexOf('stim_file') > -1) {
-            for (var k = 0; k < rows.length; k++) {
-                var stimFile = rows[k].split('\t')[headers.indexOf('stim_file')];
-                var stimPath = '/stimuli/' + stimFile;
-                if (stimFile && stimFile !== 'n/a' && stimFile !== 'stim_file' && stimFiles.indexOf(stimFile) == -1) {
-                    stimFiles.push(stimFile);
-                    stimPaths.push(stimPath);
-                    if (pathList.indexOf(stimPath) == -1) {
-                        issues.push(new Issue({
-                            file: file,
-                            evidence: stimFile,
-                            reason: 'A stimulus file (' + stimFile + ') was declared but not found in /stimuli.',
-                            line: k + 1,
-                            character: rows[k].indexOf(stimFile),
-                            code: 52
-                        }));
-                    }
-                }
-            }
-        }
-    }
-
-    // participants.tsv
-    var participants = null;
-    if (file.name === 'participants.tsv' || file.relativePath.includes('phenotype/')) {
-        var participantIdColumn = headers.indexOf('participant_id');
-        if (participantIdColumn === -1) {
-            issues.push(new Issue({
-                file: file,
-                evidence: headers.join('\t'),
-                line: 1,
-                code: 48
-            }));
-        } else {
-            participants = [];
-            for (var l = 1; l < rows.length; l++) {
-                row = rows[l].split('\t');
-                // skip empty rows
-                if (!row || /^\s*$/.test(row)) {continue;}
-                participants.push(row[participantIdColumn].replace('sub-', ''));
-            }
-        }
-
-    }
-
-    // channels.tsv
-    if (file.relativePath.includes('/meg/') && file.name.endsWith('_channels.tsv')) {
-        checkheader('name', 0, file, 71);
-        checkheader('type', 1, file, 71);
-        checkheader('units', 2, file, 71);
-    }
-
-    if (file.relativePath.includes('/ieeg/') && file.name.endsWith('_channels.tsv')) {
-        checkheader('name', 0, file, 72);
-        checkheader('type', 1, file, 72);
-        checkheader('units', 2, file, 72);
-        checkheader('sampling_frequency', 3, file, 72);
-        checkheader('low_cutoff', 4, file, 72);
-        checkheader('high_cutoff', 5, file, 72);
-        checkheader('notch', 6, file, 72);
-        checkheader('reference', 7, file, 72);
-    }
-
-    if (file.relativePath.includes('/ieeg/') && file.name.endsWith('_electrodes.tsv')) {
-        checkheader('name', 0, file, 73);
-        checkheader('x', 1, file, 73);
-        checkheader('y', 2, file, 73);
-        checkheader('z', 3, file, 73);
-        checkheader('size', 4, file, 73);
-    }
+  if (
+    file.relativePath.includes('/ieeg/') &&
+    file.name.endsWith('_electrodes.tsv')
+  ) {
+    checkheader('name', 0, file, 73)
+    checkheader('x', 1, file, 73)
+    checkheader('y', 2, file, 73)
+    checkheader('z', 3, file, 73)
+    checkheader('size', 4, file, 73)
+  }
 
   // check partcipants.tsv for age 89+
 
-    if (file.name === 'participants.tsv'){
-        checkage89_plus(rows, file, issues);
+  if (file.name === 'participants.tsv') {
+    checkage89_plus(rows, file, issues)
+  }
+
+  if (file.name.endsWith('_scans.tsv')) {
+    // check _scans.tsv for column filename
+    if (!(headers.indexOf('filename') > -1)) {
+      issues.push(
+        new Issue({
+          line: 1,
+          file: file,
+          evidence: headers.join('\t'),
+          code: 68,
+        }),
+      )
     }
 
-  
-
-    if(file.name.endsWith('_scans.tsv')){
-      // check _scans.tsv for column filename
-      if(!(headers.indexOf('filename') > -1)){
-        issues.push(new Issue({
-            line: 1,
-            file: file,
-            evidence: headers.join('\t'),
-            code: 68
-        }));
-      }
-
-      // if _scans.tsv has the acq_time header, check datetime format
-      if (headers.indexOf('acq_time') > -1) {
-          checkAcqTimeFormat(rows, file, issues);
-      }
+    // if _scans.tsv has the acq_time header, check datetime format
+    if (headers.indexOf('acq_time') > -1) {
+      checkAcqTimeFormat(rows, file, issues)
     }
+  }
 
-    callback(issues, participants, stimPaths);
-
-};
-var checkphenotype = function (phenotypeParticipants, summary, issues) {
-    for (var j=0; j < phenotypeParticipants.length; j++){
-        var fileParticpants = phenotypeParticipants[j];
-        if (phenotypeParticipants && phenotypeParticipants.length > 0 && (!utils.array.equals(fileParticpants.list, summary.subjects.sort(), true))) {
-            issues.push(new Issue({
-                code: 51,
-                evidence: fileParticpants.file + "- " + fileParticpants.list + "  Subjects -" + fileParticpants,
-                file: fileParticpants.file
-            }));
-        }
+  callback(issues, participants, stimPaths)
+}
+var checkphenotype = function(phenotypeParticipants, summary, issues) {
+  for (var j = 0; j < phenotypeParticipants.length; j++) {
+    var fileParticpants = phenotypeParticipants[j]
+    if (
+      phenotypeParticipants &&
+      phenotypeParticipants.length > 0 &&
+      !utils.array.equals(fileParticpants.list, summary.subjects.sort(), true)
+    ) {
+      issues.push(
+        new Issue({
+          code: 51,
+          evidence:
+            fileParticpants.file +
+            '- ' +
+            fileParticpants.list +
+            '  Subjects -' +
+            fileParticpants,
+          file: fileParticpants.file,
+        }),
+      )
     }
-};
+  }
+}
 
-var checkage89_plus = function(rows, file, issues){
-    var header = rows[0].trim().split('\t');
-    var ageIdColumn = header.indexOf("age");
-    for (var a = 0; a < rows.length; a++) {
-        var line = rows[a];
-        var line_values = line.trim().split('\t');
-        var age = line_values[ageIdColumn];
-        if (age >= 89) {
-            issues.push(new Issue({
-                file: file,
-                evidence: line,
-                line: a + 1,
-                character: "age of partcipant is above 89 ",
-                code: 56
-            }));
-        }
+var checkage89_plus = function(rows, file, issues) {
+  var header = rows[0].trim().split('\t')
+  var ageIdColumn = header.indexOf('age')
+  for (var a = 0; a < rows.length; a++) {
+    var line = rows[a]
+    var line_values = line.trim().split('\t')
+    var age = line_values[ageIdColumn]
+    if (age >= 89) {
+      issues.push(
+        new Issue({
+          file: file,
+          evidence: line,
+          line: a + 1,
+          character: 'age of partcipant is above 89 ',
+          code: 56,
+        }),
+      )
     }
-};
+  }
+}
 
 const checkAcqTimeFormat = function(rows, file, issues) {
-    const format = "YYYY-MM-DD'T'HH:mm:ss";
-    const header = rows[0].trim().split('\t');
-    const acqTimeColumn = header.indexOf('acq_time');
-    const testRows = rows.slice(1);
-    for (let i = 0; i < testRows.length; i++) {
-        const line = testRows[i];
-        const lineValues = line.trim().split('\t');
-        const acqTime = lineValues[acqTimeColumn];
-        const isValid = dateIsValid(parseDate(acqTime, format, new Date()));
-        if (acqTime && !isValid) {
-            issues.push(new Issue({
-                file: file,
-                evidence: file,
-                line: i + 2,
-                character: 'acq_time is not in the format YYYY-MM-DDTHH:mm:ss ',
-                code: 84,
-            }));
-        }
+  const format = "YYYY-MM-DD'T'HH:mm:ss"
+  const header = rows[0].trim().split('\t')
+  const acqTimeColumn = header.indexOf('acq_time')
+  const testRows = rows.slice(1)
+  for (let i = 0; i < testRows.length; i++) {
+    const line = testRows[i]
+    const lineValues = line.trim().split('\t')
+    const acqTime = lineValues[acqTimeColumn]
+    const isValid = dateIsValid(parseDate(acqTime, format, new Date()))
+    if (acqTime && !isValid) {
+      issues.push(
+        new Issue({
+          file: file,
+          evidence: file,
+          line: i + 2,
+          character: 'acq_time is not in the format YYYY-MM-DDTHH:mm:ss ',
+          code: 84,
+        }),
+      )
     }
-};
+  }
+}
 
 module.exports = {
-    TSV: TSV,
-    checkphenotype : checkphenotype
-};
+  TSV: TSV,
+  checkphenotype: checkphenotype,
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -85,13 +85,13 @@ ansi-escapes@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
 
-ansi-regex@*, ansi-regex@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
-
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
+
+ansi-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -697,6 +697,19 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
+eslint-config-prettier@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-2.9.0.tgz#5ecd65174d486c22dff389fe036febf502d468a3"
+  dependencies:
+    get-stdin "^5.0.1"
+
+eslint-plugin-prettier@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.2.tgz#71998c60aedfa2141f7bfcbf9d1c459bf98b4fad"
+  dependencies:
+    fast-diff "^1.1.1"
+    jest-docblock "^21.0.0"
+
 eslint-scope@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.0.tgz#50bf3071e9338bcdc43331794a0cb533f0136172"
@@ -843,6 +856,10 @@ fast-deep-equal@^1.0.0:
 fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+
+fast-diff@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.1.2.tgz#4b62c42b8e03de3f848460b639079920695d0154"
 
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
@@ -1037,6 +1054,10 @@ get-func-name@^2.0.0:
 get-port@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/get-port/-/get-port-3.2.0.tgz#dd7ce7de187c06c8bf353796ac71e099f0980ebc"
+
+get-stdin@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
 
 get-stream@^3.0.0:
   version "3.0.0"
@@ -1249,7 +1270,7 @@ ignore@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.2.tgz#0a8dd228947ec78c2d7f736b1642a9f7317c1905"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
 
@@ -1402,6 +1423,10 @@ isexe@^2.0.0:
 isstream@0.1.x, isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
+
+jest-docblock@^21.0.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-21.2.0.tgz#51529c3b30d5fd159da60c27ceedc195faf8d414"
 
 js-tokens@^3.0.2:
   version "3.0.2"
@@ -2032,6 +2057,10 @@ pluralize@^7.0.0:
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
+
+prettier@^1.14.2:
+  version "1.14.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.2.tgz#0ac1c6e1a90baa22a62925f41963c841983282f9"
 
 process-nextick-args@~1.0.6:
   version "1.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -331,7 +331,7 @@ chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.1.0:
+chalk@^2.0.0, chalk@^2.1.0, chalk@^2.3.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   dependencies:
@@ -358,6 +358,10 @@ chmodr@~1.0.2:
 chownr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.0.1.tgz#e2a75042a9551908bebd25b8523d5f9769d79181"
+
+ci-info@^1.0.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.3.tgz#710193264bb05c77b8c90d02f5aaf22216a667b2"
 
 circular-json@^0.3.1:
   version "0.3.3"
@@ -499,6 +503,14 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+
+cosmiconfig@^5.0.2:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.0.6.tgz#dca6cf680a0bd03589aff684700858c81abeeb39"
+  dependencies:
+    is-directory "^0.3.1"
+    js-yaml "^3.9.0"
+    parse-json "^4.0.0"
 
 cross-spawn@^5.0.1:
   version "5.1.0"
@@ -671,6 +683,12 @@ entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
+error-ex@^1.3.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
+  dependencies:
+    is-arrayish "^0.2.1"
+
 es-abstract@^1.10.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.12.0.tgz#9dbbdd27c6856f0001421ca18782d786bf8a6165"
@@ -812,6 +830,30 @@ execa@^0.7.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+execa@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.8.0.tgz#d8d76bbc1b55217ed190fd6dd49d3c774ecfc8da"
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
+execa@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.9.0.tgz#adb7ce62cf985071f60580deb4a88b9e34712d01"
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
 exit@0.1.2, exit@0.1.x:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
@@ -887,6 +929,12 @@ file-entry-cache@^2.0.0:
   dependencies:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
+
+find-up@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
+  dependencies:
+    locate-path "^2.0.0"
 
 find-up@^3.0.0:
   version "3.0.0"
@@ -1058,6 +1106,10 @@ get-port@^3.1.0:
 get-stdin@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
+
+get-stdin@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
 
 get-stream@^3.0.0:
   version "3.0.0"
@@ -1256,6 +1308,21 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+husky@^1.0.0-rc.13:
+  version "1.0.0-rc.13"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-1.0.0-rc.13.tgz#49c3cc210bfeac24d4ad272f770b7505c9091828"
+  dependencies:
+    cosmiconfig "^5.0.2"
+    execa "^0.9.0"
+    find-up "^3.0.0"
+    get-stdin "^6.0.0"
+    is-ci "^1.1.0"
+    pkg-dir "^3.0.0"
+    please-upgrade-node "^3.1.1"
+    read-pkg "^4.0.1"
+    run-node "^1.0.0"
+    slash "^2.0.0"
+
 iconv-lite@^0.4.17:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
@@ -1265,6 +1332,10 @@ iconv-lite@^0.4.17:
 iferr@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
+
+ignore@^3.3.7:
+  version "3.3.10"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
 
 ignore@^4.0.2:
   version "4.0.2"
@@ -1324,6 +1395,10 @@ invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
 
+is-arrayish@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
+
 is-builtin-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-1.0.0.tgz#540572d34f7ac3119f8f76c30cbc1b1e037affbe"
@@ -1334,9 +1409,19 @@ is-callable@^1.1.1, is-callable@^1.1.3:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
 
+is-ci@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.1.0.tgz#247e4162e7860cebbdaf30b774d6b0ac7dcfe7a5"
+  dependencies:
+    ci-info "^1.0.0"
+
 is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+
+is-directory@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
 
 is-fullwidth-code-point@^1.0.0:
   version "1.0.0"
@@ -1432,7 +1517,7 @@ js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.11.0:
+js-yaml@^3.11.0, js-yaml@^3.9.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
   dependencies:
@@ -1536,6 +1621,13 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+locate-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
+  dependencies:
+    p-locate "^2.0.0"
+    path-exists "^3.0.0"
+
 locate-path@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
@@ -1631,6 +1723,10 @@ mocha@^5.2.0:
     mkdirp "0.5.1"
     supports-color "5.4.0"
 
+mri@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/mri/-/mri-1.1.1.tgz#85aa26d3daeeeedf80dc5984af95cc5ca5cad9f1"
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -1685,7 +1781,7 @@ normalize-git-url@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/normalize-git-url/-/normalize-git-url-3.0.2.tgz#8e5f14be0bdaedb73e07200310aa416c27350fc4"
 
-normalize-package-data@^2.0.0, "normalize-package-data@~1.0.1 || ^2.0.0":
+normalize-package-data@^2.0.0, normalize-package-data@^2.3.2, "normalize-package-data@~1.0.1 || ^2.0.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
   dependencies:
@@ -1947,17 +2043,33 @@ p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
 
+p-limit@^1.1.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
+  dependencies:
+    p-try "^1.0.0"
+
 p-limit@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.0.0.tgz#e624ed54ee8c460a778b3c9f3670496ff8a57aec"
   dependencies:
     p-try "^2.0.0"
 
+p-locate@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
+  dependencies:
+    p-limit "^1.1.0"
+
 p-locate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
   dependencies:
     p-limit "^2.0.0"
+
+p-try@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
 
 p-try@^2.0.0:
   version "2.0.0"
@@ -1970,6 +2082,13 @@ pako@^1.0.6:
 parse-cache-control@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parse-cache-control/-/parse-cache-control-1.0.1.tgz#8eeab3e54fa56920fe16ba38f77fa21aacc2d74e"
+
+parse-json@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
+  dependencies:
+    error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
 
 path-exists@^3.0.0:
   version "3.0.0"
@@ -2036,6 +2155,10 @@ pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
 
+pify@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
+
 pinkie-promise@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
@@ -2046,9 +2169,21 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
 
+pkg-dir@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-3.0.0.tgz#2749020f239ed990881b1f71210d51eb6523bea3"
+  dependencies:
+    find-up "^3.0.0"
+
 pkginfo@0.3.x:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.3.1.tgz#5b29f6a81f70717142e09e765bbeab97b4f81e21"
+
+please-upgrade-node@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.1.1.tgz#ed320051dfcc5024fae696712c8288993595e8ac"
+  dependencies:
+    semver-compare "^1.0.0"
 
 pluralize@^7.0.0:
   version "7.0.0"
@@ -2061,6 +2196,16 @@ prelude-ls@~1.1.2:
 prettier@^1.14.2:
   version "1.14.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.2.tgz#0ac1c6e1a90baa22a62925f41963c841983282f9"
+
+pretty-quick@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/pretty-quick/-/pretty-quick-1.6.0.tgz#afc3591eb5c4cf37614a305d489a8a40e57c9258"
+  dependencies:
+    chalk "^2.3.0"
+    execa "^0.8.0"
+    find-up "^2.1.0"
+    ignore "^3.3.7"
+    mri "^1.1.0"
 
 process-nextick-args@~1.0.6:
   version "1.0.7"
@@ -2154,6 +2299,14 @@ read-installed@~4.0.3:
     slash "^1.0.0"
   optionalDependencies:
     graceful-fs "^4.1.2"
+
+read-pkg@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-4.0.1.tgz#963625378f3e1c4d48c85872b5a6ec7d5d093237"
+  dependencies:
+    normalize-package-data "^2.3.2"
+    parse-json "^4.0.0"
+    pify "^3.0.0"
 
 read@1, read@~1.0.1, read@~1.0.7:
   version "1.0.7"
@@ -2363,6 +2516,10 @@ run-async@^2.2.0:
   dependencies:
     is-promise "^2.1.0"
 
+run-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/run-node/-/run-node-1.0.0.tgz#46b50b946a2aa2d4947ae1d886e9856fd9cabe5e"
+
 rxjs@^5.5.2:
   version "5.5.11"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.11.tgz#f733027ca43e3bec6b994473be4ab98ad43ced87"
@@ -2376,6 +2533,10 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
 "safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+
+semver-compare@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
 
 "semver@2 >=2.2.1 || 3.x || 4 || 5", "semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", "semver@4 || 5", "semver@^2.3.0 || 3.x || 4 || 5", semver@^5.1.0, semver@^5.5.0:
   version "5.5.0"
@@ -2425,6 +2586,10 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
+
+slash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
 
 slice-ansi@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This allows the use of all Node 8 compatible syntax.

A pre-commit hook enforces consistent syntax following the same style guide as OpenNeuro.

```yaml
singleQuote: true
jsxBracketSameLine: true
semi: false
trailingComma: all
```

@chrisfilo This is one of the things that will make existing PRs harder to merge but I think it will help with maintainability going forward.