### PR TITLE
Add code coverage badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![](https://circleci.com/gh/bids-standard/bids-validator.svg?style=shield&circle-token=:circle-token)
+![](https://codecov.io/gh/bids-standard/bids-validator/branch/master/graph/badge.svg)
 
 # BIDS-Validator
 


### PR DESCRIPTION
Adds an at a glance coverage number for the master branch to README next to the build status one.