### PR TITLE
catch exceptions and reformat as Issue

### DIFF
--- a/tests/utils/issues.spec.js
+++ b/tests/utils/issues.spec.js
@@ -53,7 +53,7 @@ describe('issues', () => {
   })
 
   describe('exception/issue redirect', () => {
-    let test, promise, innerPromise, validIssue, invalidIssue
+    let promise, innerPromise, validIssue, invalidIssue
     beforeAll(() => {
       promise = null
       validIssue = new utils.issues.Issue({

--- a/tests/utils/issues.spec.js
+++ b/tests/utils/issues.spec.js
@@ -1,52 +1,107 @@
 const assert = require('assert')
 const utils = require('../../utils')
 
-describe('exceptionHandler', () => {
-  let testErr, issueList, summary, options, formattedIssues
+describe('issues', () => {
+  describe('exceptionHandler', () => {
+    let testErr, issueList, summary, options, formattedIssues
 
-  beforeAll(() => {
-    testErr = new Error('oh no')
-    issueList = []
-    summary = {
-      sessions: [],
-      subjects: [],
-      tasks: [],
-      modalities: [],
-      totalFiles: 0,
-      size: 0,
-    }
-    options = {
-      ignoreWarnings: false,
-      ignoreNiftiHeaders: false,
-      verbose: false,
-      bep006: false,
-      bep010: false,
-      config: {},
-    }
-    formattedIssues = utils.issues.exceptionHandler(
-      testErr,
-      issueList,
-      summary,
-      options,
-    )
+    beforeAll(() => {
+      testErr = new Error('oh no')
+      issueList = []
+      summary = {
+        sessions: [],
+        subjects: [],
+        tasks: [],
+        modalities: [],
+        totalFiles: 0,
+        size: 0,
+      }
+      options = {
+        ignoreWarnings: false,
+        ignoreNiftiHeaders: false,
+        verbose: false,
+        bep006: false,
+        bep010: false,
+        config: {},
+      }
+      formattedIssues = utils.issues.exceptionHandler(
+        testErr,
+        issueList,
+        summary,
+        options,
+      )
+    })
+
+    it('adds INTERNAL ERROR to the issues.errors list', () => {
+      assert.equal(formattedIssues.errors[0].key, 'INTERNAL ERROR')
+    })
+
+    it("creates a properly formatted issue in the error's files property", () => {
+      const exceptionIssue = formattedIssues.errors[0].files[0]
+      assert.ok(utils.issues.isAnIssue(exceptionIssue))
+    })
+
+    it('gives a reason for the error', () => {
+      const exceptionIssue = formattedIssues.errors[0].files[0]
+      assert.equal(
+        exceptionIssue.reason,
+        `${
+          testErr.message
+        }; please help the BIDS team and community by opening an issue at (https://github.com/bids-standard/bids-validator/issues) with the evidence here.`,
+      )
+    })
   })
 
-  it('adds INTERNAL ERROR to the issues.errors list', () => {
-    assert.equal(formattedIssues.errors[0].key, 'INTERNAL ERROR')
-  })
+  describe('exception/issue redirect', () => {
+    let test, promise, innerPromise, validIssue, invalidIssue
+    beforeAll(() => {
+      promise = null
+      validIssue = new utils.issues.Issue({
+        code: 12,
+        file: 'goodstuff.json',
+        reason: 'a series of unfortunate events',
+      })
+      invalidIssue = new Error('oops')
 
-  it("creates a properly formatted issue in the error's files property", () => {
-    const exceptionIssue = formattedIssues.errors[0].files[0]
-    assert.ok(utils.issues.isAnIssue(exceptionIssue))
-  })
+      promise = () => {
+        return new Promise((resolve, reject) => {
+          innerPromise().catch(err =>
+            utils.issues.redirect(err, reject, () => {
+              resolve()
+            }),
+          )
+        })
+      }
+    })
 
-  it('gives a reason for the error', () => {
-    const exceptionIssue = formattedIssues.errors[0].files[0]
-    assert.equal(
-      exceptionIssue.reason,
-      `${
-        testErr.message
-      }; please help the BIDS team and community by opening an issue at (https://github.com/bids-standard/bids-validator/issues) with the evidence here.`,
-    )
+    it('resolves with valid issue', done => {
+      innerPromise = () =>
+        new Promise((_, reject) => {
+          reject(validIssue)
+        })
+
+      promise().then(() => done())
+    })
+
+    it('rejects exceptions', done => {
+      innerPromise = () =>
+        new Promise((_, reject) => {
+          reject(invalidIssue)
+        })
+
+      promise().catch(() => done())
+    })
+
+    it('passes the exception through the error', done => {
+      innerPromise = () =>
+        new Promise((_, reject) => {
+          reject(invalidIssue)
+        })
+
+      promise().catch(err => {
+        assert.deepEqual(err, invalidIssue)
+        done()
+      })
+    })
   })
 })

--- a/tests/utils/issues.spec.js
+++ b/tests/utils/issues.spec.js
@@ -1,8 +1,5 @@
 const assert = require('assert')
 const utils = require('../../utils')
-const dir = process.cwd()
-const data_dir = dir + '/../bids-examples/'
-const test_data = data_dir + 'BIDS_test/'
 
 describe('exceptionHandler', () => {
   let testErr, issueList, summary, options, formattedIssues
@@ -26,20 +23,30 @@ describe('exceptionHandler', () => {
       bep010: false,
       config: {},
     }
-    formattedIssues = utils.issues.exceptionHandler(testErr, issueList, summary, options)
+    formattedIssues = utils.issues.exceptionHandler(
+      testErr,
+      issueList,
+      summary,
+      options,
+    )
   })
-  
+
   it('adds INTERNAL ERROR to the issues.errors list', () => {
     assert.equal(formattedIssues.errors[0].key, 'INTERNAL ERROR')
   })
 
-  it('creates a properly formatted issue in the error\'s files property', () => {
+  it("creates a properly formatted issue in the error's files property", () => {
     const exceptionIssue = formattedIssues.errors[0].files[0]
     assert.ok(utils.issues.isAnIssue(exceptionIssue))
   })
 
   it('gives a reason for the error', () => {
     const exceptionIssue = formattedIssues.errors[0].files[0]
-    assert.equal(exceptionIssue.reason, `${testErr.message}; please help the BIDS team and community by opening an issue at (https://github.com/bids-standard/bids-validator/issues) with the evidence here.`)
+    assert.equal(
+      exceptionIssue.reason,
+      `${
+        testErr.message
+      }; please help the BIDS team and community by opening an issue at (https://github.com/bids-standard/bids-validator/issues) with the evidence here.`,
+    )
   })
 })

--- a/tests/utils/issues.spec.js
+++ b/tests/utils/issues.spec.js
@@ -1,0 +1,45 @@
+const assert = require('assert')
+const utils = require('../../utils')
+const dir = process.cwd()
+const data_dir = dir + '/../bids-examples/'
+const test_data = data_dir + 'BIDS_test/'
+
+describe('exceptionHandler', () => {
+  let testErr, issueList, summary, options, formattedIssues
+
+  beforeAll(() => {
+    testErr = new Error('oh no')
+    issueList = []
+    summary = {
+      sessions: [],
+      subjects: [],
+      tasks: [],
+      modalities: [],
+      totalFiles: 0,
+      size: 0,
+    }
+    options = {
+      ignoreWarnings: false,
+      ignoreNiftiHeaders: false,
+      verbose: false,
+      bep006: false,
+      bep010: false,
+      config: {},
+    }
+    formattedIssues = utils.issues.exceptionHandler(testErr, issueList, summary, options)
+  })
+  
+  it('adds INTERNAL ERROR to the issues.errors list', () => {
+    assert.equal(formattedIssues.errors[0].key, 'INTERNAL ERROR')
+  })
+
+  it('creates a properly formatted issue in the error\'s files property', () => {
+    const exceptionIssue = formattedIssues.errors[0].files[0]
+    assert.ok(utils.issues.isAnIssue(exceptionIssue))
+  })
+
+  it('gives a reason for the error', () => {
+    const exceptionIssue = formattedIssues.errors[0].files[0]
+    assert.equal(exceptionIssue.reason, `${testErr.message}; please help the BIDS team and community by opening an issue at (https://github.com/bids-standard/bids-validator/issues) with the evidence here.`)
+  })
+})

--- a/utils/issues/index.js
+++ b/utils/issues/index.js
@@ -190,7 +190,7 @@ var issues = {
 
   /**
    * Error/Issue redirector
-   * 
+   *
    * takes an error, resolve callback, and reject callback
    */
   redirect: function(err, reject, resolveCB) {
@@ -199,7 +199,7 @@ var issues = {
     } else {
       reject(err)
     }
-  }
+  },
 }
 
 module.exports = issues

--- a/utils/issues/index.js
+++ b/utils/issues/index.js
@@ -187,6 +187,19 @@ var issues = {
     const issues = this.format(issueList, summary, options)
     return issues
   },
+
+  /**
+   * Error/Issue redirector
+   * 
+   * takes an error, resolve callback, and reject callback
+   */
+  redirect: function(err, reject, resolveCB) {
+    if (this.isAnIssue(err)) {
+      resolveCB()
+    } else {
+      reject(err)
+    }
+  }
 }
 
 module.exports = issues

--- a/utils/issues/index.js
+++ b/utils/issues/index.js
@@ -132,7 +132,9 @@ var issues = {
     return new Issue({
       file: callStack,
       evidence: err.stack || '',
-      reason: `${err.message}; please help the BIDS team and community by opening an issue at (https://github.com/bids-standard/bids-validator/issues) with the evidence here.`,
+      reason: `${
+        err.message
+      }; please help the BIDS team and community by opening an issue at (https://github.com/bids-standard/bids-validator/issues) with the evidence here.`,
       code: 0,
     })
   },
@@ -172,7 +174,7 @@ var issues = {
   },
   /**
    * Exception Handler
-   * 
+   *
    * takes an error in fullTest.js catch
    * converts it to an Issue and pushes it to the total list of issues
    * formats issue list and returns it
@@ -184,7 +186,7 @@ var issues = {
     // Format issues
     const issues = this.format(issueList, summary, options)
     return issues
-  }
+  },
 }
 
 module.exports = issues

--- a/utils/issues/index.js
+++ b/utils/issues/index.js
@@ -85,33 +85,66 @@ var issues = {
 
     // organize by severity
     for (var code in categorized) {
-      issue = categorized[code]
-      issue.code = code
+      if (code !== undefined) {
+        issue = categorized[code]
+        issue.code = code
 
-      if (severityMap.hasOwnProperty(issue.code)) {
-        issue.severity = severityMap[issue.code]
-      }
-
-      if (severityMap.hasOwnProperty(issue.key)) {
-        issue.severity = severityMap[issue.key]
-      }
-
-      if (issue.severity === 'error') {
-        // Schema validation issues will yield the JSON file invalid, we should display them first to attract
-        // user attention.
-        if (code == 55) {
-          errors.unshift(issue)
-        } else {
-          errors.push(issue)
+        if (severityMap.hasOwnProperty(issue.code)) {
+          issue.severity = severityMap[issue.code]
         }
-      } else if (issue.severity === 'warning' && !options.ignoreWarnings) {
-        warnings.push(issue)
-      } else if (issue.severity === 'ignore') {
-        ignored.push(issue)
+
+        if (severityMap.hasOwnProperty(issue.key)) {
+          issue.severity = severityMap[issue.key]
+        }
+
+        if (issue.severity === 'error') {
+          // Schema validation issues will yield the JSON file invalid, we should display them first to attract
+          // user attention.
+          if (code == 55) {
+            errors.unshift(issue)
+          } else {
+            errors.push(issue)
+          }
+        } else if (issue.severity === 'warning' && !options.ignoreWarnings) {
+          warnings.push(issue)
+        } else if (issue.severity === 'ignore') {
+          ignored.push(issue)
+        }
       }
     }
-
     return { errors: errors, warnings: warnings, ignored: ignored }
+  },
+
+  /**
+   * Error To Issue
+   *
+   * Takes and expection and returns an Issue
+   */
+  errorToIssue: function(err) {
+    const callStack = err.stack
+      ? err.stack
+          .split('\n')
+          .slice(1)
+          .join('\n')
+          .trim()
+      : ''
+
+    return new Issue({
+      file: callStack,
+      evidence: err.stack || '',
+      reason: `${err.message}; please help the BIDS team and community by opening an issue at (https://github.com/bids-standard/bids-validator/issues) with the evidence here.`,
+      code: 0,
+    })
+  },
+
+  /**
+   * isAnIssue
+   *
+   * takes an object and checks if it's an Issue
+   */
+  isAnIssue: function(obj) {
+    const objKeys = Object.keys(obj)
+    return objKeys.includes('code') && objKeys.includes('reason')
   },
 
   /**
@@ -137,6 +170,21 @@ var issues = {
     }
     return issues.format(unformatted, summary, { config: config })
   },
+  /**
+   * Exception Handler
+   * 
+   * takes an error in fullTest.js catch
+   * converts it to an Issue and pushes it to the total list of issues
+   * formats issue list and returns it
+   */
+  exceptionHandler: function(err, issueList, summary, options) {
+    const genericIssue = this.errorToIssue(err)
+    issueList.push(genericIssue)
+
+    // Format issues
+    const issues = this.format(issueList, summary, options)
+    return issues
+  }
 }
 
 module.exports = issues

--- a/utils/issues/list.js
+++ b/utils/issues/list.js
@@ -6,6 +6,11 @@
  * agnostic to file specifics.
  */
 module.exports = {
+  0: {
+    key: 'INTERNAL ERROR',
+    severity: 'error',
+    reason: 'Internal error. SOME VALIDATION STEPS MAY NOT HAVE OCCURRED'
+  },
   1: {
     key: 'NOT_INCLUDED',
     severity: 'error',

--- a/utils/issues/list.js
+++ b/utils/issues/list.js
@@ -9,7 +9,7 @@ module.exports = {
   0: {
     key: 'INTERNAL ERROR',
     severity: 'error',
-    reason: 'Internal error. SOME VALIDATION STEPS MAY NOT HAVE OCCURRED'
+    reason: 'Internal error. SOME VALIDATION STEPS MAY NOT HAVE OCCURRED',
   },
   1: {
     key: 'NOT_INCLUDED',

--- a/validators/bids/fullTest.js
+++ b/validators/bids/fullTest.js
@@ -182,6 +182,12 @@ const fullTest = (fileList, options, callback) => {
       const issues = utils.issues.format(self.issues, summary, self.options)
       callback(issues, summary)
     })
+    .catch((err) => {
+      // take internal exceptions and push to issues
+      // note: exceptions caught here may have skipped subsequent validations
+      const issues = utils.issues.exceptionHandler(err, self.issues, summary, self.options)
+      callback(issues, summary)
+    })
 }
 
 module.exports = fullTest

--- a/validators/bids/fullTest.js
+++ b/validators/bids/fullTest.js
@@ -92,105 +92,95 @@ const fullTest = (fileList, options, callback) => {
       self.issues = self.issues.concat(tsvIssues)
 
       // Bvec validation
-      bvec.validate(files.bvec, bContentsDict).then(bvecIssues => {
-        self.issues = self.issues.concat(bvecIssues)
+      return bvec.validate(files.bvec, bContentsDict)
+    })
+    .then(bvecIssues => {
+      self.issues = self.issues.concat(bvecIssues)
 
-        // Bval validation
-        bval.validate(files.bval, bContentsDict).then(bvalIssues => {
-          self.issues = self.issues.concat(bvalIssues)
+      // Bval validation
+      return bval.validate(files.bval, bContentsDict)
+    })
+    .then(bvalIssues => {
+      self.issues = self.issues.concat(bvalIssues)
 
-          // Load json files and construct a contents object with field, value pairs
-          json
-            .load(files.json, jsonFiles, jsonContentsDict)
-            .then(jsonLoadIssues => {
-              self.issues = self.issues.concat(jsonLoadIssues)
+      // Load json files and construct a contents object with field, value pairs
+      return json.load(files.json, jsonFiles, jsonContentsDict)
+    })
+    .then(jsonLoadIssues => {
+      self.issues = self.issues.concat(jsonLoadIssues)
 
-              // Check for at least one subject
-              const noSubjectIssues = subjects.atLeastOneSubject(fileList)
-              self.issues = self.issues.concat(noSubjectIssues)
+      // Check for at least one subject
+      const noSubjectIssues = subjects.atLeastOneSubject(fileList)
+      self.issues = self.issues.concat(noSubjectIssues)
 
-              // Check for datasetDescription file in the proper place
-              const datasetDescriptionIssues = checkDatasetDescription(fileList)
-              self.issues = self.issues.concat(datasetDescriptionIssues)
+      // Check for datasetDescription file in the proper place
+      const datasetDescriptionIssues = checkDatasetDescription(fileList)
+      self.issues = self.issues.concat(datasetDescriptionIssues)
 
-              // Validate json files and contents
-              json
-                .validate(jsonFiles, fileList, jsonContentsDict, summary)
-                .then(jsonIssues => {
-                  self.issues = self.issues.concat(jsonIssues)
+      // Validate json files and contents
+      return json.validate(jsonFiles, fileList, jsonContentsDict, summary)
+    })
+    .then(jsonIssues => {
+      self.issues = self.issues.concat(jsonIssues)
 
-                  // Nifti validation
-                  NIFTI.validate(
-                    files.nifti,
-                    fileList,
-                    self.options,
-                    jsonContentsDict,
-                    bContentsDict,
-                    events,
-                    headers,
-                  ).then(niftiIssues => {
-                    self.issues = self.issues.concat(niftiIssues)
+      // Nifti validation
+      return NIFTI.validate(
+        files.nifti,
+        fileList,
+        self.options,
+        jsonContentsDict,
+        bContentsDict,
+        events,
+        headers,
+      )
+    })
+    .then(niftiIssues => {
+      self.issues = self.issues.concat(niftiIssues)
 
-                    // Issues related to participants not listed in the subjects list
-                    const participantsInSubjectsIssues = subjects.participantsInSubjects(
-                      participants,
-                      summary.subjects,
-                    )
-                    self.issues = self.issues.concat(
-                      participantsInSubjectsIssues,
-                    )
+      // Issues related to participants not listed in the subjects list
+      const participantsInSubjectsIssues = subjects.participantsInSubjects(
+        participants,
+        summary.subjects,
+      )
+      self.issues = self.issues.concat(participantsInSubjectsIssues)
 
-                    // Check for equal number of participants from ./phenotype/*.tsv and participants in dataset
-                    const phenotypeIssues = tsv.checkPhenotype(
-                      phenotypeParticipants,
-                      summary,
-                    )
-                    self.issues = self.issues.concat(phenotypeIssues)
+      // Check for equal number of participants from ./phenotype/*.tsv and participants in dataset
+      const phenotypeIssues = tsv.checkPhenotype(phenotypeParticipants, summary)
+      self.issues = self.issues.concat(phenotypeIssues)
 
-                    // Validate nii header fields
-                    self.issues = self.issues.concat(headerFields(headers))
+      // Validate nii header fields
+      self.issues = self.issues.concat(headerFields(headers))
 
-                    // Events validation
-                    stimuli.directory = files.stimuli
-                    const eventsIssues = Events.validateEvents(
-                      events,
-                      stimuli,
-                      headers,
-                      jsonContentsDict,
-                      self.issues,
-                    )
-                    self.issues = self.issues.concat(eventsIssues)
+      // Events validation
+      stimuli.directory = files.stimuli
+      const eventsIssues = Events.validateEvents(
+        events,
+        stimuli,
+        headers,
+        jsonContentsDict,
+        self.issues,
+      )
+      self.issues = self.issues.concat(eventsIssues)
 
-                    // Validate custom fields in all TSVs and add any issues to the list
-                    self.issues = self.issues.concat(
-                      tsv.validateTsvColumns(tsvs, jsonContentsDict),
-                    )
+      // Validate custom fields in all TSVs and add any issues to the list
+      self.issues = self.issues.concat(
+        tsv.validateTsvColumns(tsvs, jsonContentsDict),
+      )
 
-                    // Validate session files
-                    self.issues = self.issues.concat(session(fileList))
+      // Validate session files
+      self.issues = self.issues.concat(session(fileList))
 
-                    // Determine if each subject has data present
-                    self.issues = self.issues.concat(
-                      checkAnyDataPresent(fileList, summary.subjects),
-                    )
+      // Determine if each subject has data present
+      self.issues = self.issues.concat(
+        checkAnyDataPresent(fileList, summary.subjects),
+      )
 
-                    // Group summary modalities
-                    summary.modalities = utils.modalities.group(
-                      summary.modalities,
-                    )
+      // Group summary modalities
+      summary.modalities = utils.modalities.group(summary.modalities)
 
-                    // Format issues
-                    const issues = utils.issues.format(
-                      self.issues,
-                      summary,
-                      self.options,
-                    )
-                    callback(issues, summary)
-                  })
-                })
-            })
-        })
-      })
+      // Format issues
+      const issues = utils.issues.format(self.issues, summary, self.options)
+      callback(issues, summary)
     })
 }
 

--- a/validators/bids/fullTest.js
+++ b/validators/bids/fullTest.js
@@ -182,10 +182,15 @@ const fullTest = (fileList, options, callback) => {
       const issues = utils.issues.format(self.issues, summary, self.options)
       callback(issues, summary)
     })
-    .catch((err) => {
+    .catch(err => {
       // take internal exceptions and push to issues
       // note: exceptions caught here may have skipped subsequent validations
-      const issues = utils.issues.exceptionHandler(err, self.issues, summary, self.options)
+      const issues = utils.issues.exceptionHandler(
+        err,
+        self.issues,
+        summary,
+        self.options,
+      )
       callback(issues, summary)
     })
 }

--- a/validators/bval/validate.js
+++ b/validators/bval/validate.js
@@ -15,14 +15,12 @@ const validate = (files, bContentsDict) => {
             resolve()
           })
         })
-        .catch(err => {
-          if (utils.issues.isAnIssue(err)) {
+        .catch(err =>
+          utils.issues.redirect(err, reject, () => {
             issues.push(err)
             resolve()
-          } else {
-            reject(err)
-          }
-        })
+          }),
+        )
     })
   })
 

--- a/validators/bval/validate.js
+++ b/validators/bval/validate.js
@@ -23,12 +23,7 @@ const validate = (files, bContentsDict) => {
         )
     })
   })
