### PR TITLE
FIX: Ensure package data is included in package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,6 @@ classifiers =
 
 [options]
 packages = find:
-include_package_data = True
 
 [options.package_data]
 bids_validator =


### PR DESCRIPTION
bids-validator 1.1.2 is missing the JSON rules. Apparently I wasn't very careful in cleaning the build artifacts between tests. The line I'm removing restores the files, but putting it back after building and then rebuilding will still build the package with them in... :-/