### PR TITLE
schema checks are made against merged json dictionaries

### DIFF
--- a/tests/json.spec.js
+++ b/tests/json.spec.js
@@ -6,30 +6,39 @@ describe('JSON', function() {
     name: 'task-rest_bold.json',
     relativePath: '/task-rest_bold.json',
   }
-
-  it('should catch missing closing brackets', function() {
-    validate.JSON(file, '{', function(issues) {
-      assert(issues && issues.length > 0)
-    })
-  })
+  var jsonDict = {}
 
   it('sidecars should have key/value pair for "RepetitionTime" expressed in seconds', function() {
-    var jsonObj =
-      '{"RepetitionTime": 1.2, "echo_time": 0.005, "flip_angle": 90, "TaskName": "Rest"}'
-    validate.JSON(file, jsonObj, function(issues) {
+    var jsonObj = {
+      RepetitionTime: 1.2,
+      echo_time: 0.005,
+      flip_angle: 90,
+      TaskName: 'Rest',
+    }
+    jsonDict[file.relativePath] = jsonObj
+    validate.JSON(file, jsonDict, function(issues) {
       assert(issues.length === 0)
     })
-    var jsonObjInval =
-      '{"RepetitionTime": 1200, "echo_time": 0.005, "flip_angle": 90, "TaskName": "Rest"}'
-    validate.JSON(file, jsonObjInval, function(issues) {
+    var jsonObjInval = {
+      RepetitionTime: 1200,
+      echo_time: 0.005,
+      flip_angle: 90,
+      TaskName: 'Rest',
+    }
+    jsonDict[file.relativePath] = jsonObjInval
+    validate.JSON(file, jsonDict, function(issues) {
       assert(issues && issues.length === 1)
     })
   })
 
   it('should detect negative value for SliceTiming', function() {
-    var jsonObj =
-      '{"RepetitionTime": 1.2, "SliceTiming": [-1.0, 0.0, 1.0], "TaskName": "Rest"}'
-    validate.JSON(file, jsonObj, function(issues) {
+    var jsonObj = {
+      RepetitionTime: 1.2,
+      SliceTiming: [-1.0, 0.0, 1.0],
+      TaskName: 'Rest',
+    }
+    jsonDict[file.relativePath] = jsonObj
+    validate.JSON(file, jsonDict, function(issues) {
       assert(issues.length === 1 && issues[0].code == 55)
     })
   })
@@ -40,17 +49,24 @@ describe('JSON', function() {
   }
 
   it('*_meg.json sidecars should have required key/value pairs', function() {
-    var jsonObj =
-      '{"TaskName": "Audiovis", "SamplingFrequency": 1000, ' +
-      ' "PowerLineFrequency": 50, "DewarPosition": "Upright", ' +
-      ' "SoftwareFilters": "n/a", "DigitizedLandmarks": true,' +
-      ' "DigitizedHeadPoints": false}'
-    validate.JSON(meg_file, jsonObj, function(issues) {
+    var jsonObj = {
+      TaskName: 'Audiovis',
+      SamplingFrequency: 1000,
+      PowerLineFrequency: 50,
+      DewarPosition: 'Upright',
+      SoftwareFilters: 'n/a',
+      DigitizedLandmarks: true,
+      DigitizedHeadPoints: false,
+    }
+    jsonDict[meg_file.relativePath] = jsonObj
+    validate.JSON(meg_file, jsonDict, function(issues) {
       assert(issues.length === 0)
     })
 
-    var jsonObjInval = jsonObj.replace(/"SamplingFrequency": 1000, /g, '')
-    validate.JSON(meg_file, jsonObjInval, function(issues) {
+    var jsonObjInval = jsonObj
+    jsonObjInval['SamplingFrequency'] = ''
+    jsonDict[meg_file.relativePath] = jsonObjInval
+    validate.JSON(meg_file, jsonDict, function(issues) {
       assert(issues && issues.length === 1)
     })
   })
@@ -61,15 +77,21 @@ describe('JSON', function() {
   }
 
   it('*_ieeg.json sidecars should have required key/value pairs', function() {
-    var jsonObj =
-      '{"TaskName": "Audiovis", "Manufacturer": "TDT", ' +
-      ' "PowerLineFrequency": 50, "SamplingFrequency": 10, "iEEGReference": "reference"}'
-    validate.JSON(ieeg_file, jsonObj, function(issues) {
+    var jsonObj = {
+      TaskName: 'Audiovis',
+      Manufacturer: 'TDT',
+      PowerLineFrequency: 50,
+      SamplingFrequency: 10,
+      iEEGReference: 'reference',
+    }
+    jsonDict[ieeg_file.relativePath] = jsonObj
+    validate.JSON(ieeg_file, jsonDict, function(issues) {
       assert(issues.length === 0)
     })
-
-    var jsonObjInval = jsonObj.replace(/"Manufacturer": "TDT", /g, '')
-    validate.JSON(ieeg_file, jsonObjInval, function(issues) {
+    var jsonObjInval = jsonObj
+    jsonObjInval['Manufacturer'] = ''
+    jsonDict[ieeg_file.relativePath] = jsonObjInval
+    validate.JSON(ieeg_file, jsonDict, function(issues) {
       assert(issues && issues.length === 1)
     })
   })

--- a/utils/files.js
+++ b/utils/files.js
@@ -43,34 +43,34 @@ var fileUtils = {
  * In node the file should be a path to a file.
  *
  */
-function readFile(file, callback) {
-  if (fs) {
-    testFile(file, function(issue) {
-      if (issue) {
-        process.nextTick(function() {
-          callback(issue, null)
-        })
-        return
-      }
-      fs.readFile(file.path, 'utf8', function(err, data) {
-        process.nextTick(function() {
-          callback(null, data)
+function readFile(file) {
+  return new Promise((resolve, reject) => {
+    if (fs) {
+      testFile(file, function(issue) {
+        if (issue) {
+          process.nextTick(function() {
+            return reject(issue)
+          })
+        }
+        fs.readFile(file.path, 'utf8', function(err, data) {
+          process.nextTick(function() {
+            return resolve(data)
+          })
         })
       })
-    })
-  } else {
-    var reader = new FileReader()
-    reader.onloadend = function(e) {
-      if (e.target.readyState == FileReader.DONE) {
-        if (!e.target.result) {
-          callback(new Issue({ code: 44, file: file }), null)
-          return
+    } else {
+      var reader = new FileReader()
+      reader.onloadend = function(e) {
+        if (e.target.readyState == FileReader.DONE) {
+          if (!e.target.result) {
+            return reject(new Issue({ code: 44, file: file }))
+          }
+          return resolve(e.target.result)
         }
-        callback(null, e.target.result)
       }
+      reader.readAsBinaryString(file)
     }
-    reader.readAsBinaryString(file)
-  }
+  })
 }
 
 function getBIDSIgnoreFileObjNode(dir) {
@@ -120,7 +120,7 @@ function getBIDSIgnore(dir, callback) {
 
   var bidsIgnoreFileObj = getBIDSIgnoreFileObj(dir)
   if (bidsIgnoreFileObj) {
-    readFile(bidsIgnoreFileObj, function(issue, content) {
+    readFile(bidsIgnoreFileObj).then(content => {
       ig = ig.add(content)
       callback(ig)
     })

--- a/utils/options.js
+++ b/utils/options.js
@@ -31,13 +31,14 @@ module.exports = {
   loadConfig: function(config, callback) {
     if (typeof config === 'string') {
       // load file
-      files.readFile({ path: config }, function(issue, contents) {
-        if (issue) {
-          callback([issue], { path: config }, null)
-        } else {
+      files
+        .readFile({ path: config })
+        .then(contents => {
           callback(null, { path: config }, contents)
-        }
-      })
+        })
+        .catch(issue => {
+          callback([issue], { path: config }, null)
+        })
     } else if (typeof config === 'object') {
       callback(null, { path: 'config' }, JSON.stringify(config))
     }

--- a/validators/json.js
+++ b/validators/json.js
@@ -12,18 +12,19 @@ var Issue = utils.issues.Issue
  * it finds while validating against the BIDS
  * specification.
  */
-module.exports = function(file, contents, callback) {
+module.exports = function(file, jsonContentsDict, callback) {
   // primary flow --------------------------------------------------------------------
 
   var issues = []
-
-  utils.json.parse(file, contents, function(pissues, jsObj) {
-    issues = pissues
-    if (jsObj) {
-      issues = issues.concat(checkUnits(file, jsObj))
-    }
-    callback(issues, jsObj)
-  })
+  var potentialSidecars = utils.files.potentialLocations(file.relativePath)
+  var mergedDictionary = utils.files.generateMergedSidecarDict(
+    potentialSidecars,
+    jsonContentsDict,
+  )
+  if (mergedDictionary) {
+    issues = issues.concat(checkUnits(file, mergedDictionary))
+  }
+  callback(issues, mergedDictionary)
 }
 
 // individual checks ---------------------------------------------------------------


### PR DESCRIPTION
fixes #438 

* separates json file reading from json validation - this allows all the json data to be present when validating a single json file 
* json schema validation is now runs against the mergedDictionary generated from all sidecars that are related to the file
* existing json tests were updated to reflect this new change
* new unit tests implemented to ensure that a) schemas are validated against merged dictionaries and b) local values of a field are preferred to inherited values (value furthest from the root is used for schema validation)