### PR TITLE
Missing sub ids

### DIFF
--- a/validators/bids/__tests__/subjects.spec.js
+++ b/validators/bids/__tests__/subjects.spec.js
@@ -1,0 +1,34 @@
+const assert = require('chai').assert
+const subjects = require('../subjects')
+
+describe('subjects', () => {
+  const subjectsArray = ['01', '02', '03']
+
+  describe('participantsInSubjects', () => {
+    it('returns no issues if there are no participants provided', () => {
+      const issues = subjects.participantsInSubjects(null, [])
+      assert.lengthOf(issues, 0)
+    })
+    it('returns no issues if all participants are in the subjects array', () => {
+      const participants = {
+        list: subjectsArray,
+      }
+      const issues = subjects.participantsInSubjects(
+        participants,
+        subjectsArray,
+      )
+      assert.lengthOf(issues, 0)
+    })
+    it('return issue code 49 if participants are not the same as subjects', () => {
+      const participants = {
+        list: ['01', '05'],
+      }
+      const issues = subjects.participantsInSubjects(
+        participants,
+        subjectsArray,
+      )
+      assert.lengthOf(issues, 1)
+      assert.equal(issues[0].code, 49)
+    })
+  })
+})

--- a/validators/bids/subjects.js
+++ b/validators/bids/subjects.js
@@ -9,20 +9,38 @@ const participantsInSubjects = (participants, subjects) => {
     if (
       !utils.array.equals(participantsFromFolders, participantsFromFile, true)
     ) {
+      const evidence = constructMismatchEvidence(
+        participantsFromFolders,
+        participantsFromFile,
+      )
       issues.push(
         new Issue({
           code: 49,
-          evidence:
-            'participants.tsv: ' +
-            participantsFromFile.join(', ') +
-            ' folder structure: ' +
-            participantsFromFolders.join(', '),
+          evidence: evidence,
           file: participants.file,
         }),
       )
     }
   }
   return issues
