### PR TITLE
fix magnitude and t1w dimension check

### DIFF
--- a/tests/headerField.spec.js
+++ b/tests/headerField.spec.js
@@ -2,7 +2,7 @@ const assert = require('assert')
 const headerFields = require('../validators/headerFields')
 
 describe('headerFields', () => {
-  it('should throw an error if _magnitude1 or _magnitude2 files do not have exactly dimensions.', () => {
+  it('should throw an error if _magnitude1 or _magnitude2 files do not have exactly 3 dimensions.', () => {
     const headers = [
       // each of these headers has one too many dimensions on the 'dim' field.
       [
@@ -69,9 +69,9 @@ describe('headerFields', () => {
           relativePath: 'sub-01_magnitude1.nii',
         },
         {
-          dim: [4, 1, 1, 1],
-          pixdim: [4, 1, 1, 1],
-          xyzt_units: [4, 1, 1, 1],
+          dim: [3, 1, 1, 1],
+          pixdim: [3, 1, 1, 1],
+          xyzt_units: [3, 1, 1, 1],
         },
       ],
       [
@@ -80,9 +80,9 @@ describe('headerFields', () => {
           relativePath: 'sub-01_magnitude2.nii',
         },
         {
-          dim: [4, 1, 1, 1],
-          pixdim: [4, 1, 1, 1],
-          xyzt_units: [4, 1, 1, 1],
+          dim: [3, 1, 1, 1],
+          pixdim: [3, 1, 1, 1],
+          xyzt_units: [3, 1, 1, 1],
         },
       ],
     ]
@@ -131,8 +131,8 @@ describe('headerFields', () => {
           relativePath: 'sub-01_T1w.nii',
         },
         {
-          dim: [4, 1, 1, 1],
-          pixdim: [4, 1, 1, 1],
+          dim: [3, 1, 1, 1],
+          pixdim: [3, 1, 1, 1],
           xyzt_units: [4, 1, 1, 1],
         },
       ],

--- a/validators/headerFields.js
+++ b/validators/headerFields.js
@@ -93,14 +93,14 @@ var headerField = function headerField(headers, field) {
       } else if (
         (file.name.indexOf('magnitude1') > -1 ||
           file.name.indexOf('magnitude2') > -1) &&
-        header[field][0] !== 4
+        header[field].length !== 4
       ) {
         issues[file.relativePath] = new Issue({
           file: file,
           code: 94,
           evidence: 'this magnitude file has more than three dimensions. ',
         })
-      } else if (file.name.indexOf('T1w') > -1 && header[field][0] !== 4) {
+      } else if (file.name.indexOf('T1w') > -1 && header[field].length !== 4) {
         issues[file.relativePath] = new Issue({
           file: file,
           code: 95,


### PR DESCRIPTION
fixes #565 

* checks for dimensionality of nifti headers in _magnitude(1/2) and _t1w files now rely on the length of `header["dim"]` rather than the value of `header["dim"][0]`