### PR TITLE
[MRG] Add coordsystem eeg

### DIFF
--- a/validators/json.js
+++ b/validators/json.js
@@ -46,6 +46,8 @@ function checkUnits(file, sidecar) {
       schema = require('./schemas/meg.json')
     } else if (file.name.endsWith('ieeg.json')) {
       schema = require('./schemas/ieeg.json')
+    } else if (file.name.endsWith('eeg.json')) {
+      schema = require('./schemas/eeg.json')
     } else if (
       file.relativePath.includes('/meg/') &&
       file.name.endsWith('coordsystem.json')
@@ -56,8 +58,11 @@ function checkUnits(file, sidecar) {
       file.name.endsWith('coordsystem.json')
     ) {
       schema = require('./schemas/coordsystem_ieeg.json')
-    } else if (file.name.endsWith('eeg.json')) {
-      schema = require('./schemas/eeg.json')
+    } else if (
+      file.relativePath.includes('/eeg/') &&
+      file.name.endsWith('coordsystem.json')
+    ) {
+      schema = require('./schemas/coordsystem_eeg.json')
     }
     if (schema) {
       var validate = ajv.compile(schema)

--- a/validators/schemas/coordsystem_eeg.json
+++ b/validators/schemas/coordsystem_eeg.json
@@ -1,0 +1,15 @@
+{
+  "type": "object",
+  "properties": {
+    "IntendedFor": { "type": "string", "minLength": 1 },
+    "FiducialsDescription": { "type": "string", "minLength": 1 },
+    "EEGCoordinateSystem": { "type": "string", "minLength": 1 },
+    "EEGCoordinateUnits": { "type": "string", "minLength": 1 },
+    "EEGCoordinateSystemDescription": { "type": "string" },
+    "AnatomicalLandmarkCoordinateSystem": { "type": "string", "minLength": 1 },
+    "AnatomicalLandmarkCoordinateUnits": { "type": "string", "minLength": 1 },
+    "AnatomicalLandmarkCoordinateSystemDescription": { "type": "string" }
+  },
+  "required": ["EEGCoordinateSystem", "EEGCoordinateUnits"],
+  "additionalProperties": false
+}

--- a/validators/schemas/coordsystem_meg.json
+++ b/validators/schemas/coordsystem_meg.json
@@ -1,55 +1,44 @@
 {
-        "type": "object",
-        "properties": {
-                "MEGCoordinateSystem": {"type": "string","minLength": 1},
-                "MEGCoordinateUnits": {"type": "string","minLength": 1},
-                "MEGCoordinateSystemDescription": {"type": "string"},
-                "EEGCoordinateSystem": {"type": "string","minLength": 1},
-                "EEGCoordinateUnits": {"type": "string","minLength": 1},
-                "EEGCoordinateSystemDescription": {"type": "string"},
-                "IntendedFor": {
-                  "anyOf": [
-                    {
-                      "type": "array",
-                      "items": {
-                        "type": "string",
-                        "minLength": 1
-                      }
-                    },
-                    {"type": "string", "minLength": 1}
-                  ]
-                },
-                "FiducialsDescription": {"type": "string", "minLength": 1},
-                "HeadCoilCoordinates": {"type": "object",
-                                        "additionalProperties": {"type": "array"}
-                                       },
-                "HeadCoilCoordinateSystem": {"type": "string","minLength": 1},
-                "HeadCoilCoordinateUnits": {"type": "string","minLength": 1},
-                "HeadCoilCoordinateSystemDescription": {"type": "string"},
-                "AnatomicalLandmarkCoordinates": {"type": "object",
-                                                  "additionalProperties": {"type": "array"}
-                                                 },
-                "AnatomicalLandmarkCoordinateSystem": {"type": "string","minLength": 1},
-                "AnatomicalLandmarkCoordinateUnits": {"type": "string","minLength": 1},
-                "AnatomicalLandmarkCoordinateSystemDescription": {"type": "string"},
-                "DigitizedHeadPoints": {"type": "string"},
-                "DigitizedHeadPointsCoordinateSystem": {"type": "string"},
-                "DigitizedHeadPointsCoordinateUnits": {"type": "string"},
-                "DigitizedHeadPointsCoordinateSystemDescription": {"type": "string"}
-                },
-        "anyOf": [
-            {
-                "required": [
-                    "MEGCoordinateSystem",
-                    "MEGCoordinateUnits"
-                ]
-            },
-            {
-                "required": [
-                    "EEGCoordinateSystem",
-                    "EEGCoordinateUnits"
-                ]
-            }
-        ],
-        "additionalProperties": false
+  "type": "object",
+  "properties": {
+    "MEGCoordinateSystem": { "type": "string", "minLength": 1 },
+    "MEGCoordinateUnits": { "type": "string", "minLength": 1 },
+    "MEGCoordinateSystemDescription": { "type": "string" },
+    "EEGCoordinateSystem": { "type": "string", "minLength": 1 },
+    "EEGCoordinateUnits": { "type": "string", "minLength": 1 },
+    "EEGCoordinateSystemDescription": { "type": "string" },
+    "IntendedFor": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        { "type": "string", "minLength": 1 }
+      ]
+    },
+    "FiducialsDescription": { "type": "string", "minLength": 1 },
+    "HeadCoilCoordinates": {
+      "type": "object",
+      "additionalProperties": { "type": "array" }
+    },
+    "HeadCoilCoordinateSystem": { "type": "string", "minLength": 1 },
+    "HeadCoilCoordinateUnits": { "type": "string", "minLength": 1 },
+    "HeadCoilCoordinateSystemDescription": { "type": "string" },
+    "AnatomicalLandmarkCoordinates": {
+      "type": "object",
+      "additionalProperties": { "type": "array" }
+    },
+    "AnatomicalLandmarkCoordinateSystem": { "type": "string", "minLength": 1 },
+    "AnatomicalLandmarkCoordinateUnits": { "type": "string", "minLength": 1 },
+    "AnatomicalLandmarkCoordinateSystemDescription": { "type": "string" },
+    "DigitizedHeadPoints": { "type": "string" },
+    "DigitizedHeadPointsCoordinateSystem": { "type": "string" },
+    "DigitizedHeadPointsCoordinateUnits": { "type": "string" },
+    "DigitizedHeadPointsCoordinateSystemDescription": { "type": "string" }
+  },
+  "required": ["MEGCoordinateSystem", "MEGCoordinateUnits"],
+  "additionalProperties": false
 }


### PR DESCRIPTION
so far, the eeg coordsystem definition was squashed into the meg coordsystem using "anyOf". This is now fixed by introducing an eeg specific file, adjusting the meg file, and making the appropriate calls in validators/json.js