### PR TITLE
Adjust Code Climate threshold for duplication to 3

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,10 @@
+version: '2'
+checks:
+  similar-code:
+    config:
+      count_threshold: 3
+      threshold: 50
+  identical-code:
+    config:
+      count_threshold: 3
+      threshold: 50


### PR DESCRIPTION
This changes the Code Climate duplicate code warning from two to three duplicates. Refactoring two similar pieces of code is often more complex and less readable than leaving in some limited duplication.