### PR TITLE
[MRG] bring eeg json schema up to date

### DIFF
--- a/tests/json.spec.js
+++ b/tests/json.spec.js
@@ -81,10 +81,10 @@ describe('JSON', function() {
       TaskName: 'rest',
       SamplingFrequency: 1000,
       EEGChannelCount: 1,
-      EOGChannelCount: 2,
-      ECGChannelCount: 3,
-      EMGChannelCount: 4,
       EEGReference: 'Cz',
+      SoftwareFilters: {
+        HighPass: { HalfAmplitudeCutOffHz: 1, RollOff: '6dB/Octave' },
+      },
       PowerLineFrequency: 50,
     }
     jsonDict[eeg_file.relativePath] = jsonObj

--- a/validators/json/schemas/eeg.json
+++ b/validators/json/schemas/eeg.json
@@ -12,7 +12,6 @@
     "Manufacturer": { "type": "string", "minLength": 1 },
     "ManufacturersModelName": { "type": "string", "minLength": 1 },
     "DeviceSerialNumber": { "type": "string" },
-    "DeviceSoftwareVersion": { "type": "string" },
     "SoftwareVersions": { "type": "string" },
     "PowerLineFrequency": { "type": "number" },
     "SamplingFrequency": { "type": "number" },
@@ -27,6 +26,7 @@
     "EEGGround": { "type": "string" },
     "CapManufacturer": { "type": "string" },
     "CapManufacturersModelName": { "type": "string" },
+    "HeadCircumference": { "type": "number" },
     "HardwareFilters": {
       "anyOf": [
         { "type": "object", "additionalProperties": { "type": "object" } },
@@ -47,10 +47,8 @@
   "required": [
     "TaskName",
     "SamplingFrequency",
+    "SoftwareFilters",
     "EEGChannelCount",
-    "EOGChannelCount",
-    "ECGChannelCount",
-    "EMGChannelCount",
     "EEGReference",
     "PowerLineFrequency"
   ],

--- a/validators/json/schemas/ieeg.json
+++ b/validators/json/schemas/ieeg.json
@@ -55,5 +55,5 @@
     "SoftwareFilters",
     "iEEGReference"
   ],
-  "additionalProperties": true
+  "additionalProperties": false
 }


### PR DESCRIPTION
related to #592 

@choldgraf I saw that in the [ieeg.json schema](https://github.com/bids-standard/bids-validator/blob/master/validators/json/schemas/ieeg.json) you have `"additionalProperties": true`, whereas it is false in `meg`, `eeg`, and the coordsystem definitions. Having it at false allows for a tight control during validation ... at the expense that users cannot define their own fields in the modality specific json file.

What is more desirable in this case?

cc @robertoostenveld 