### PR TITLE
validate IntendedFor filetype

### DIFF
--- a/tests/nii.spec.js
+++ b/tests/nii.spec.js
@@ -187,8 +187,7 @@ describe('NIFTI', function() {
     })
     validate.NIFTI(null, file, jsonContentsDict, {}, [], [], function(issues) {
       assert(
-        // TODO: DaNish808 - correct issues.length equality
-        (issues.length = 2 && issues[0].code == 17 && issues[1].code == 37), 
+        (issues.length === 3 && issues[0].code == 17 && issues[1].code == 37), 
       )
     })
   })

--- a/tests/nii.spec.js
+++ b/tests/nii.spec.js
@@ -125,6 +125,41 @@ describe('NIFTI', function() {
     })
   })
 
+  it('should generate warning if files listed in IntendedFor of fieldmap json are not of type .nii or .nii.gz', function() {
+    var file = {
+      name: 'sub-09_ses-test_run-01_fieldmap.nii.gz',
+      path:
+        '/ds114/sub-09/ses-test/fmap/sub-09_ses-test_run-01_fieldmap.nii.gz',
+      relativePath:
+        '/sub-09/ses-test/fmap/sub-09_ses-test_run-01_fieldmap.nii.gz',
+    }
+
+    var jsonContentsDict = {
+      '/sub-09/ses-test/fmap/sub-09_ses-test_run-01_fieldmap.json': {
+        TaskName: 'Mixed Event Related Probe',
+        IntendedFor: [
+          'func/sub-15_task-mixedeventrelatedprobe_run-05_bold.json',
+          'func/sub-15_task-mixedeventrelatedprobe_run-02_bold.nii.gz',
+        ],
+      },
+    }
+    var fileList = []
+    fileList.push({
+      name: 'sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz',
+      path: 'sub-15/func/sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz',
+      relativePath:
+        '/func/sub-15_task-mixedeventrelatedprobe_run-01_bold.nii.gz',
+    })
+    validate.NIFTI(null, file, jsonContentsDict, {}, [], [], function(issues) {
+      assert(
+        issues.some(issue => (
+          issue.reason === 'Invalid filetype: IntendedFor should point to the .nii[.gz] files.' &&
+          issue.evidence === 'func/sub-15_task-mixedeventrelatedprobe_run-05_bold.json'
+        )),
+      )
+    })
+  })
+  
   it('should generate warning if files listed in IntendedFor of fieldmap json do not exist', function() {
     var file = {
       name: 'sub-09_ses-test_run-01_fieldmap.nii.gz',
@@ -152,7 +187,8 @@ describe('NIFTI', function() {
     })
     validate.NIFTI(null, file, jsonContentsDict, {}, [], [], function(issues) {
       assert(
-        (issues.length = 2 && issues[0].code == 17 && issues[1].code == 37),
+        // TODO: DaNish808 - correct issues.length equality
+        (issues.length = 2 && issues[0].code == 17 && issues[1].code == 37), 
       )
     })
   })

--- a/tests/nii.spec.js
+++ b/tests/nii.spec.js
@@ -152,14 +152,17 @@ describe('NIFTI', function() {
     })
     validate.NIFTI(null, file, jsonContentsDict, {}, [], [], function(issues) {
       assert(
-        issues.some(issue => (
-          issue.reason === 'Invalid filetype: IntendedFor should point to the .nii[.gz] files.' &&
-          issue.evidence === 'func/sub-15_task-mixedeventrelatedprobe_run-05_bold.json'
-        )),
+        issues.some(
+          issue =>
+            issue.reason ===
+              'Invalid filetype: IntendedFor should point to the .nii[.gz] files.' &&
+            issue.evidence ===
+              'func/sub-15_task-mixedeventrelatedprobe_run-05_bold.json',
+        ),
       )
     })
   })
-  
+
   it('should generate warning if files listed in IntendedFor of fieldmap json do not exist', function() {
     var file = {
       name: 'sub-09_ses-test_run-01_fieldmap.nii.gz',
@@ -187,7 +190,7 @@ describe('NIFTI', function() {
     })
     validate.NIFTI(null, file, jsonContentsDict, {}, [], [], function(issues) {
       assert(
-        (issues.length === 3 && issues[0].code == 17 && issues[1].code == 37), 
+        issues.length === 3 && issues[0].code == 17 && issues[1].code == 37,
       )
     })
   })

--- a/validators/nifti/nii.js
+++ b/validators/nifti/nii.js
@@ -420,15 +420,15 @@ module.exports = function NIFTI(
         )
       }
     }
