### PR TITLE
[MRG] add non-custom events columns

### DIFF
--- a/bids-validator/bids_validator/tsv/non_custom_columns.json
+++ b/bids-validator/bids_validator/tsv/non_custom_columns.json
@@ -34,7 +34,9 @@
     "onset",
     "trial_type",
     "response_time",
-    "stim_file"
+    "stim_file",
+    "sample",
+    "value"
   ],
   "misc": [],
   "participants": ["participant_id"],


### PR DESCRIPTION
This is adding two column names to events.tsv:

- sample ... describing the exact digitization point at which an event had its onset 
- value ... describing the value of a potential TTL trigger marking the event onset

These are non-custom column names that will be introduced with BEP006 and BEP010.