### PR TITLE
_magnitude1 and _magnitude2 should not have a fourth dimension

### DIFF
--- a/tests/headerField.spec.js
+++ b/tests/headerField.spec.js
@@ -1,0 +1,66 @@
+const assert = require('assert')
+const headerFields = require('../validators/headerFields')
+
+describe('headerFields', () => {
+  it('should throw an error if _magnitude1 or _magnitude2 files have too many dimensions.', () => {
+    // each of these headers has one too many dimensions on the 'dim' field.
+    // the first entry is the total count, and the following three entries are spatial.
+    const headers = [
+      [
+        {
+          name: 'sub-01_magnitude1.nii',
+          relativePath: 'sub-01_magnitude1.nii',
+        },
+        {
+          dim: [5, 1, 1, 1, 1],
+          pixdim: [5, 1, 1, 1, 1],
+          xyzt_units: [5, 1, 1, 1, 1],
+        },
+      ],
+      [
+        {
+          name: 'sub-01_magnitude2.nii',
+          relativePath: 'sub-01_magnitude2.nii',
+        },
+        {
+          dim: [5, 1, 1, 1, 1],
+          pixdim: [5, 1, 1, 1, 1],
+          xyzt_units: [5, 1, 1, 1, 1],
+        },
+      ],
+    ]
+    const issues = headerFields(headers)
+    assert(
+      issues.length == 2 && issues[0].code == '94' && issues[1].code == '94',
+    )
+  })
+
+  it('_magnitude1 or _magnitude2 files should have 3 dimensions.', () => {
+    const headers = [
+      [
+        {
+          name: 'sub-01_magnitude1.nii',
+          relativePath: 'sub-01_magnitude1.nii',
+        },
+        {
+          dim: [4, 1, 1, 1],
+          pixdim: [4, 1, 1, 1],
+          xyzt_units: [4, 1, 1, 1],
+        },
+      ],
+      [
+        {
+          name: 'sub-01_magnitude2.nii',
+          relativePath: 'sub-01_magnitude2.nii',
+        },
+        {
+          dim: [3, 1, 1],
+          pixdim: [4, 1, 1, 1],
+          xyzt_units: [4, 1, 1, 1],
+        },
+      ],
+    ]
+    const issues = headerFields(headers)
+    assert.deepEqual(issues, [])
+  })
+})

--- a/utils/issues/list.js
+++ b/utils/issues/list.js
@@ -509,4 +509,10 @@ module.exports = {
     reason:
       'Each _phasediff.nii[.gz] file should be associated with a _magnitude1.nii[.gz] file.',
   },
+  94: {
+    key: 'MAGNITUDE_FILE_WITH_TOO_MANY_DIMENSIONS',
+    severity: 'error',
+    reason:
+      '_magnitude1.nii[.gz] and _magnitude2.nii[.gz] files must not have more than three dimensions. ',
+  },
 }

--- a/validators/headerFields.js
+++ b/validators/headerFields.js
@@ -90,6 +90,16 @@ var headerField = function headerField(headers, field) {
           evidence: 'header field "dim" = ' + header[field],
         })
         continue
+      } else if (
+        (file.name.indexOf('magnitude1') > -1 ||
+          file.name.indexOf('magnitude2') > -1) &&
+        header[field][0] > 4
+      ) {
+        issues[file.relativePath] = new Issue({
+          file: file,
+          code: 94,
+          evidence: 'this magnitude file has more than three dimensions. ',
+        })
       }
       field_value = header[field].slice(1, header[field][0] + 1).toString()
     } else if (field === 'pixdim') {


### PR DESCRIPTION
fixes #540 

* if _magnitude1 or _magnitude2 nifti headers have header['dim'][0] > 4 (corresponding to more than just an x, y, and z value) throw an error
* implement headerField.spec.js test suite