### PR TITLE
_magnitudex.nii[.gz] should have exactly 3  dimensions

### DIFF
--- a/tests/headerField.spec.js
+++ b/tests/headerField.spec.js
@@ -2,10 +2,9 @@ const assert = require('assert')
 const headerFields = require('../validators/headerFields')
 
 describe('headerFields', () => {
-  it('should throw an error if _magnitude1 or _magnitude2 files have too many dimensions.', () => {
-    // each of these headers has one too many dimensions on the 'dim' field.
-    // the first entry is the total count, and the following three entries are spatial.
+  it('should throw an error if _magnitude1 or _magnitude2 files do not have exactly dimensions.', () => {
     const headers = [
+      // each of these headers has one too many dimensions on the 'dim' field.
       [
         {
           name: 'sub-01_magnitude1.nii',
@@ -28,10 +27,37 @@ describe('headerFields', () => {
           xyzt_units: [5, 1, 1, 1, 1],
         },
       ],
+      // each of these headers has one too few dimensions on the 'dim' field.
+      [
+        {
+          name: 'sub-02_magnitude1.nii',
+          relativePath: 'sub-02_magnitude1.nii',
+        },
+        {
+          dim: [3, 1, 1],
+          pixdim: [4, 1, 1, 1],
+          xyzt_units: [4, 1, 1, 1],
+        },
+      ],
+      [
+        {
+          name: 'sub-02_magnitude2.nii',
+          relativePath: 'sub-02_magnitude2.nii',
+        },
+        {
+          dim: [3, 1, 1],
+          pixdim: [4, 1, 1, 1],
+          xyzt_units: [4, 1, 1, 1],
+        },
+      ],
     ]
     const issues = headerFields(headers)
     assert(
-      issues.length == 2 && issues[0].code == '94' && issues[1].code == '94',
+      issues.length == 4 &&
+        issues[0].code == '94' &&
+        issues[1].code == '94' &&
+        issues[2].code == '94' &&
+        issues[3].code == '94',
     )
   })
 
@@ -54,7 +80,7 @@ describe('headerFields', () => {
           relativePath: 'sub-01_magnitude2.nii',
         },
         {
-          dim: [3, 1, 1],
+          dim: [4, 1, 1, 1],
           pixdim: [4, 1, 1, 1],
           xyzt_units: [4, 1, 1, 1],
         },

--- a/utils/issues/list.js
+++ b/utils/issues/list.js
@@ -513,6 +513,6 @@ module.exports = {
     key: 'MAGNITUDE_FILE_WITH_TOO_MANY_DIMENSIONS',
     severity: 'error',
     reason:
-      '_magnitude1.nii[.gz] and _magnitude2.nii[.gz] files must not have more than three dimensions. ',
+      '_magnitude1.nii[.gz] and _magnitude2.nii[.gz] files must have exactly three dimensions. ',
   },
 }

--- a/validators/headerFields.js
+++ b/validators/headerFields.js
@@ -93,7 +93,7 @@ var headerField = function headerField(headers, field) {
       } else if (
         (file.name.indexOf('magnitude1') > -1 ||
           file.name.indexOf('magnitude2') > -1) &&
-        header[field][0] > 4
+        header[field][0] !== 4
       ) {
         issues[file.relativePath] = new Issue({
           file: file,


### PR DESCRIPTION
the fix implemented for #543 checked for _no more than_ three dimensions. we wanted to check for _exactly_ three dimensions in the _magnitude1.nii[.gz] and _magnitude2.nii[.gz] nifti headers. this pr fixes that and updates tests.