### PR TITLE
Remove misspelled modality field from groupFileTypes

### DIFF
--- a/validators/bids/groupFileTypes.js
+++ b/validators/bids/groupFileTypes.js
@@ -10,7 +10,6 @@ const groupFileTypes = (fileList, options) => {
     bval: [],
     bvec: [],
     invalid: [],
-    modaility: [],
   }
   sortFiles(fileList, options, files)
   //   reportFileTypeCounts(files)

--- a/validators/bids/groupFileTypes.js
+++ b/validators/bids/groupFileTypes.js
@@ -12,7 +12,6 @@ const groupFileTypes = (fileList, options) => {
     invalid: [],
   }
   sortFiles(fileList, options, files)
-  //   reportFileTypeCounts(files)
   return files
 }
 


### PR DESCRIPTION
"modaility" isn't referenced anywhere else so this is some cruft.