-
-  return new Promise((resolve, reject) =>
-    Promise.all(bvalPromises)
-      .then(() => resolve(issues))
-      .catch(reject),
-  )
+  return Promise.all(bvalPromises).then(() => issues)
 }
 
 module.exports = validate

--- a/validators/bval/validate.js
+++ b/validators/bval/validate.js
@@ -26,7 +26,7 @@ const validate = (files, bContentsDict) => {
 
   return new Promise((resolve, reject) =>
     Promise.all(bvalPromises)
-      .then(() => issues)
+      .then(() => resolve(issues))
       .catch(reject),
   )
 }

--- a/validators/bval/validate.js
+++ b/validators/bval/validate.js
@@ -5,7 +5,7 @@ const validate = (files, bContentsDict) => {
   let issues = []
   // validate bval
   const bvalPromises = files.map(function(file) {
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
       utils.files
         .readFile(file)
         .then(contents => {
@@ -15,15 +15,21 @@ const validate = (files, bContentsDict) => {
             resolve()
           })
         })
-        .catch(issue => {
-          issues.push(issue)
-          resolve()
+        .catch(err => {
+          if (utils.issues.isAnIssue(err)) {
+            issues.push(err)
+            resolve()
+          } else {
+            reject(err)
+          }
         })
     })
   })
 
