### PR TITLE
Add the ce label to anat type.spec and the corresponding test

### DIFF
--- a/bids_validator/rules/file_level_rules.json
+++ b/bids_validator/rules/file_level_rules.json
@@ -1,6 +1,6 @@
 {
   "anat": {
-    "regexp": "^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)\\/)?anat\\/\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?_(?:@@@_anat_suffixes_@@@).(@@@_anat_ext_@@@)$",
+    "regexp": "^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)\\/)?anat\\/\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_ce-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?_(?:@@@_anat_suffixes_@@@).(@@@_anat_ext_@@@)$",
     "tokens": {
       "@@@_anat_suffixes_@@@": [
         "T1w",

--- a/tests/type.spec.js
+++ b/tests/type.spec.js
@@ -13,6 +13,7 @@ var suiteAnat = describe('utils.type.file.isAnat', function() {
       '/sub-16/anat/sub-16_run-01_T1w.nii.gz',
       '/sub-16/anat/sub-16_acq-highres_T1w.nii.gz',
       '/sub-16/anat/sub-16_rec-mc_T1w.nii.gz',
+      '/sub-16/anat/sub-16_ce-contrastagent_T1w.nii.gz',
     ]
 
     goodFilenames.forEach(function(path) {


### PR DESCRIPTION
The optional contrast enhancement label  (`[_ce-<label>]`) was missing in `bids_validator/rules/file_level_rules.json`

See spec 1.0.2 : 8.3 Anatomy imaging data

I added the corresponding test.

Hope that helps