### PR TITLE
[FIX #575] readDir.js now follow Symlink directories

### DIFF
--- a/utils/files/readDir.js
+++ b/utils/files/readDir.js
@@ -108,7 +108,7 @@ function getFiles(dir, files_, rootpath, ig) {
       fileObj.ignore = true
     }
 
-    if (isDirectory(fullPath) {
+    if (isDirectory(fullPath)) {
       getFiles(fullPath, files_, rootpath, ig)
     } else {
       files_.push(fileObj)

--- a/utils/files/readDir.js
+++ b/utils/files/readDir.js
@@ -108,12 +108,18 @@ function getFiles(dir, files_, rootpath, ig) {
       fileObj.ignore = true
     }
 
-    if (fs.lstatSync(fullPath).isDirectory()) {
+    var isDirectory = fs.lstatSync(fullPath).isDirectory()
+    if (fs.lstatSync(fullPath).isSymbolicLink()) {
+      targetPath = fs.realpathSync(fullPath)
+      isDirectory = fs.lstatSync(targetPath).isDirectory()
+    }
+    if (isDirectory) {
       getFiles(fullPath, files_, rootpath, ig)
     } else {
       files_.push(fileObj)
     }
   })
+
   return files_
 }
 

--- a/utils/files/readDir.js
+++ b/utils/files/readDir.js
@@ -122,8 +122,9 @@ function getFiles(dir, files_, rootpath, ig) {
  * Leverage fs.isDirectory by following Symbolic Links
  */
 function isDirectory(path) {
-  var isDir = fs.lstatSync(path).isDirectory()
-  if (fs.lstatSync(path).isSymbolicLink()) {
+  var pathStat = fs.lstatSync(path)
+  var isDir = pathStat.isDirectory()
+  if (pathStat.isSymbolicLink()) {
     var targetPath = fs.realpathSync(path)
     isDir = fs.lstatSync(targetPath).isDirectory()
   }

--- a/utils/files/readDir.js
+++ b/utils/files/readDir.js
@@ -108,12 +108,7 @@ function getFiles(dir, files_, rootpath, ig) {
       fileObj.ignore = true
     }
 
-    var isDirectory = fs.lstatSync(fullPath).isDirectory()
-    if (fs.lstatSync(fullPath).isSymbolicLink()) {
-      targetPath = fs.realpathSync(fullPath)
-      isDirectory = fs.lstatSync(targetPath).isDirectory()
-    }
-    if (isDirectory) {
+    if (isDirectory(fullPath) {
       getFiles(fullPath, files_, rootpath, ig)
     } else {
       files_.push(fileObj)
@@ -121,6 +116,18 @@ function getFiles(dir, files_, rootpath, ig) {
   })
 
   return files_
+}
+
+/**
+ * Leverage fs.isDirectory by following Symbolic Links
+ */
+function isDirectory(path) {
+  var isDir = fs.lstatSync(path).isDirectory()
+  if (fs.lstatSync(path).isSymbolicLink()) {
+    var targetPath = fs.realpathSync(path)
+    isDir = fs.lstatSync(targetPath).isDirectory()
+  }
+  return isDir
 }
 
 function getBIDSIgnore(dir, callback) {


### PR DESCRIPTION
Should fix #575 

I don't have any test for this PR. Mocking symlink (https://github.com/tschaub/mock-fs) is probably an overkill.