-  return new Promise(resolve =>
-    Promise.all(bvalPromises).then(() => resolve(issues)),
+  return new Promise((resolve, reject) =>
+    Promise.all(bvalPromises)
+      .then(() => resolve(issues))
+      .catch(reject),
   )
 }
 

--- a/validators/bval/validate.js
+++ b/validators/bval/validate.js
@@ -26,7 +26,7 @@ const validate = (files, bContentsDict) => {
 
   return new Promise((resolve, reject) =>
     Promise.all(bvalPromises)
-      .then(() => resolve(issues))
+      .then(() => issues)
       .catch(reject),
   )
 }

--- a/validators/bvec/validate.js
+++ b/validators/bvec/validate.js
@@ -23,12 +23,7 @@ const validate = (files, bContentsDict) => {
         )
     })
   })
-
-  return new Promise((resolve, reject) =>
-    Promise.all(bvecPromises)
-      .then(() => resolve(issues))
-      .catch(reject),
-  )
+  return Promise.all(bvecPromises).then(() => issues)
 }
 
 module.exports = validate

--- a/validators/bvec/validate.js
+++ b/validators/bvec/validate.js
@@ -15,14 +15,12 @@ const validate = (files, bContentsDict) => {
             resolve()
           })
         })
-        .catch(err => {
-          if (utils.issues.isAnIssue(err)) {
+        .catch(err =>
+          utils.issues.redirect(err, reject, () => {
             issues.push(err)
             resolve()
-          } else {
-            reject(err)
-          }
-        })
+          }),
+        )
     })
   })
 

