### PR TITLE
Fix deprecated Buffer constructor in readNiftiHeader

### DIFF
--- a/utils/files/readNiftiHeader.js
+++ b/utils/files/readNiftiHeader.js
@@ -38,8 +38,8 @@ function nodeNiftiTest(file, callback) {
 }
 
 function extractNiftiFile(file, callback) {
-  var bytesRead = 500
-  var buffer = new Buffer(bytesRead)
+  const bytesRead = 500
+  const buffer = Buffer.alloc(bytesRead)
 
   var decompressStream = zlib
     .createGunzip()


### PR DESCRIPTION
Buffer.alloc is the supported way to do this as of Node 6.