### PR TITLE
failing fs access in web validator

### DIFF
--- a/utils/files/readFile.js
+++ b/utils/files/readFile.js
@@ -16,7 +16,7 @@ const isNode = typeof window === 'undefined'
  */
 function readFile(file) {
   return new Promise((resolve, reject) => {
-    if (fs) {
+    if (isNode) {
       testFile(file, function(issue) {
         if (issue) {
           process.nextTick(function() {


### PR DESCRIPTION
fixes #544 (a regression caused by merge conflict resolution [here](https://github.com/INCF/bids-validator/commit/abe53f6d8728f598f0ddde60454897f697748f73#diff-fb0b7896fb16689756863e176a24a827R19)). 

we now use typeof window === 'undefined' (`isNode` vs `fs`) as a check for node vs web environment