--- a/validators/bvec/validate.js
+++ b/validators/bvec/validate.js
@@ -5,7 +5,7 @@ const validate = (files, bContentsDict) => {
   // validate bvec
   let issues = []
   const bvecPromises = files.map(function(file) {
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
       utils.files
         .readFile(file)
         .then(contents => {
@@ -15,16 +15,22 @@ const validate = (files, bContentsDict) => {
             resolve()
           })
         })
-        .catch(issue => {
-          issues.push(issue)
-          resolve()
+        .catch(err => {
+          if(utils.issues.isAnIssue(err)) {
+            issues.push(err)
+            resolve()
+          } else {
+            reject(err)
+          }
         })
     })
   })
 
-  return new Promise(resolve => {
-    Promise.all(bvecPromises).then(() => resolve(issues))
-  })
+  return new Promise((resolve, reject) =>
+    Promise.all(bvecPromises)
+      .then(() => resolve(issues))
+      .catch(reject),
+  )
 }
 
 module.exports = validate

--- a/validators/bvec/validate.js
+++ b/validators/bvec/validate.js
@@ -26,7 +26,7 @@ const validate = (files, bContentsDict) => {
 
   return new Promise((resolve, reject) =>
     Promise.all(bvecPromises)
-      .then(() => issues)
+      .then(() => resolve(issues))
       .catch(reject),
   )
 }

