### PR TITLE
[MRG] Adding electrodes tsv regexp for EEG

### DIFF
--- a/bids_validator/rules/session_level_rules.json
+++ b/bids_validator/rules/session_level_rules.json
@@ -68,6 +68,7 @@
       "@@@_anat_eeg_type_@@@": [
         "_events.tsv",
         "_channels.tsv",
+        "_electrodes.tsv",
         "_eeg.json",
         "_coordsystem.json",
         "_photo.jpg"
@@ -84,8 +85,7 @@
         "_electrodes.tsv",
         "_ieeg.json",
         "_coordsystem.json",
-        "_photo.jpg",
-        "_headshape.pos"
+        "_photo.jpg"
       ]
     }
   }

--- a/bids_validator/rules/top_level_rules.json
+++ b/bids_validator/rules/top_level_rules.json
@@ -50,6 +50,7 @@
       "@@@_eeg_top_ext_@@@": [
         "_eeg.json",
         "_channels.tsv",
+        "_electrodes.tsv",
         "_photo.jpg",
         "_coordsystem.json"
       ]


### PR DESCRIPTION
This PR adds the `electrode.tsv` regexp for EEG which was missing at several points. It was simply forgotten.

Furthermore, I remove a `headshape.pos` regexp from iEEG, because such a file is not part of the iEEG specification and this was most likely a copy/paste error. Please review @choldgraf 

EDIT: I just noticed that we do have a `headshape.<manufacturer_specific_extension>` as an optional session specific file in the EEG BEP. --> One question about that: why is it `.pos` in the BIDS-validator also for MEG? Is that the most common <manufacturer_specific_extension>?