### PR TITLE
[MRG] add missing field to eeg coords json

### DIFF
--- a/validators/schemas/coordsystem_eeg.json
+++ b/validators/schemas/coordsystem_eeg.json
@@ -6,6 +6,10 @@
     "EEGCoordinateSystem": { "type": "string", "minLength": 1 },
     "EEGCoordinateUnits": { "type": "string", "minLength": 1 },
     "EEGCoordinateSystemDescription": { "type": "string" },
+    "AnatomicalLandmarkCoordinates": {
+      "type": "object",
+      "additionalProperties": { "type": "array" }
+    },
     "AnatomicalLandmarkCoordinateSystem": { "type": "string", "minLength": 1 },
     "AnatomicalLandmarkCoordinateUnits": { "type": "string", "minLength": 1 },
     "AnatomicalLandmarkCoordinateSystemDescription": { "type": "string" }


### PR DESCRIPTION
This will fix the failing examples on github.com/INCF/BIDS-examples

Travis report: https://travis-ci.org/INCF/BIDS-examples/builds/427549450

Error that will be fixed: 
```
Validating dataset eeg_ds000117/
1: Invalid JSON file. The file is not formatted according the schema. (code: 55 - JSON_SCHEMA_VALIDATION_ERROR)
		./sub-01/eeg/sub-01_task-facerecognition_coordsystem.json
			Evidence:  should NOT have additional properties
		./sub-02/eeg/sub-02_task-facerecognition_coordsystem.json
			Evidence:  should NOT have additional properties
		./sub-03/eeg/sub-03_task-facerecognition_coordsystem.json
			Evidence:  should NOT have additional properties
		./sub-04/eeg/sub-04_task-facerecognition_coordsystem.json
			Evidence:  should NOT have additional properties
		./sub-05/eeg/sub-05_task-facerecognition_coordsystem.json
			Evidence:  should NOT have additional properties
		./sub-06/eeg/sub-06_task-facerecognition_coordsystem.json
			Evidence:  should NOT have additional properties
		./sub-07/eeg/sub-07_task-facerecognition_coordsystem.json
			Evidence:  should NOT have additional properties
		./sub-08/eeg/sub-08_task-facerecognition_coordsystem.json
			Evidence:  should NOT have additional properties
		./sub-09/eeg/sub-09_task-facerecognition_coordsystem.json
			Evidence:  should NOT have additional properties
		./sub-10/eeg/sub-10_task-facerecognition_coordsystem.json
			Evidence:  should NOT have additional properties
... and 6 more files having this issue (Use --verbose to see them all).
```