### PR TITLE
Sub-emptyroom excluded from dataset summary

### DIFF
--- a/tests/bids.spec.js
+++ b/tests/bids.spec.js
@@ -28,7 +28,6 @@ var missing_session_files = [
   'ds109',
   'ds113b',
   'ds000117',
-  'ds000246',
   'ds000247',
 ]
 

--- a/validators/bids.js
+++ b/validators/bids.js
@@ -509,16 +509,19 @@ BIDS = {
           )
         ) {
           var pathValues = utils.type.getPathValues(file.relativePath)
+          const isEmptyRoom = pathValues.sub && pathValues.sub == 'emptyroom'
 
           if (
             pathValues.sub &&
-            summary.subjects.indexOf(pathValues.sub) === -1
+            summary.subjects.indexOf(pathValues.sub) === -1 &&
+            !isEmptyRoom
           ) {
             summary.subjects.push(pathValues.sub)
           }
           if (
             pathValues.ses &&
-            summary.sessions.indexOf(pathValues.ses) === -1
+            summary.sessions.indexOf(pathValues.ses) === -1 &&
+            !isEmptyRoom
           ) {
             summary.sessions.push(pathValues.ses)
           }

--- a/validators/checkAnyDataPresent.js
+++ b/validators/checkAnyDataPresent.js
@@ -2,7 +2,7 @@ var utils = require('../utils')
 var Issue = utils.issues.Issue
 
 function addIfNotPresent(folderSubjects, subject) {
-  if (folderSubjects.indexOf(subject) == -1) {
+  if (folderSubjects.indexOf(subject) == -1 && subject !== 'emptyroom') {
     folderSubjects.push(subject)
   }
 }
@@ -13,6 +13,7 @@ function getFolderSubjects(fileList) {
     var file = fileList[key]
     var match = file.relativePath.match(/sub-(.*?)(?=\/)/)
     if (match) {
+      // console.log('match:', match)
       addIfNotPresent(folderSubjects, match[1])
     }
   }
@@ -30,7 +31,6 @@ var checkAnyDataPresent = function checkAnyDataPresent(
 ) {
   var issues = []
   var folderSubjects = getFolderSubjects(fileList)
-
   var subjectsWithoutAnyValidData = folderSubjects.filter(function(i) {
     return summarySubjects.indexOf(i) < 0
   })

--- a/validators/session.js
+++ b/validators/session.js
@@ -31,6 +31,13 @@ var session = function missingSessionFiles(fileList) {
     } else {
       subject = match[0]
     }
+
+    // suppress inconsistent subject warnings for sub-emptyroom scans
+    // in MEG data
+    if (subject == 'sub-emptyroom') {
+      continue
+    }
+
     // initialize an empty array if we haven't seen this subject before
     if (typeof subjects[subject] === 'undefined') {
       subjects[subject] = []

--- a/validators/tsv.js
+++ b/validators/tsv.js
@@ -205,7 +205,11 @@ var TSV = function TSV(file, contents, fileList, callback) {
         if (!row || /^\s*$/.test(row)) {
           continue
         }
-        participants.push(row[participantIdColumn].replace('sub-', ''))
+        const participant = row[participantIdColumn].replace('sub-', '')
+        if (participant == 'emptyroom') {
+          continue
+        }
+        participants.push(participant)
       }
     }
   }


### PR DESCRIPTION
fixes #453 

* removes sub-emptyroom from subject count in dataset summary
* removes related sessions (sub-emptyroom/ses-*) from session count in dataset summary
* fixes inconsistent subject warning for cases where emptyroom session ids are not present in other subject folders