### PR TITLE
added missing iEEGCoordinateSystemDescription

### DIFF
--- a/validators/schemas/coordsystem_ieeg.json
+++ b/validators/schemas/coordsystem_ieeg.json
@@ -3,6 +3,7 @@
         "properties": {
                 "iEEGCoordinateSystem": {"type": "string","minLength": 1},
                 "iEEGCoordinateUnits": {"type": "string","minLength": 1},
+                "iEEGCoordinateSystemDescription": {"type": "string","minLength": 1},
                 "iEEGCoordinateProcessingDescripton": {"type": "string","minLength": 1},
                 "iEEGCoordinateProcessingReference": {"type": "string","minLength": 1},
                 "IntendedFor": {"type": "string","minLength": 1}


### PR DESCRIPTION
This is an optional field in coordsystem.json according to the iEEG draft, and also used in EEG and MEG specifications.