### PR TITLE
more robust .bvec and .bval validation

### DIFF
--- a/tests/bval.spec.js
+++ b/tests/bval.spec.js
@@ -22,4 +22,18 @@ describe('bval', function() {
       assert(issues.length == 1 && issues[0].code == 47)
     })
   })
+
+  it('should not allow undefined bvals', function() {
+    const bval = undefined
+    validate.bval({}, bval, function(issues) {
+      assert(issues.length == 1 && issues[0].code == 89)
+    })
+  })
+
+  it('should not allow bvals of types other than string', function() {
+    const bval = [0, 1, 2, 3]
+    validate.bval({}, bval, function(issues) {
+      assert(issues.length == 1 && issues[0].code == 89)
+    })
+  })
 })

--- a/tests/bval.spec.js
+++ b/tests/bval.spec.js
@@ -36,4 +36,11 @@ describe('bval', function() {
       assert(issues.length == 1 && issues[0].code == 89)
     })
   })
+
+  it('should not allow bvecs to be submitted in place of bval', function() {
+    const bvec = '4 6 7\n 2 3 4\n 4 5 6'
+    validate.bval({}, bvec, function(issues) {
+      assert(issues.length == 1 && issues[0].code == 30)
+    })
+  })
 })

--- a/tests/bvec.spec.js
+++ b/tests/bvec.spec.js
@@ -35,4 +35,18 @@ describe('bvec', function() {
       assert(issues.length == 1 && issues[0].code == 47)
     })
   })
+
+  it('should not allow undefined bvecs', function() {
+    const bvec = undefined
+    validate.bvec({}, bvec, function(issues) {
+      assert(issues.length == 1 && issues[0].code == 88)
+    })
+  })
+
+  it('should not allow bvecs of types other than string', function() {
+    const bvec = [0, 1, 2, 3]
+    validate.bvec({}, bvec, function(issues) {
+      assert(issues.length == 1 && issues[0].code == 88)
+    })
+  })
 })

--- a/tests/bvec.spec.js
+++ b/tests/bvec.spec.js
@@ -49,4 +49,11 @@ describe('bvec', function() {
       assert(issues.length == 1 && issues[0].code == 88)
     })
   })
+
+  it('should not allow bvals to be submitted in place of bvec', function() {
+    const bval = '4 6 7'
+    validate.bvec({}, bval, function(issues) {
+      assert(issues.length == 1 && issues[0].code == 31)
+    })
+  })
 })

--- a/tests/type.spec.js
+++ b/tests/type.spec.js
@@ -3,7 +3,7 @@ var utils = require('../utils')
 var Test = require('mocha/lib/test')
 var BIDS = require('../validators/bids')
 