--- a/validators/bvec/validate.js
+++ b/validators/bvec/validate.js
@@ -26,7 +26,7 @@ const validate = (files, bContentsDict) => {
 
   return new Promise((resolve, reject) =>
     Promise.all(bvecPromises)
-      .then(() => resolve(issues))
+      .then(() => issues)
       .catch(reject),
   )
 }

--- a/validators/bvec/validate.js
+++ b/validators/bvec/validate.js
@@ -16,7 +16,7 @@ const validate = (files, bContentsDict) => {
           })
         })
         .catch(err => {
-          if(utils.issues.isAnIssue(err)) {
+          if (utils.issues.isAnIssue(err)) {
             issues.push(err)
             resolve()
           } else {

--- a/validators/tsv/validate.js
+++ b/validators/tsv/validate.js
@@ -58,12 +58,7 @@ const validate = (
         .catch(reject)
     })
   })
-
-  return new Promise((resolve, reject) =>
-    Promise.all(tsvPromises)
-      .then(() => resolve(issues))
-      .catch(reject),
-  )
+  return Promise.all(tsvPromises).then(() => issues)
 }
 
 module.exports = validate

--- a/validators/tsv/validate.js
+++ b/validators/tsv/validate.js
@@ -61,7 +61,7 @@ const validate = (
 
   return new Promise((resolve, reject) =>
     Promise.all(tsvPromises)
-      .then(() => issues)
+      .then(() => resolve(issues))
       .catch(reject),
   )
 }

