### PR TITLE
getFolderSubjects() test improvements and bug fix

### DIFF
--- a/validators/__tests__/checkAnyDataPresent.spec.js
+++ b/validators/__tests__/checkAnyDataPresent.spec.js
@@ -10,14 +10,18 @@ describe('checkAnyDataPresent', () => {
         { relativePath: 'sub-01/another' },
         { relativePath: 'sub-02/data' },
       ]
-      assert.lengthOf(getFolderSubjects(fileList), 2)
+      const subjects = getFolderSubjects(fileList)
+      assert.lengthOf(subjects, 2)
+      assert.deepEqual(subjects, ['01', '02'])
     })
     it('filters out emptyroom subject', () => {
       const fileList = [
         { relativePath: 'sub-01/files' },
         { relativePath: 'sub-emptyroom/data' },
       ]
-      assert.lengthOf(getFolderSubjects(fileList), 1)
+      const subjects = getFolderSubjects(fileList)
+      assert.lengthOf(subjects, 1)
+      assert.deepEqual(subjects, ['01'])
     })
     it('works for deeply nested files', () => {
       const fileList = [
@@ -25,11 +29,15 @@ describe('checkAnyDataPresent', () => {
         { relativePath: 'sub-01/another/b.nii.gz' },
         { relativePath: 'sub-02/data/test' },
       ]
-      assert.lengthOf(getFolderSubjects(fileList), 2)
+      const subjects = getFolderSubjects(fileList)
+      assert.lengthOf(subjects, 2)
+      assert.deepEqual(subjects, ['01', '02'])
     })
     it('works with object arguments', () => {
       const fileList = { 0: { relativePath: 'sub-01/anat/one.nii.gz' } }
-      assert.lengthOf(getFolderSubjects(fileList), 1)
+      const subjects = getFolderSubjects(fileList)
+      assert.lengthOf(subjects, 1)
+      assert.deepEqual(subjects, ['01'])
     })
   })
 })

--- a/validators/__tests__/checkAnyDataPresent.spec.js
+++ b/validators/__tests__/checkAnyDataPresent.spec.js
@@ -10,14 +10,22 @@ describe('checkAnyDataPresent', () => {
         { relativePath: 'sub-01/another' },
         { relativePath: 'sub-02/data' },
       ]
-      assert.equal(2, getFolderSubjects(fileList).length)
+      assert.lengthOf(getFolderSubjects(fileList), 2)
     })
     it('filters out emptyroom subject', () => {
       const fileList = [
         { relativePath: 'sub-01/files' },
         { relativePath: 'sub-emptyroom/data' },
       ]
-      assert.equal(1, getFolderSubjects(fileList).length)
+      assert.lengthOf(getFolderSubjects(fileList), 1)
+    })
+    it('works for deeply nested files', () => {
+      const fileList = [
+        { relativePath: 'sub-01/files/a.nii.gz' },
+        { relativePath: 'sub-01/another/b.nii.gz' },
+        { relativePath: 'sub-02/data/test' },
+      ]
+      assert.lengthOf(getFolderSubjects(fileList), 2)
     })
   })
 })

