### PR TITLE
fix circle ci tag filter and deployment steps

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -42,6 +42,7 @@ jobs:
       - image: node:8.11.3-alpine
     steps:
       - checkout
+      - run: apk --no-cache add ca-certificates
       - run: apk --no-cache add git python build-base openssh
       # Publish to NPM
       - run: npm install -g npm-cli-login

--- a/circle.yml
+++ b/circle.yml
@@ -42,10 +42,6 @@ jobs:
       - image: node:8.11.3-alpine
     steps:
       - checkout
-      - run: apk --no-cache add ca-certificates
-      - restore_cache:
-          keys:
-            - npm-deps-{{ checksum "package.json" }}
       - run: apk --no-cache add git python build-base openssh
       # Publish to NPM
       - run: npm install -g npm-cli-login
@@ -53,7 +49,7 @@ jobs:
       - run: git checkout -f $CIRCLE_TAG
       # Set the version number
       - run: sed -i -E "s/0.0.0/$CIRCLE_TAG/" package.json
-      - run: npm install publish
+      - run: npm install -g publish
       - run: npm run npmPublish
       # Update gh-pages demo site
       - run: git config --global user.email circleci@circleci

--- a/circle.yml
+++ b/circle.yml
@@ -41,6 +41,9 @@ jobs:
     docker:
       - image: node:8.11.3-alpine
     steps:
+      - add_ssh_keys:
+          fingerprints:
+            - '44:93:5a:f4:2b:2d:c1:8a:f2:8e:8b:e9:27:5f:93:25'
       - checkout
       - run: apk --no-cache add ca-certificates
       - run: apk --no-cache add git python build-base openssh
@@ -58,6 +61,7 @@ jobs:
       - run: rm -rf node_modules/
       - run: rm -rf tests/
       - run: git checkout gh-pages -f
+      - run: ssh-keyscan github.com >> ~/.ssh/known_hosts
       - run: git pull
       - run: npm install
       - run: ./node_modules/.bin/gulp build


### PR DESCRIPTION
if you look at the circle ci githubPagesTest and deployment steps since #500, they have failed to actually generate the gh-pages dist/* files, as well as publish npm package / gh-pages updates on tag releases. this pr fixes these issues by updating the deployment step.