--- a/validators/tsv/validate.js
+++ b/validators/tsv/validate.js
@@ -13,51 +13,56 @@ const validate = (
   let issues = []
   // validate tsv
   const tsvPromises = files.map(function(file) {
-    return new Promise(resolve => {
-      utils.files.readFile(file).then(contents => {
-        // Push TSV to list for custom column verification after all data dictionaries have been read
-        tsvs.push({
-          file: file,
-          contents: contents,
-        })
-        if (file.name.endsWith('_events.tsv')) {
-          events.push({
+    return new Promise((resolve, reject) => {
+      utils.files
+        .readFile(file)
+        .then(contents => {
+          // Push TSV to list for custom column verification after all data dictionaries have been read
+          tsvs.push({
             file: file,
-            path: file.relativePath,
             contents: contents,
           })
-        }
-        tsv(file, contents, fileList, function(
-          tsvIssues,
-          participantList,
-          stimFiles,
-        ) {
-          if (participantList) {
-            if (file.name.endsWith('participants.tsv')) {
-              participants = {
-                list: participantList,
-                file: file,
+          if (file.name.endsWith('_events.tsv')) {
+            events.push({
+              file: file,
+              path: file.relativePath,
+              contents: contents,
+            })
+          }
+          tsv(file, contents, fileList, function(
+            tsvIssues,
+            participantList,
+            stimFiles,
+          ) {
+            if (participantList) {
+              if (file.name.endsWith('participants.tsv')) {
+                participants = {
+                  list: participantList,
+                  file: file,
+                }
+              } else if (file.relativePath.includes('phenotype/')) {
+                phenotypeParticipants.push({
+                  list: participantList,
+                  file: file,
+                })
               }
-            } else if (file.relativePath.includes('phenotype/')) {
-              phenotypeParticipants.push({
-                list: participantList,
-                file: file,
-              })
             }
-          }
-          if (stimFiles && stimFiles.length) {
-            // add unique new events to the stimuli.events array
-            stimuli.events = [...new Set([...stimuli.events, ...stimFiles])]
-          }
-          issues = issues.concat(tsvIssues)
-          return resolve()
+            if (stimFiles && stimFiles.length) {
+              // add unique new events to the stimuli.events array
+              stimuli.events = [...new Set([...stimuli.events, ...stimFiles])]
+            }
+            issues = issues.concat(tsvIssues)
+            return resolve()
+          })
         })
-      })
+        .catch(reject)
     })
   })
 
-  return new Promise(resolve =>
-    Promise.all(tsvPromises).then(() => resolve(issues)),
+  return new Promise((resolve, reject) =>
+    Promise.all(tsvPromises)
+      .then(() => resolve(issues))
+      .catch(reject),
   )
 }
 

--- a/validators/tsv/validate.js
+++ b/validators/tsv/validate.js
@@ -61,7 +61,7 @@ const validate = (
 
   return new Promise((resolve, reject) =>
     Promise.all(tsvPromises)
-      .then(() => resolve(issues))
+      .then(() => issues)
       .catch(reject),
   )
 }

--- a/validators/tsv/validate.js
+++ b/validators/tsv/validate.js
@@ -14,51 +14,45 @@ const validate = (
   // validate tsv
   const tsvPromises = files.map(function(file) {
     return new Promise(resolve => {
-      utils.files
-        .readFile(file)
-        .then(contents => {
-          // Push TSV to list for custom column verification after all data dictionaries have been read
-          tsvs.push({
+      utils.files.readFile(file).then(contents => {
+        // Push TSV to list for custom column verification after all data dictionaries have been read
+        tsvs.push({
+          file: file,
+          contents: contents,
+        })
+        if (file.name.endsWith('_events.tsv')) {
+          events.push({
             file: file,
+            path: file.relativePath,
             contents: contents,
           })
-          if (file.name.endsWith('_events.tsv')) {
-            events.push({
-              file: file,
-              path: file.relativePath,
-              contents: contents,
-            })
-          }
-          tsv(file, contents, fileList, function(
-            tsvIssues,
-            participantList,
-            stimFiles,
-          ) {
-            if (participantList) {
-              if (file.name.endsWith('participants.tsv')) {
-                participants = {
-                  list: participantList,
-                  file: file,
-                }
-              } else if (file.relativePath.includes('phenotype/')) {
-                phenotypeParticipants.push({
-                  list: participantList,
-                  file: file,
-                })
+        }
+        tsv(file, contents, fileList, function(
+          tsvIssues,
+          participantList,
+          stimFiles,
+        ) {
+          if (participantList) {
+            if (file.name.endsWith('participants.tsv')) {
+              participants = {
+                list: participantList,
+                file: file,
               }
+            } else if (file.relativePath.includes('phenotype/')) {
+              phenotypeParticipants.push({
+                list: participantList,
+                file: file,
+              })
             }
-            if (stimFiles && stimFiles.length) {
-              // add unique new events to the stimuli.events array
-              stimuli.events = [...new Set([...stimuli.events, ...stimFiles])]
-            }
-            issues = issues.concat(tsvIssues)
-            return resolve()
-          })
-        })
-        .catch(issue => {
-          issues = issues.concat(issue)
+          }
+          if (stimFiles && stimFiles.length) {
+            // add unique new events to the stimuli.events array
+            stimuli.events = [...new Set([...stimuli.events, ...stimFiles])]
+          }
+          issues = issues.concat(tsvIssues)
           return resolve()
         })
+      })
     })
   })
 


### PR DESCRIPTION
fix for #582

Notable changes

addition of catch to fullTest
exceptions now reformatted as issues and added to issue error list (code 0), along with the callstack and directions to (https://github.com/bids-standard/bids-validator/issues)
redirects invalid issues in the bval and bvec validators to fullTest catch
should work with both web and cli