--- a/validators/__tests__/checkAnyDataPresent.spec.js
+++ b/validators/__tests__/checkAnyDataPresent.spec.js
@@ -4,7 +4,7 @@ const { getFolderSubjects } = require('../checkAnyDataPresent.js')
 describe('checkAnyDataPresent', () => {
   describe('getFolderSubjects()', () => {
     it('returns only unique subjects', () => {
-      // Native FileList but an array simulates it
+      // Pseudo-FileList object but an array simulates it
       const fileList = [
         { relativePath: 'sub-01/files' },
         { relativePath: 'sub-01/another' },
@@ -26,6 +26,10 @@ describe('checkAnyDataPresent', () => {
         { relativePath: 'sub-02/data/test' },
       ]
       assert.lengthOf(getFolderSubjects(fileList), 2)
+    })
+    it('works with object arguments', () => {
+      const fileList = { 0: { relativePath: 'sub-01/anat/one.nii.gz' } }
+      assert.lengthOf(getFolderSubjects(fileList), 1)
     })
   })
 })

--- a/validators/__tests__/checkAnyDataPresent.spec.js
+++ b/validators/__tests__/checkAnyDataPresent.spec.js
@@ -11,7 +11,7 @@ describe('checkAnyDataPresent', () => {
         { relativePath: 'sub-02/data' },
       ]
       const subjects = getFolderSubjects(fileList)
-      assert.lengthOf(subjects, 2)
+      assert.isArray(subjects)
       assert.deepEqual(subjects, ['01', '02'])
     })
     it('filters out emptyroom subject', () => {
@@ -20,7 +20,7 @@ describe('checkAnyDataPresent', () => {
         { relativePath: 'sub-emptyroom/data' },
       ]
       const subjects = getFolderSubjects(fileList)
-      assert.lengthOf(subjects, 1)
+      assert.isArray(subjects)
       assert.deepEqual(subjects, ['01'])
     })
     it('works for deeply nested files', () => {
@@ -30,13 +30,13 @@ describe('checkAnyDataPresent', () => {
         { relativePath: 'sub-02/data/test' },
       ]
       const subjects = getFolderSubjects(fileList)
-      assert.lengthOf(subjects, 2)
+      assert.isArray(subjects)
       assert.deepEqual(subjects, ['01', '02'])
     })
     it('works with object arguments', () => {
       const fileList = { 0: { relativePath: 'sub-01/anat/one.nii.gz' } }
       const subjects = getFolderSubjects(fileList)
-      assert.lengthOf(subjects, 1)
+      assert.isArray(subjects)
       assert.deepEqual(subjects, ['01'])
     })
   })

--- a/validators/checkAnyDataPresent.js
+++ b/validators/checkAnyDataPresent.js
@@ -10,10 +10,10 @@ const uniqueArray = (value, index, self) => self.indexOf(value) === index
 
 /**
  * Find unique subjects from FileList
- * @param {FileList} fileList Browser FileList or Node equivalent
+ * @param {object} fileList Browser FileList or Node equivalent
  */
 const getFolderSubjects = fileList =>
-  Array.from(fileList)
+  Object.values(fileList)
     .filter(matchSubjectPath)
     .map(f => matchSubjectPath(f)[1])
     .filter(uniqueArray)

--- a/validators/checkAnyDataPresent.js
+++ b/validators/checkAnyDataPresent.js
@@ -3,7 +3,7 @@ var Issue = utils.issues.Issue
 
 // Match sub-.../... files, except sub-emptyroom
 const matchSubjectPath = file =>
-  file.relativePath.match(/sub-((?!emptyroom).)*?(?=\/)/)
+  file.relativePath.match(/sub-((?!emptyroom).*?)(?=\/)/)
 
 // Helper for filtering unique values in an array
 const uniqueArray = (value, index, self) => self.indexOf(value) === index

--- a/validators/checkAnyDataPresent.js
+++ b/validators/checkAnyDataPresent.js
@@ -3,7 +3,7 @@ var Issue = utils.issues.Issue
 
 // Match sub-.../... files, except sub-emptyroom
 const matchSubjectPath = file =>
-  file.relativePath.match(/sub-((?!emptyroom).)*(?=\/)/)
+  file.relativePath.match(/sub-((?!emptyroom).)*?(?=\/)/)
 
 // Helper for filtering unique values in an array
 const uniqueArray = (value, index, self) => self.indexOf(value) === index


### PR DESCRIPTION
* Adds a test for the object case. This was mixed up because `Array.from({FileList})` works but this function accepts an object derived from that which is not Array-like.
* Adds a test for a third directory level and makes the regular expression less greedy in this case.