### PR TITLE
Fix nodejs only unhandled error crash for empty files

### DIFF
--- a/utils/issues/index.js
+++ b/utils/issues/index.js
@@ -180,8 +180,12 @@ var issues = {
    * formats issue list and returns it
    */
   exceptionHandler: function(err, issueList, summary, options) {
-    const genericIssue = this.errorToIssue(err)
-    issueList.push(genericIssue)
+    // err here can be a validator Issue or an unknown exception
+    if (err.hasOwnProperty('key')) {
+      issueList.push(err)
+    } else {
+      issueList.push(this.errorToIssue(err))
+    }
 
     // Format issues
     const issues = this.format(issueList, summary, options)


### PR DESCRIPTION
Empty file error code 99 was being hidden by the generic error handler here, leading to a difference in behavior between the web and nodejs versions of the validator. If the exceptionHandler receives an Issue instead of an error this will report the correct issue instead of the internal error warning.