-var suiteAnat = describe('utils.type.isAnat', function() {
+var suiteAnat = describe('utils.type.file.isAnat', function() {
   before(function(done) {
     var goodFilenames = [
       '/sub-15/anat/sub-15_inplaneT2.nii.gz',
@@ -18,7 +18,7 @@ var suiteAnat = describe('utils.type.isAnat', function() {
     goodFilenames.forEach(function(path) {
       suiteAnat.addTest(
         new Test("isAnat('" + path + "') === true", function(isdone) {
-          assert.equal(utils.type.isAnat(path), true)
+          assert.equal(utils.type.file.isAnat(path), true)
           isdone()
         }),
       )
@@ -36,7 +36,7 @@ var suiteAnat = describe('utils.type.isAnat', function() {
     badFilenames.forEach(function(path) {
       suiteAnat.addTest(
         new Test("isAnat('" + path + "') === false", function(isdone) {
-          assert.equal(utils.type.isAnat(path), false)
+          assert.equal(utils.type.file.isAnat(path), false)
           isdone()
         }),
       )
@@ -50,7 +50,7 @@ var suiteAnat = describe('utils.type.isAnat', function() {
   })
 })
 
-var suiteFunc = describe('utils.type.isFunc', function() {
+var suiteFunc = describe('utils.type.file.isFunc', function() {
   before(function(done) {
     var goodFilenames = [
       '/sub-15/func/sub-15_task-0back_bold.nii.gz',
@@ -64,7 +64,7 @@ var suiteFunc = describe('utils.type.isFunc', function() {
     goodFilenames.forEach(function(path) {
       suiteFunc.addTest(
         new Test("isFunc('" + path + "') === true", function(isdone) {
-          assert.equal(utils.type.isFunc(path), true)
+          assert.equal(utils.type.file.isFunc(path), true)
           isdone()
         }),
       )
@@ -83,7 +83,7 @@ var suiteFunc = describe('utils.type.isFunc', function() {
     badFilenames.forEach(function(path) {
       suiteFunc.addTest(
         new Test("isFunc('" + path + "') === false", function(isdone) {
-          assert.equal(utils.type.isFunc(path), false)
+          assert.equal(utils.type.file.isFunc(path), false)
           isdone()
         }),
       )
@@ -97,7 +97,7 @@ var suiteFunc = describe('utils.type.isFunc', function() {
   })
 })
 
-var suiteTop = describe('utils.type.isTopLevel', function() {
+var suiteTop = describe('utils.type.file.isTopLevel', function() {
   before(function(done) {
     var goodFilenames = [
       '/README',
@@ -114,7 +114,7 @@ var suiteTop = describe('utils.type.isTopLevel', function() {
     goodFilenames.forEach(function(path) {
       suiteTop.addTest(
         new Test("isTopLevel('" + path + "') === true", function(isdone) {
-          assert.equal(utils.type.isTopLevel(path), true)
+          assert.equal(utils.type.file.isTopLevel(path), true)
           isdone()
         }),
       )
@@ -133,7 +133,7 @@ var suiteTop = describe('utils.type.isTopLevel', function() {
     badFilenames.forEach(function(path) {
       suiteTop.addTest(
         new Test("isTopLevel('" + path + "') === false", function(isdone) {
-          assert.equal(utils.type.isTopLevel(path), false)
+          assert.equal(utils.type.file.isTopLevel(path), false)
           isdone()
         }),
       )
@@ -147,7 +147,7 @@ var suiteTop = describe('utils.type.isTopLevel', function() {
   })
 })
 
-var suiteSession = describe('utils.type.isSessionLevel', function() {
+var suiteSession = describe('utils.type.file.isSessionLevel', function() {
   before(function(done) {
     var goodFilenames = [
       '/sub-12/sub-12_scans.tsv',
@@ -157,7 +157,7 @@ var suiteSession = describe('utils.type.isSessionLevel', function() {
     goodFilenames.forEach(function(path) {
       suiteSession.addTest(
         new Test("isSessionLevel('" + path + "') === true", function(isdone) {
-          assert.equal(utils.type.isSessionLevel(path), true)
+          assert.equal(utils.type.file.isSessionLevel(path), true)
           isdone()
         }),
       )
@@ -171,7 +171,7 @@ var suiteSession = describe('utils.type.isSessionLevel', function() {
     badFilenames.forEach(function(path) {
       suiteSession.addTest(
         new Test("isSessionLevel('" + path + "') === false", function(isdone) {
-          assert.equal(utils.type.isSessionLevel(path), false)
+          assert.equal(utils.type.file.isSessionLevel(path), false)
           isdone()
         }),
       )
@@ -185,7 +185,7 @@ var suiteSession = describe('utils.type.isSessionLevel', function() {
   })
 })
 
-var suiteDWI = describe('utils.type.isDWI', function() {
+var suiteDWI = describe('utils.type.file.isDWI', function() {
   before(function(done) {
     var goodFilenames = [
       '/sub-12/dwi/sub-12_dwi.nii.gz',
@@ -197,7 +197,7 @@ var suiteDWI = describe('utils.type.isDWI', function() {
     goodFilenames.forEach(function(path) {
       suiteDWI.addTest(
         new Test("isDWI('" + path + "') === true", function(isdone) {
-          assert.equal(utils.type.isDWI(path), true)
+          assert.equal(utils.type.file.isDWI(path), true)
           isdone()
         }),
       )
@@ -213,7 +213,7 @@ var suiteDWI = describe('utils.type.isDWI', function() {
     badFilenames.forEach(function(path) {
       suiteDWI.addTest(
         new Test("isDWI('" + path + "') === false", function(isdone) {
-          assert.equal(utils.type.isDWI(path), false)
+          assert.equal(utils.type.file.isDWI(path), false)
           isdone()
         }),
       )
@@ -227,7 +227,7 @@ var suiteDWI = describe('utils.type.isDWI', function() {
   })
 })
 
-var suiteMEG = describe('utils.type.isMEG', function() {
+var suiteMEG = describe('utils.type.file.isMEG', function() {
   before(function(done) {
     var goodFilenames = [
       '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg/sub-01_ses-001_task-rest_run-01_meg.sqd',
@@ -242,7 +242,7 @@ var suiteMEG = describe('utils.type.isMEG', function() {
     goodFilenames.forEach(function(path) {
       suiteMEG.addTest(
         new Test("isMeg('" + path + "') === true", function(isdone) {
-          assert.equal(utils.type.isMeg(path), true)
+          assert.equal(utils.type.file.isMeg(path), true)
           isdone()
         }),
       )
@@ -259,7 +259,7 @@ var suiteMEG = describe('utils.type.isMEG', function() {
     badFilenames.forEach(function(path) {
       suiteMEG.addTest(
         new Test("isMeg('" + path + "') === false", function(isdone) {
-          assert.equal(utils.type.isMeg(path), false)
+          assert.equal(utils.type.file.isMeg(path), false)
           isdone()
         }),
       )
@@ -273,7 +273,7 @@ var suiteMEG = describe('utils.type.isMEG', function() {
   })
 })
 
-var suiteEEG = describe('utils.type.isEEG', function() {
+var suiteEEG = describe('utils.type.file.isEEG', function() {
   before(function(done) {
     var goodFilenames = [
       '/sub-01/ses-001/eeg/sub-01_ses-001_task-rest_run-01_eeg.json',
@@ -284,7 +284,7 @@ var suiteEEG = describe('utils.type.isEEG', function() {
     goodFilenames.forEach(function(path) {
       suiteEEG.addTest(
         new Test("isEeg('" + path + "') === true", function(isdone) {
-          assert.equal(utils.type.isEeg(path), true)
+          assert.equal(utils.type.file.isEeg(path), true)
           isdone()
         }),
       )
@@ -299,7 +299,7 @@ var suiteEEG = describe('utils.type.isEEG', function() {
     badFilenames.forEach(function(path) {
       suiteEEG.addTest(
         new Test("isEeg('" + path + "') === false", function(isdone) {
-          assert.equal(utils.type.isEeg(path), false)
+          assert.equal(utils.type.file.isEeg(path), false)
           isdone()
         }),
       )
@@ -313,7 +313,7 @@ var suiteEEG = describe('utils.type.isEEG', function() {
   })
 })
 
-var suiteIEEG = describe('utils.type.isIEEG', function() {
+var suiteIEEG = describe('utils.type.file.isIEEG', function() {
   before(function(done) {
     var goodFilenames = [
       '/sub-01/ses-001/ieeg/sub-01_ses-001_task-rest_run-01_ieeg.json',
@@ -328,7 +328,7 @@ var suiteIEEG = describe('utils.type.isIEEG', function() {
     goodFilenames.forEach(function(path) {
       suiteIEEG.addTest(
         new Test("isIEEG('" + path + "') === true", function(isdone) {
-          assert.equal(utils.type.isIEEG(path), true)
+          assert.equal(utils.type.file.isIEEG(path), true)
           isdone()
         }),
       )
@@ -343,7 +343,7 @@ var suiteIEEG = describe('utils.type.isIEEG', function() {
     badFilenames.forEach(function(path) {
       suiteIEEG.addTest(
         new Test("isIEEG('" + path + "') === false", function(isdone) {
-          assert.equal(utils.type.isIEEG(path), false)
+          assert.equal(utils.type.file.isIEEG(path), false)
           isdone()
         }),
       )
@@ -357,24 +357,24 @@ var suiteIEEG = describe('utils.type.isIEEG', function() {
   })
 })
 
-describe('utils.type.isPhenotypic', function() {
+describe('utils.type.file.isPhenotypic', function() {
   it('should allow .tsv and .json files in the /phenotype directory', function() {
-    assert(utils.type.isPhenotypic('/phenotype/acds_adult.json'))
-    assert(utils.type.isPhenotypic('/phenotype/acds_adult.tsv'))
+    assert(utils.type.file.isPhenotypic('/phenotype/acds_adult.json'))
+    assert(utils.type.file.isPhenotypic('/phenotype/acds_adult.tsv'))
   })
 
   it('should not allow non .tsv and .json files in the /phenotype directory', function() {
-    assert(!utils.type.isPhenotypic('/phenotype/acds_adult.jpeg'))
-    assert(!utils.type.isPhenotypic('/phenotype/acds_adult.gif'))
+    assert(!utils.type.file.isPhenotypic('/phenotype/acds_adult.jpeg'))
+    assert(!utils.type.file.isPhenotypic('/phenotype/acds_adult.gif'))
   })
 })
 
-describe('utils.type.isAssociatedData', function() {
+describe('utils.type.file.isAssociatedData', function() {
   it('should return false for unknown root directories', function() {
     var badFilenames = ['/images/picture.jpeg', '/temporary/test.json']
 
     badFilenames.forEach(function(path) {
-      assert.equal(utils.type.isAssociatedData(path), false)
+      assert.equal(utils.type.file.isAssociatedData(path), false)
     })
   })
 
@@ -387,17 +387,17 @@ describe('utils.type.isAssociatedData', function() {
     ]
 
     goodFilenames.forEach(function(path) {
-      assert(utils.type.isAssociatedData(path))
+      assert(utils.type.file.isAssociatedData(path))
     })
   })
 })
 
-describe('utils.type.isStimuliData', function() {
+describe('utils.type.file.isStimuliData', function() {
   it('should return false for unknown root directories', function() {
     var badFilenames = ['/images/picture.jpeg', '/temporary/test.json']
 
     badFilenames.forEach(function(path) {
-      assert.equal(utils.type.isStimuliData(path), false)
+      assert.equal(utils.type.file.isStimuliData(path), false)
     })
   })
 
@@ -405,7 +405,7 @@ describe('utils.type.isStimuliData', function() {
     var goodFilenames = ['/stimuli/sub-01/mov.avi', '/stimuli/text.pdf']
 
     goodFilenames.forEach(function(path) {
-      assert(utils.type.isStimuliData(path))
+      assert(utils.type.file.isStimuliData(path))
     })
   })
 })

--- a/utils/issues/list.js
+++ b/utils/issues/list.js
@@ -480,4 +480,14 @@ module.exports = {
     reason:
       "The number of elements in the SliceTiming array should match the 'k' dimension of the corresponding nifti volume.",
   },
+  88: {
+    key: 'MALFORMED_BVEC',
+    severity: 'error',
+    reason: 'The contents of this .bvec file are undefined or severely malformed. '
+  },
+  89: {
+    key: 'MALFORMED_BVAL',
+    severity: 'error',
+    reason: 'The contents of this .bval file are undefined or severely malformed. '
+  }
 }

--- a/utils/type.js
+++ b/utils/type.js
@@ -374,6 +374,14 @@ module.exports = {
     return !isNaN(parseFloat(n)) && isFinite(n)
   },
 
+  isUndefined: function(obj) {
+    return typeof obj == 'undefined'
+  },
+
+  isString: function(obj) {
+    return typeof obj == 'string'
+  },
+
   /**
    * Get Path Values
    *

--- a/utils/type.js
+++ b/utils/type.js
@@ -33,341 +33,347 @@ module.exports = {
    */
   isBIDS: function(path, bep006, bep010) {
     return (
-      this.isTopLevel(path) ||
-      this.isStimuliData(path) ||
-      this.isSessionLevel(path) ||
-      this.isSubjectLevel(path) ||
-      this.isAnat(path) ||
-      this.isDWI(path) ||
-      this.isFunc(path) ||
-      this.isMeg(path) ||
-      (this.isIEEG(path) && bep010) ||
-      (this.isEeg(path) && bep006) ||
-      this.isBehavioral(path) ||
-      this.isCont(path) ||
-      this.isFieldMap(path) ||
-      this.isPhenotypic(path)
+      this.file.isTopLevel(path) ||
+      this.file.isStimuliData(path) ||
+      this.file.isSessionLevel(path) ||
+      this.file.isSubjectLevel(path) ||
+      this.file.isAnat(path) ||
+      this.file.isDWI(path) ||
+      this.file.isFunc(path) ||
+      this.file.isMeg(path) ||
+      (this.file.isIEEG(path) && bep010) ||
+      (this.file.isEeg(path) && bep006) ||
+      this.file.isBehavioral(path) ||
+      this.file.isCont(path) ||
+      this.file.isFieldMap(path) ||
+      this.file.isPhenotypic(path)
     )
   },
 
   /**
-   * Check if the file has appropriate name for a top level file
+   * Object with all file type checks
    */
-  isTopLevel: function(path) {
-    var fixedTopLevelNames = [
-      '/README',
-      '/CHANGES',
-      '/dataset_description.json',
-      '/participants.tsv',
-      '/participants.json',
-      '/phasediff.json',
-      '/phase1.json',
-      '/phase2.json',
-      '/fieldmap.json',
-    ]
+  file: {
+    /**
+     * Check if the file has appropriate name for a top level file
+     */
+    isTopLevel: function(path) {
+      var fixedTopLevelNames = [
+        '/README',
+        '/CHANGES',
+        '/dataset_description.json',
+        '/participants.tsv',
+        '/participants.json',
+        '/phasediff.json',
+        '/phase1.json',
+        '/phase2.json',
+        '/fieldmap.json',
+      ]
 
-    var funcTopRe = new RegExp(
-      '^\\/(?:ses-[a-zA-Z0-9]+_)?(?:recording-[a-zA-Z0-9]+_)?(?:task-[a-zA-Z0-9]+_)?(?:acq-[a-zA-Z0-9]+_)?(?:rec-[a-zA-Z0-9]+_)?(?:run-[0-9]+_)?(?:echo-[0-9]+_)?' +
-        '(bold.json|sbref.json|events.json|events.tsv|physio.json|stim.json|beh.json)$',
-    )
+      var funcTopRe = new RegExp(
+        '^\\/(?:ses-[a-zA-Z0-9]+_)?(?:recording-[a-zA-Z0-9]+_)?(?:task-[a-zA-Z0-9]+_)?(?:acq-[a-zA-Z0-9]+_)?(?:rec-[a-zA-Z0-9]+_)?(?:run-[0-9]+_)?(?:echo-[0-9]+_)?' +
+          '(bold.json|sbref.json|events.json|events.tsv|physio.json|stim.json|beh.json)$',
+      )
 
-    var anatTopRe = new RegExp(
-      '^\\/(?:ses-[a-zA-Z0-9]+_)?(?:acq-[a-zA-Z0-9]+_)?(?:rec-[a-zA-Z0-9]+_)?(?:run-[0-9]+_)?' +
-        '(' +
-        anatSuffixes.join('|') +
-        ').json$',
-    )
+      var anatTopRe = new RegExp(
+        '^\\/(?:ses-[a-zA-Z0-9]+_)?(?:acq-[a-zA-Z0-9]+_)?(?:rec-[a-zA-Z0-9]+_)?(?:run-[0-9]+_)?' +
+          '(' +
+          anatSuffixes.join('|') +
+          ').json$',
+      )
 
-    var dwiTopRe = new RegExp(
-      '^\\/(?:ses-[a-zA-Z0-9]+_)?(?:acq-[a-zA-Z0-9]+_)?(?:rec-[a-zA-Z0-9]+_)?(?:run-[0-9]+_)?' +
-        'dwi.(?:json|bval|bvec)$',
-    )
+      var dwiTopRe = new RegExp(
+        '^\\/(?:ses-[a-zA-Z0-9]+_)?(?:acq-[a-zA-Z0-9]+_)?(?:rec-[a-zA-Z0-9]+_)?(?:run-[0-9]+_)?' +
+          'dwi.(?:json|bval|bvec)$',
+      )
 
-    var multiDirFieldmapRe = new RegExp('^\\/(?:dir-[a-zA-Z0-9]+)_epi.json$')
+      var multiDirFieldmapRe = new RegExp('^\\/(?:dir-[a-zA-Z0-9]+)_epi.json$')
 
-    var megTopRe = new RegExp(
-      '^\\/(?:ses-[a-zA-Z0-9]+_)?task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_proc-[a-zA-Z0-9]+)?' +
-        '(_meg.json|_channels.tsv|_photo.jpg|_coordsystem.json)$',
-    )
+      var megTopRe = new RegExp(
+        '^\\/(?:ses-[a-zA-Z0-9]+_)?task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_proc-[a-zA-Z0-9]+)?' +
+          '(_meg.json|_channels.tsv|_photo.jpg|_coordsystem.json)$',
+      )
 
-    var ieegTopRe = new RegExp(
-      '^\\/(?:ses-[a-zA-Z0-9]+_)?task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_proc-[a-zA-Z0-9]+)?' +
-        '(_ieeg.json|_channels.tsv|_electrodes.tsv|_photo.jpg|_coordsystem.json)$',
-    )
-    var eegTopRe = new RegExp(
-      '^\\/(?:ses-[a-zA-Z0-9]+_)?task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_proc-[a-zA-Z0-9]+)?' +
-        '(_eeg.json|_channels.tsv|_photo.jpg|_coordsystem.json)$',
-    )
+      var ieegTopRe = new RegExp(
+        '^\\/(?:ses-[a-zA-Z0-9]+_)?task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_proc-[a-zA-Z0-9]+)?' +
+          '(_ieeg.json|_channels.tsv|_electrodes.tsv|_photo.jpg|_coordsystem.json)$',
+      )
+      var eegTopRe = new RegExp(
+        '^\\/(?:ses-[a-zA-Z0-9]+_)?task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_proc-[a-zA-Z0-9]+)?' +
+          '(_eeg.json|_channels.tsv|_photo.jpg|_coordsystem.json)$',
+      )
 
-    var otherTopFiles = new RegExp(
-      '^\\/(?:ses-[a-zA-Z0-9]+_)?(?:recording-[a-zA-Z0-9]+_)?(?:task-[a-zA-Z0-9]+_)?(?:acq-[a-zA-Z0-9]+_)?(?:rec-[a-zA-Z0-9]+_)?(?:run-[0-9]+_)?' +
-        '(physio.json|stim.json)$',
-    )
+      var otherTopFiles = new RegExp(
+        '^\\/(?:ses-[a-zA-Z0-9]+_)?(?:recording-[a-zA-Z0-9]+_)?(?:task-[a-zA-Z0-9]+_)?(?:acq-[a-zA-Z0-9]+_)?(?:rec-[a-zA-Z0-9]+_)?(?:run-[0-9]+_)?' +
+          '(physio.json|stim.json)$',
+      )
 
-    return (
-      fixedTopLevelNames.indexOf(path) != -1 ||
-      funcTopRe.test(path) ||
-      dwiTopRe.test(path) ||
-      anatTopRe.test(path) ||
-      multiDirFieldmapRe.test(path) ||
-      otherTopFiles.test(path) ||
-      megTopRe.test(path) ||
-      eegTopRe.test(path) ||
-      ieegTopRe.test(path)
-    )
-  },
+      return (
+        fixedTopLevelNames.indexOf(path) != -1 ||
+        funcTopRe.test(path) ||
+        dwiTopRe.test(path) ||
+        anatTopRe.test(path) ||
+        multiDirFieldmapRe.test(path) ||
+        otherTopFiles.test(path) ||
+        megTopRe.test(path) ||
+        eegTopRe.test(path) ||
+        ieegTopRe.test(path)
+      )
+    },
 
-  /**
-   * Check if file is appropriate associated data.
-   */
-  isAssociatedData: function(path) {
-    var associatedData = new RegExp(
-      '^\\/(?:code|derivatives|sourcedata|stimuli|[.]git)\\/(?:.*)$',
-    )
-    return associatedData.test(path)
-  },
+    /**
+     * Check if file is appropriate associated data.
+     */
+    isAssociatedData: function(path) {
+      var associatedData = new RegExp(
+        '^\\/(?:code|derivatives|sourcedata|stimuli|[.]git)\\/(?:.*)$',
+      )
+      return associatedData.test(path)
+    },
 
-  isStimuliData: function(path) {
-    var stimuliDataRe = new RegExp('^\\/(?:stimuli)\\/(?:.*)$')
-    return stimuliDataRe.test(path)
-  },
+    isStimuliData: function(path) {
+      var stimuliDataRe = new RegExp('^\\/(?:stimuli)\\/(?:.*)$')
+      return stimuliDataRe.test(path)
+    },
 
-  /**
-   * Check if file is phenotypic data.
-   */
-  isPhenotypic: function(path) {
-    var phenotypicData = new RegExp('^\\/(?:phenotype)\\/(?:.*.tsv|.*.json)$')
-    return phenotypicData.test(path)
-  },
+    /**
+     * Check if file is phenotypic data.
+     */
+    isPhenotypic: function(path) {
+      var phenotypicData = new RegExp('^\\/(?:phenotype)\\/(?:.*.tsv|.*.json)$')
+      return phenotypicData.test(path)
+    },
 
-  /**
-   * Check if the file has appropriate name for a session level
-   */
-  isSessionLevel: function(path) {
-    var scansRe = new RegExp(
-      '^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)' +
-        '\\/)?\\1(_\\2)?(_scans.tsv|_scans.json)$',
-    )
+    /**
+     * Check if the file has appropriate name for a session level
+     */
+    isSessionLevel: function(path) {
+      var scansRe = new RegExp(
+        '^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)' +
+          '\\/)?\\1(_\\2)?(_scans.tsv|_scans.json)$',
+      )
 
-    var funcSesRe = new RegExp(
-      '^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)' +
-        '\\/)?\\1(_\\2)?_task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_echo-[0-9]+)?' +
-        '(_bold.json|_sbref.json|_events.json|_events.tsv|_physio.json|_stim.json)$',
-    )
+      var funcSesRe = new RegExp(
+        '^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)' +
+          '\\/)?\\1(_\\2)?_task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_echo-[0-9]+)?' +
+          '(_bold.json|_sbref.json|_events.json|_events.tsv|_physio.json|_stim.json)$',
+      )
 
-    var anatSesRe = new RegExp(
-      '^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)' +
-        '\\/)?\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+_)?' +
-        '(' +
-        anatSuffixes.join('|') +
-        ').json$',
-    )
+      var anatSesRe = new RegExp(
+        '^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)' +
+          '\\/)?\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+_)?' +
+          '(' +
+          anatSuffixes.join('|') +
+          ').json$',
+      )
 
-    var dwiSesRe = new RegExp(
-      '^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)' +
-        '\\/)?\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_)?' +
-        'dwi.(?:json|bval|bvec)$',
-    )
+      var dwiSesRe = new RegExp(
+        '^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)' +
+          '\\/)?\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_)?' +
+          'dwi.(?:json|bval|bvec)$',
+      )
 
-    var megSesRe = new RegExp(
-      '^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)' +
-        '\\/)?\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_proc-[a-zA-Z0-9]+)?' +
-        '(_events.tsv|_channels.tsv|_meg.json|_coordsystem.json|_photo.jpg|_headshape.pos)$',
-    )
+      var megSesRe = new RegExp(
+        '^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)' +
+          '\\/)?\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_proc-[a-zA-Z0-9]+)?' +
+          '(_events.tsv|_channels.tsv|_meg.json|_coordsystem.json|_photo.jpg|_headshape.pos)$',
+      )
 
-    var eegSesRe = new RegExp(
-      '^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)' +
-        '\\/)?\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_proc-[a-zA-Z0-9]+)?' +
-        '(_events.tsv|_channels.tsv|_eeg.json|_coordsystem.json|_photo.jpg)$',
-    )
+      var eegSesRe = new RegExp(
+        '^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)' +
+          '\\/)?\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_proc-[a-zA-Z0-9]+)?' +
+          '(_events.tsv|_channels.tsv|_eeg.json|_coordsystem.json|_photo.jpg)$',
+      )
 
-    var ieegSesRe = new RegExp(
-      '^\\/(sub-[a-zA-Z0-9]+)' +
-        '\\/(?:(ses-[a-zA-Z0-9]+)' +
-        '\\/)?\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_proc-[a-zA-Z0-9]+)?(?:_space-[a-zA-Z0-9]+)?' +
-        '(_events.tsv|_channels.tsv|_electrodes.tsv|_ieeg.json|_coordsystem.json|_photo.jpg|_headshape.pos)$',
-    )
+      var ieegSesRe = new RegExp(
+        '^\\/(sub-[a-zA-Z0-9]+)' +
+          '\\/(?:(ses-[a-zA-Z0-9]+)' +
+          '\\/)?\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_proc-[a-zA-Z0-9]+)?(?:_space-[a-zA-Z0-9]+)?' +
+          '(_events.tsv|_channels.tsv|_electrodes.tsv|_ieeg.json|_coordsystem.json|_photo.jpg|_headshape.pos)$',
+      )
 
-    return (
-      conditionalMatch(scansRe, path) ||
-      conditionalMatch(funcSesRe, path) ||
-      conditionalMatch(anatSesRe, path) ||
-      conditionalMatch(dwiSesRe, path) ||
-      conditionalMatch(megSesRe, path) ||
-      conditionalMatch(eegSesRe, path) ||
-      conditionalMatch(ieegSesRe, path)
-    )
-  },
+      return (
+        conditionalMatch(scansRe, path) ||
+        conditionalMatch(funcSesRe, path) ||
+        conditionalMatch(anatSesRe, path) ||
+        conditionalMatch(dwiSesRe, path) ||
+        conditionalMatch(megSesRe, path) ||
+        conditionalMatch(eegSesRe, path) ||
+        conditionalMatch(ieegSesRe, path)
+      )
+    },
 
-  /**
-   * Check if the file has appropriate name for a subject level
-   */
-  isSubjectLevel: function(path) {
-    var scansRe = new RegExp(
-      '^\\/(sub-[a-zA-Z0-9]+)' + '\\/\\1(_sessions.tsv|_sessions.json)$',
-    )
-    return scansRe.test(path)
-  },
+    /**
+     * Check if the file has appropriate name for a subject level
+     */
+    isSubjectLevel: function(path) {
+      var scansRe = new RegExp(
+        '^\\/(sub-[a-zA-Z0-9]+)' + '\\/\\1(_sessions.tsv|_sessions.json)$',
+      )
+      return scansRe.test(path)
+    },
 
-  /**
-   * Check if the file has a name appropriate for an anatomical scan
-   */
-  isAnat: function(path) {
-    var anatRe = new RegExp(
-      '^\\/(sub-[a-zA-Z0-9]+)' +
-        '\\/(?:(ses-[a-zA-Z0-9]+)' +
-        '\\/)?anat' +
-        '\\/\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?_(?:' +
-        anatSuffixes.join('|') +
-        ').(nii.gz|nii|json)$',
-    )
+    /**
+     * Check if the file has a name appropriate for an anatomical scan
+     */
+    isAnat: function(path) {
+      var anatRe = new RegExp(
+        '^\\/(sub-[a-zA-Z0-9]+)' +
+          '\\/(?:(ses-[a-zA-Z0-9]+)' +
+          '\\/)?anat' +
+          '\\/\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?_(?:' +
+          anatSuffixes.join('|') +
+          ').(nii.gz|nii|json)$',
+      )
 
-    var anatDefacemaskRe = new RegExp(
-      '^\\/(sub-[a-zA-Z0-9]+)' +
-        '\\/(?:(ses-[a-zA-Z0-9]+)' +
-        '\\/)?anat' +
-        '\\/\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_mod-(' +
-        anatSuffixes.join('|') +
-        '))?_defacemask.(nii.gz|nii)$',
-    )
-    return (
-      conditionalMatch(anatRe, path) || conditionalMatch(anatDefacemaskRe, path)
-    )
-  },
+      var anatDefacemaskRe = new RegExp(
+        '^\\/(sub-[a-zA-Z0-9]+)' +
+          '\\/(?:(ses-[a-zA-Z0-9]+)' +
+          '\\/)?anat' +
+          '\\/\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_mod-(' +
+          anatSuffixes.join('|') +
+          '))?_defacemask.(nii.gz|nii)$',
+      )
+      return (
+        conditionalMatch(anatRe, path) ||
+        conditionalMatch(anatDefacemaskRe, path)
+      )
+    },
 
-  /**
-   * Check if the file has a name appropriate for a diffusion scan
-   */
-  isDWI: function(path) {
-    var suffixes = ['dwi', 'sbref']
-    var anatRe = new RegExp(
-      '^\\/(sub-[a-zA-Z0-9]+)' +
-        '\\/(?:(ses-[a-zA-Z0-9]+)' +
-        '\\/)?dwi' +
-        '\\/\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?_(?:' +
-        suffixes.join('|') +
-        ').(nii.gz|nii|json|bvec|bval)$',
-    )
-    return conditionalMatch(anatRe, path)
-  },
+    /**
+     * Check if the file has a name appropriate for a diffusion scan
+     */
+    isDWI: function(path) {
+      var suffixes = ['dwi', 'sbref']
+      var anatRe = new RegExp(
+        '^\\/(sub-[a-zA-Z0-9]+)' +
+          '\\/(?:(ses-[a-zA-Z0-9]+)' +
+          '\\/)?dwi' +
+          '\\/\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?_(?:' +
+          suffixes.join('|') +
+          ').(nii.gz|nii|json|bvec|bval)$',
+      )
+      return conditionalMatch(anatRe, path)
+    },
 
-  /**
-   * Check if the file has a name appropriate for a fieldmap scan
-   */
-  isFieldMap: function(path) {
-    var suffixes = [
-      'phasediff',
-      'phase1',
-      'phase2',
-      'magnitude1',
-      'magnitude2',
-      'magnitude',
-      'fieldmap',
-      'epi',
-    ]
-    var anatRe = new RegExp(
-      '^\\/(sub-[a-zA-Z0-9]+)' +
-        '\\/(?:(ses-[a-zA-Z0-9]+)' +
-        '\\/)?fmap' +
-        '\\/\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_dir-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?_(?:' +
-        suffixes.join('|') +
-        ').(nii.gz|nii|json)$',
-    )
-    return conditionalMatch(anatRe, path)
-  },
+    /**
+     * Check if the file has a name appropriate for a fieldmap scan
+     */
+    isFieldMap: function(path) {
+      var suffixes = [
+        'phasediff',
+        'phase1',
+        'phase2',
+        'magnitude1',
+        'magnitude2',
+        'magnitude',
+        'fieldmap',
+        'epi',
+      ]
+      var anatRe = new RegExp(
+        '^\\/(sub-[a-zA-Z0-9]+)' +
+          '\\/(?:(ses-[a-zA-Z0-9]+)' +
+          '\\/)?fmap' +
+          '\\/\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_dir-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?_(?:' +
+          suffixes.join('|') +
+          ').(nii.gz|nii|json)$',
+      )
+      return conditionalMatch(anatRe, path)
+    },
 
-  isFieldMapMainNii: function(path) {
-    var suffixes = ['phasediff', 'phase1', 'phase2', 'fieldmap', 'epi']
-    var anatRe = new RegExp(
-      '^\\/(sub-[a-zA-Z0-9]+)' +
-        '\\/(?:(ses-[a-zA-Z0-9]+)' +
-        '\\/)?fmap' +
-        '\\/\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_dir-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?_(?:' +
-        suffixes.join('|') +
-        ').(nii.gz|nii)$',
-    )
-    return conditionalMatch(anatRe, path)
-  },
+    isFieldMapMainNii: function(path) {
+      var suffixes = ['phasediff', 'phase1', 'phase2', 'fieldmap', 'epi']
+      var anatRe = new RegExp(
+        '^\\/(sub-[a-zA-Z0-9]+)' +
+          '\\/(?:(ses-[a-zA-Z0-9]+)' +
+          '\\/)?fmap' +
+          '\\/\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_dir-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?_(?:' +
+          suffixes.join('|') +
+          ').(nii.gz|nii)$',
+      )
+      return conditionalMatch(anatRe, path)
+    },
 
-  /**
-   * Check if the file has a name appropriate for a functional scan
-   */
-  isFunc: function(path) {
-    var funcRe = new RegExp(
-      '^\\/(sub-[a-zA-Z0-9]+)' +
-        '\\/(?:(ses-[a-zA-Z0-9]+)' +
-        '\\/)?func' +
-        '\\/\\1(_\\2)?_task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_echo-[0-9]+)?' +
-        '(?:_bold.nii.gz|_bold.nii|_bold.json|_sbref.nii.gz|_sbref.nii|_sbref.json|_events.json|_events.tsv|_physio.tsv.gz|_stim.tsv.gz|_physio.json|_stim.json|_defacemask.nii.gz|_defacemask.nii)$',
-    )
-    return conditionalMatch(funcRe, path)
-  },
+    /**
+     * Check if the file has a name appropriate for a functional scan
+     */
+    isFunc: function(path) {
+      var funcRe = new RegExp(
+        '^\\/(sub-[a-zA-Z0-9]+)' +
+          '\\/(?:(ses-[a-zA-Z0-9]+)' +
+          '\\/)?func' +
+          '\\/\\1(_\\2)?_task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_echo-[0-9]+)?' +
+          '(?:_bold.nii.gz|_bold.nii|_bold.json|_sbref.nii.gz|_sbref.nii|_sbref.json|_events.json|_events.tsv|_physio.tsv.gz|_stim.tsv.gz|_physio.json|_stim.json|_defacemask.nii.gz|_defacemask.nii)$',
+      )
+      return conditionalMatch(funcRe, path)
+    },
 
-  isMeg: function(path) {
-    var MegRe = new RegExp(
-      '^\\/(sub-[a-zA-Z0-9]+)' +
-        '\\/(?:(ses-[a-zA-Z0-9]+)' +
-        '\\/)?meg' +
-        '\\/\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_proc-[a-zA-Z0-9]+)?(?:_part-[0-9]+)?' +
-        '(_meg(.fif|.fif.gz|.ds\\/.*|\\/.*)|(_events.tsv|_channels.tsv|_meg.json|_coordsystem.json|_photo.jpg|_headshape.pos))$',
-    )
-    return conditionalMatch(MegRe, path)
-  },
+    isMeg: function(path) {
+      var MegRe = new RegExp(
+        '^\\/(sub-[a-zA-Z0-9]+)' +
+          '\\/(?:(ses-[a-zA-Z0-9]+)' +
+          '\\/)?meg' +
+          '\\/\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_proc-[a-zA-Z0-9]+)?(?:_part-[0-9]+)?' +
+          '(_meg(.fif|.fif.gz|.ds\\/.*|\\/.*)|(_events.tsv|_channels.tsv|_meg.json|_coordsystem.json|_photo.jpg|_headshape.pos))$',
+      )
+      return conditionalMatch(MegRe, path)
+    },
 
-  isEeg: function(path) {
-    var EegRe = new RegExp(
-      '^\\/(sub-[a-zA-Z0-9]+)' +
-        '\\/(?:(ses-[a-zA-Z0-9]+)' +
-        '\\/)?eeg' +
-        '\\/\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_proc-[a-zA-Z0-9]+)?(?:_part-[0-9]+)?' +
-        '(_eeg.(vhdr|vmrk|eeg|edf|bdf|set|fdt|cnt)|(_events.tsv|_electrodes.tsv|_channels.tsv|_eeg.json|_coordsystem.json|_photo.jpg))$',
-    )
-    return conditionalMatch(EegRe, path)
-  },
+    isEeg: function(path) {
+      var EegRe = new RegExp(
+        '^\\/(sub-[a-zA-Z0-9]+)' +
+          '\\/(?:(ses-[a-zA-Z0-9]+)' +
+          '\\/)?eeg' +
+          '\\/\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_proc-[a-zA-Z0-9]+)?(?:_part-[0-9]+)?' +
+          '(_eeg.(vhdr|vmrk|eeg|edf|bdf|set|fdt|cnt)|(_events.tsv|_electrodes.tsv|_channels.tsv|_eeg.json|_coordsystem.json|_photo.jpg))$',
+      )
+      return conditionalMatch(EegRe, path)
+    },
 
-  isIEEG: function(path) {
-    var IEEGRe = new RegExp(
-      '^\\/(sub-[a-zA-Z0-9]+)' +
-        '\\/(?:(ses-[a-zA-Z0-9]+)' +
-        '\\/)?ieeg' +
-        '\\/\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_proc-[a-zA-Z0-9]+)?(?:_part-[0-9]+)?(?:_space-[a-zA-Z0-9]+)?' +
-        '(_ieeg.(edf|vhdr|vmrk|dat)|(_events.tsv|_channels.tsv|_electrodes.tsv|_ieeg.json|_coordsystem.json|_photo.jpg))$',
-    )
-    return conditionalMatch(IEEGRe, path)
-  },
+    isIEEG: function(path) {
+      var IEEGRe = new RegExp(
+        '^\\/(sub-[a-zA-Z0-9]+)' +
+          '\\/(?:(ses-[a-zA-Z0-9]+)' +
+          '\\/)?ieeg' +
+          '\\/\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_proc-[a-zA-Z0-9]+)?(?:_part-[0-9]+)?(?:_space-[a-zA-Z0-9]+)?' +
+          '(_ieeg.(edf|vhdr|vmrk|dat)|(_events.tsv|_channels.tsv|_electrodes.tsv|_ieeg.json|_coordsystem.json|_photo.jpg))$',
+      )
+      return conditionalMatch(IEEGRe, path)
+    },
 
-  isBehavioral: function(path) {
-    var funcBeh = new RegExp(
-      '^\\/(sub-[a-zA-Z0-9]+)' +
-        '\\/(?:(ses-[a-zA-Z0-9]+)' +
-        '\\/)?beh' +
-        '\\/\\1(_\\2)?_task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?' +
-        '(?:_beh.json|_beh.tsv|_events.json|_events.tsv|_physio.tsv.gz|_stim.tsv.gz|_physio.json|_stim.json)$',
-    )
-    return conditionalMatch(funcBeh, path)
-  },
+    isBehavioral: function(path) {
+      var funcBeh = new RegExp(
+        '^\\/(sub-[a-zA-Z0-9]+)' +
+          '\\/(?:(ses-[a-zA-Z0-9]+)' +
+          '\\/)?beh' +
+          '\\/\\1(_\\2)?_task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?' +
+          '(?:_beh.json|_beh.tsv|_events.json|_events.tsv|_physio.tsv.gz|_stim.tsv.gz|_physio.json|_stim.json)$',
+      )
+      return conditionalMatch(funcBeh, path)
+    },
 
-  isFuncBold: function(path) {
-    var funcRe = new RegExp(
-      '^\\/(sub-[a-zA-Z0-9]+)' +
-        '\\/(?:(ses-[a-zA-Z0-9]+)' +
-        '\\/)?func' +
-        '\\/\\1(_\\2)?_task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_echo-[0-9]+)?' +
-        '(?:_bold.nii.gz|_bold.nii|_sbref.nii.gz|_sbref.nii)$',
-    )
-    return conditionalMatch(funcRe, path)
-  },
+    isFuncBold: function(path) {
+      var funcRe = new RegExp(
+        '^\\/(sub-[a-zA-Z0-9]+)' +
+          '\\/(?:(ses-[a-zA-Z0-9]+)' +
+          '\\/)?func' +
+          '\\/\\1(_\\2)?_task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_echo-[0-9]+)?' +
+          '(?:_bold.nii.gz|_bold.nii|_sbref.nii.gz|_sbref.nii)$',
+      )
+      return conditionalMatch(funcRe, path)
+    },
 
-  isCont: function(path) {
-    var contRe = new RegExp(
-      '^\\/(sub-[a-zA-Z0-9]+)' +
-        '\\/(?:(ses-[a-zA-Z0-9]+)' +
-        '\\/)?(?:func|beh)' +
-        '\\/\\1(_\\2)?_task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?' +
-        '(?:_recording-[a-zA-Z0-9]+)?' +
-        '(?:_physio.tsv.gz|_stim.tsv.gz|_physio.json|_stim.json)$',
-    )
-    return conditionalMatch(contRe, path)
+    isCont: function(path) {
+      var contRe = new RegExp(
+        '^\\/(sub-[a-zA-Z0-9]+)' +
+          '\\/(?:(ses-[a-zA-Z0-9]+)' +
+          '\\/)?(?:func|beh)' +
+          '\\/\\1(_\\2)?_task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?' +
+          '(?:_recording-[a-zA-Z0-9]+)?' +
+          '(?:_physio.tsv.gz|_stim.tsv.gz|_physio.json|_stim.json)$',
+      )
+      return conditionalMatch(contRe, path)
+    },
   },
 
   checkType(obj, typeString) {

--- a/utils/type.js
+++ b/utils/type.js
@@ -370,16 +370,12 @@ module.exports = {
     return conditionalMatch(contRe, path)
   },
 
-  isNumber: function(n) {
-    return !isNaN(parseFloat(n)) && isFinite(n)
-  },
-
-  isUndefined: function(obj) {
-    return typeof obj == 'undefined'
-  },
-
-  isString: function(obj) {
-    return typeof obj == 'string'
+  checkType(obj, typeString) {
+    if (typeString == 'number') {
+      return !isNaN(parseFloat(obj)) && isFinite(obj)
+    } else {
+      return typeof obj == typeString
+    }
   },
 
   /**

--- a/validators/bids.js
+++ b/validators/bids.js
@@ -289,7 +289,7 @@ BIDS = {
         )
 
         // ignore associated data
-        if (utils.type.isStimuliData(file.relativePath)) {
+        if (utils.type.file.isStimuliData(file.relativePath)) {
           stimuli.directory.push(file)
           process.nextTick(cb)
         }
@@ -499,7 +499,7 @@ BIDS = {
 
         // collect sessions & subjects
         if (
-          !utils.type.isStimuliData(file.relativePath) &&
+          !utils.type.file.isStimuliData(file.relativePath) &&
           utils.type.isBIDS(
             file.relativePath,
             BIDS.options.bep006,

--- a/validators/bval.js
+++ b/validators/bval.js
@@ -13,14 +13,18 @@ module.exports = function bval(file, contents, callback) {
   var issues = []
 
   // throw error if contents are undefined or the wrong type
-  if (!contents || typeof(contents) !== 'string') {
-    let evidence = contents ? 'The contents of this .bval file have type ' + typeof(contents) + ' but should be a string.' : 'The contents of this .bval file are undefined.'
+  if (!contents || typeof contents !== 'string') {
+    let evidence = contents
+      ? 'The contents of this .bval file have type ' +
+        typeof contents +
+        ' but should be a string.'
+      : 'The contents of this .bval file are undefined.'
     issues.push(
       new Issue({
         code: 89,
         file: file,
-        evidence: evidence
-      })
+        evidence: evidence,
+      }),
     )
     return callback(issues)
   }

--- a/validators/bval.js
+++ b/validators/bval.js
@@ -12,6 +12,19 @@ var type = require('../utils').type
 module.exports = function bval(file, contents, callback) {
   var issues = []
 
+  // throw error if contents are undefined or the wrong type
+  if (!contents || typeof(contents) !== 'string') {
+    let evidence = contents ? 'The contents of this .bval file have type ' + typeof(contents) + ' but should be a string.' : 'The contents of this .bval file are undefined.'
+    issues.push(
+      new Issue({
+        code: 89,
+        file: file,
+        evidence: evidence
+      })
+    )
+    return callback(issues)
+  }
+
   if (contents.replace(/^\s+|\s+$/g, '').split('\n').length !== 1) {
     issues.push(
       new Issue({

--- a/validators/bval.js
+++ b/validators/bval.js
@@ -10,10 +10,27 @@ var type = require('../utils').type
  * against the BIDS specification.
  */
 module.exports = function bval(file, contents, callback) {
-  var issues = []
+  let issues = []
 
-  // throw error if contents are undefined or the wrong type
-  if (!contents || typeof contents !== 'string') {
+  // break val if type of contents is not string
+  issues = issues.concat(checkType(contents, file))
+  if (issues.length) {
+    return callback(issues)
+  }
+
+  // check number of rows in contents
+  issues = issues.concat(checkNumberOfRows(contents, file))
+
+  // check for proper separator and value type
+  issues = issues.concat(checkSeparatorAndValueType(contents, file))
+
+  callback(issues)
+}
+
+function checkType(contents, file) {
+  let issues = []
+  // throw error if contents are not string
+  if (!type.checkType(contents, 'string')) {
     let evidence = contents
       ? 'The contents of this .bval file have type ' +
         typeof contents +
@@ -26,24 +43,17 @@ module.exports = function bval(file, contents, callback) {
         evidence: evidence,
       }),
     )
-    return callback(issues)
   }
+  return issues
+}
 
-  if (contents.replace(/^\s+|\s+$/g, '').split('\n').length !== 1) {
-    issues.push(
-      new Issue({
-        code: 30,
-        file: file,
-      }),
-    )
-  }
-
-  // check for proper separator and value type
-  var row = contents.replace(/^\s+|\s+$/g, '').split(' ')
-  var invalidValue = false
-  for (var j = 0; j < row.length; j++) {
-    var value = row[j]
-    if (!type.isNumber(value)) {
+function checkSeparatorAndValueType(contents, file) {
+  let issues = []
+  const row = contents.replace(/^\s+|\s+$/g, '').split(' ')
+  let invalidValue = false
+  for (let j = 0; j < row.length; j++) {
+    const value = row[j]
+    if (!type.checkType(value, 'number')) {
       invalidValue = true
     }
   }
@@ -55,6 +65,18 @@ module.exports = function bval(file, contents, callback) {
       }),
     )
   }
+  return issues
+}
 
-  callback(issues)
+function checkNumberOfRows(contents, file) {
+  let issues = []
+  if (contents.replace(/^\s+|\s+$/g, '').split('\n').length !== 1) {
+    issues.push(
+      new Issue({
+        code: 30,
+        file: file,
+      }),
+    )
+  }
+  return issues
 }

--- a/validators/bval.js
+++ b/validators/bval.js
@@ -31,11 +31,10 @@ function checkType(contents, file) {
   let issues = []
   // throw error if contents are not string
   if (!type.checkType(contents, 'string')) {
-    let evidence = contents
-      ? 'The contents of this .bval file have type ' +
-        typeof contents +
-        ' but should be a string.'
-      : 'The contents of this .bval file are undefined.'
+    let evidence =
+      'The contents of this .bval file have type ' +
+      typeof contents +
+      ' but should be a string.'
     issues.push(
       new Issue({
         code: 89,
@@ -70,7 +69,8 @@ function checkSeparatorAndValueType(contents, file) {
 
 function checkNumberOfRows(contents, file) {
   let issues = []
-  if (contents.replace(/^\s+|\s+$/g, '').split('\n').length !== 1) {
+  const numberOfRows = contents.replace(/^\s+|\s+$/g, '').split('\n').length
+  if (numberOfRows !== 1) {
     issues.push(
       new Issue({
         code: 30,

--- a/validators/bvec.js
+++ b/validators/bvec.js
@@ -11,16 +11,20 @@ var type = require('../utils').type
  */
 module.exports = function bvec(file, contents, callback) {
   var issues = []
-  
+
   // throw error if contents are undefined or the wrong type
-  if (!contents || typeof(contents) !== 'string') {
-    let evidence = contents ? 'The contents of this .bvec file have type ' + typeof(contents) + ' but should be a string.' : 'The contents of this .bvec file are undefined.'
+  if (!contents || typeof contents !== 'string') {
+    let evidence = contents
+      ? 'The contents of this .bvec file have type ' +
+        typeof contents +
+        ' but should be a string.'
+      : 'The contents of this .bvec file are undefined.'
     issues.push(
       new Issue({
         code: 88,
         file: file,
-        evidence: evidence
-      })
+        evidence: evidence,
+      }),
     )
     return callback(issues)
   }

--- a/validators/bvec.js
+++ b/validators/bvec.js
@@ -11,6 +11,19 @@ var type = require('../utils').type
  */
 module.exports = function bvec(file, contents, callback) {
   var issues = []
+  
+  // throw error if contents are undefined or the wrong type
+  if (!contents || typeof(contents) !== 'string') {
+    let evidence = contents ? 'The contents of this .bvec file have type ' + typeof(contents) + ' but should be a string.' : 'The contents of this .bvec file are undefined.'
+    issues.push(
+      new Issue({
+        code: 88,
+        file: file,
+        evidence: evidence
+      })
+    )
+    return callback(issues)
+  }
 
   if (contents.replace(/^\s+|\s+$/g, '').split('\n').length !== 3) {
     issues.push(

--- a/validators/nii.js
+++ b/validators/nii.js
@@ -421,7 +421,7 @@ module.exports = function NIFTI(
     }
 
     if (
-      utils.type.isFieldMapMainNii(path) &&
+      utils.type.file.isFieldMapMainNii(path) &&
       mergedDictionary.hasOwnProperty('IntendedFor')
     ) {
       var intendedFor =

--- a/validators/session.js
+++ b/validators/session.js
@@ -20,7 +20,7 @@ var session = function missingSessionFiles(fileList) {
     }
 
     var path = file.relativePath
-    if (!utils.type.isBIDS(path) || utils.type.isStimuliData(path)) {
+    if (!utils.type.isBIDS(path) || utils.type.file.isStimuliData(path)) {
       continue
     }
     var subject


### PR DESCRIPTION
fixes #229 

a bug in the bval.js + bvec.js validation logic failed to check if the `contents` of .bval and .bvec files are defined + of type string before calling string-ony function `.replace()`.

* checks to make sure that contents of .bval and .bvec files are defined and of type string
* throws error if the above condition is not met (88 for .bval, 89 for .bvec)
* implements unit tests for these conditions in bval.spec.js and bvec.spec.js