### PR TITLE
Display the invalid acqTime as evidence

### DIFF
--- a/validators/tsv.js
+++ b/validators/tsv.js
@@ -331,7 +331,7 @@ const checkAcqTimeFormat = function(rows, file, issues) {
       issues.push(
         new Issue({
           file: file,
-          evidence: file,
+          evidence: acqTime,
           line: i + 2,
           reason: 'acq_time is not in the format YYYY-MM-DDTHH:mm:ss ',
           code: 84,


### PR DESCRIPTION
This shows `Evidence: 1877-07-12T20:55:80` instead of `Evidence: [object Object]` for invalid acqTimes.