-    
+
     if (
       utils.type.file.isFieldMapMainNii(path) &&
       mergedDictionary.hasOwnProperty('IntendedFor')
     ) {
       const intendedFor =
-      typeof mergedDictionary['IntendedFor'] == 'string'
-      ? [mergedDictionary['IntendedFor']]
-      : mergedDictionary['IntendedFor']
+        typeof mergedDictionary['IntendedFor'] == 'string'
+          ? [mergedDictionary['IntendedFor']]
+          : mergedDictionary['IntendedFor']
       
       for (let key = 0; key < intendedFor.length; key++) {
         const intendedForFile = intendedFor[key]

--- a/validators/nifti/nii.js
+++ b/validators/nifti/nii.js
@@ -429,7 +429,7 @@ module.exports = function NIFTI(
         typeof mergedDictionary['IntendedFor'] == 'string'
           ? [mergedDictionary['IntendedFor']]
           : mergedDictionary['IntendedFor']
-      
+
       for (let key = 0; key < intendedFor.length; key++) {
         const intendedForFile = intendedFor[key]
         checkIfIntendedExists(intendedForFile, fileList, issues, file)
@@ -486,9 +486,11 @@ function checkIfIntendedExists(intendedForFile, fileList, issues, file) {
   let onTheList = false
 
   for (let key2 in fileList) {
-    const filePath = fileList[key2].relativePath
-    if (filePath === intendedForFileFull) {
-      onTheList = true
+    if (key2) {
+      const filePath = fileList[key2].relativePath
+      if (filePath === intendedForFileFull) {
+        onTheList = true
+      }
     }
   }
   if (!onTheList) {
@@ -519,8 +521,7 @@ function checkIfValidFiletype(intendedForFile, issues, file) {
       new Issue({
         file: file,
         code: 37,
-        reason:
-          `Invalid filetype: IntendedFor should point to the .nii[.gz] files.`,
+        reason: `Invalid filetype: IntendedFor should point to the .nii[.gz] files.`,
         evidence: intendedForFile,
       }),
     )

--- a/validators/nifti/nii.js
+++ b/validators/nifti/nii.js
@@ -420,19 +420,20 @@ module.exports = function NIFTI(
         )
       }
     }
-
+    
     if (
       utils.type.file.isFieldMapMainNii(path) &&
       mergedDictionary.hasOwnProperty('IntendedFor')
     ) {
       const intendedFor =
-        typeof mergedDictionary['IntendedFor'] == 'string'
-          ? [mergedDictionary['IntendedFor']]
-          : mergedDictionary['IntendedFor']
-
+      typeof mergedDictionary['IntendedFor'] == 'string'
+      ? [mergedDictionary['IntendedFor']]
+      : mergedDictionary['IntendedFor']
+      
       for (let key = 0; key < intendedFor.length; key++) {
         const intendedForFile = intendedFor[key]
         checkIfIntendedExists(intendedForFile, fileList, issues, file)
+        checkIfValidFiletype(intendedForFile, issues, file)
       }
     }
   }
@@ -504,6 +505,22 @@ function checkIfIntendedExists(intendedForFile, fileList, issues, file) {
           "('/" +
           file.relativePath.split('/')[1] +
           "/').",
+        evidence: intendedForFile,
+      }),
+    )
+  }
+}
+
+function checkIfValidFiletype(intendedForFile, issues, file) {
+  const validFiletype = new RegExp('.nii(.gz)?$')
+  const isValidFiletype = validFiletype.test(intendedForFile)
+  if (!isValidFiletype) {
+    issues.push(
+      new Issue({
+        file: file,
+        code: 37,
+        reason:
+          `Invalid filetype: IntendedFor should point to the .nii[.gz] files.`,
         evidence: intendedForFile,
       }),
     )


### PR DESCRIPTION
fixes #597

- adds check validating filetypes .nii[.gz] in validators/nifti/nii.js
- adds test to /tests/nii.spec.js