+}
+
+const constructMismatchEvidence = (participants, subjects) => {
+  const diffs = utils.array.diff(participants, subjects)
+  const subjectsNotInParticipantsArray = diffs[0]
+  const subjectsNotInSubjectsArray = diffs[1]
+  const evidenceOfMissingParticipants = subjectsNotInParticipantsArray.length
+    ? 'Subjects ' +
+      subjectsNotInParticipantsArray.join(', ') +
+      ' were found in the folder structure but are missing in participants.tsv. '
+    : ''
+  const evidenceOfMissingSubjects = subjectsNotInSubjectsArray.length
+    ? 'Subjects ' +
+      subjectsNotInSubjectsArray.join(', ') +
+      ' were found in participants.tsv but are not present in the folder structure. '
+    : ''
+  const evidence = evidenceOfMissingParticipants + evidenceOfMissingSubjects
+  return evidence
 }
 
 const atLeastOneSubject = fileList => {

--- a/validators/bids/subjects.js
+++ b/validators/bids/subjects.js
@@ -10,8 +10,8 @@ const participantsInSubjects = (participants, subjects) => {
       !utils.array.equals(participantsFromFolders, participantsFromFile, true)
     ) {
       const evidence = constructMismatchEvidence(
-        participantsFromFolders,
         participantsFromFile,
+        participantsFromFolders,
       )
       issues.push(
         new Issue({
@@ -27,8 +27,8 @@ const participantsInSubjects = (participants, subjects) => {
 
 const constructMismatchEvidence = (participants, subjects) => {
   const diffs = utils.array.diff(participants, subjects)
-  const subjectsNotInParticipantsArray = diffs[0]
-  const subjectsNotInSubjectsArray = diffs[1]
+  const subjectsNotInSubjectsArray = diffs[0]
+  const subjectsNotInParticipantsArray = diffs[1]
   const evidenceOfMissingParticipants = subjectsNotInParticipantsArray.length
     ? 'Subjects ' +
       subjectsNotInParticipantsArray.join(', ') +

--- a/validators/tsv/__tests__/checkPhenotype.spec.js
+++ b/validators/tsv/__tests__/checkPhenotype.spec.js
@@ -1,0 +1,31 @@
+const assert = require('chai').assert
+const checkPhenotype = require('../checkPhenotype')
+
+describe('checkPhenotype', () => {
+  const summary = { subjects: ['01', '02'] }
+
+  it('returns no issue if there are no phenotype participants provided', () => {
+    const issues = checkPhenotype([], [])
+    assert.lengthOf(issues, 0)
+  })
+  it('returns no issues if all phenotype participants are included in the summary object', () => {
+    const phenotypeParticipants = [{ list: ['01', '02'] }]
+    const issues = checkPhenotype(phenotypeParticipants, summary)
+    assert.lengthOf(issues, 0)
+  })
+  it('returns issue code 51 if phenotype participants are not the same as subjects', () => {
+    const phenotypeParticipants = [
+      { file: 'phenotype/test.tsv', list: ['01', '06'] },
+    ]
+    const issues = checkPhenotype(phenotypeParticipants, summary)
+    assert.lengthOf(issues, 1)
+  })
+  it('returns issues for any mismatched participants.tsv files', () => {
+    const phenotypeParticipants = [
+      { file: 'phenotype/test_1.tsv', list: ['01', '06'] },
+      { file: 'phenotype/test_2.tsv', list: ['01', '07'] },
+    ]
+    const issues = checkPhenotype(phenotypeParticipants, summary)
+    assert.lengthOf(issues, 2)
+  })
+})

--- a/validators/tsv/checkPhenotype.js
+++ b/validators/tsv/checkPhenotype.js
@@ -4,27 +4,42 @@ const Issue = utils.issues.Issue
 const checkPhenotype = (phenotypeParticipants, summary) => {
   const issues = []
   for (let j = 0; j < phenotypeParticipants.length; j++) {
-    const fileParticpants = phenotypeParticipants[j]
-    if (
-      phenotypeParticipants &&
-      phenotypeParticipants.length > 0 &&
-      !utils.array.equals(fileParticpants.list, summary.subjects.sort(), true)
-    ) {
+    const fileParticipants = phenotypeParticipants[j]
+    const participantList = fileParticipants.list.sort()
+    const summarySubjects = summary.subjects.sort()
+    if (!utils.array.equals(participantList, summarySubjects)) {
+      const evidence = constructMissingPhenotypeEvidence(
+        participantList,
+        summarySubjects,
+      )
       issues.push(
         new Issue({
           code: 51,
-          evidence:
-            fileParticpants.file +
-            '- ' +
-            fileParticpants.list +
-            '  Subjects -' +
-            fileParticpants,
-          file: fileParticpants.file,
+          evidence: evidence,
+          file: fileParticipants.file,
         }),
       )
     }
   }
   return issues
+}
+
+const constructMissingPhenotypeEvidence = (fileParticipants, subjects) => {
+  const diffs = utils.array.diff(fileParticipants, subjects)
+  const subjectsNotInSummarySubjects = diffs[0]
+  const subjectsNotInFileParticipants = diffs[1]
+  const evidenceOfMissingParticipants = subjectsNotInFileParticipants.length
+    ? 'Subjects ' +
+      subjectsNotInFileParticipants.join(', ') +
+      ' were found in the folder structure but are missing in phenotype/ .tsv. '
+    : ''
+  const evidenceOfMissingSubjects = subjectsNotInSummarySubjects.length
+    ? 'Subjects ' +
+      subjectsNotInSummarySubjects.join(', ') +
+      ' were found in phenotype/ .tsv file but are not present in the folder structure. '
+    : ''
+  const evidence = evidenceOfMissingParticipants + evidenceOfMissingSubjects
+  return evidence
 }
 
 module.exports = checkPhenotype


### PR DESCRIPTION
fixes #350 

* issue code 51 evidence now includes exact participant ids missing in participants.tsv, as well as those missing in folder structure
* ^^ same for issue code 49
* unit test for validators/tsv/checkPhenotype.js:checkPhenotype()
* unit test for validators/bids/subjects.js:participantsInSubjects()