### PR TITLE
[MRG] make 0KB admissible exceptions for certain CTF files

### DIFF
--- a/tests/utils/files.spec.js
+++ b/tests/utils/files.spec.js
@@ -48,6 +48,8 @@ describe('validateMisc', () => {
   let filelist, dir
 
   beforeAll(() => {
+    // contains stripped down CTF format dataset: BadChannels and bad.segments
+    // can be empty and valid. Everything else must not be empty
     dir = `${process.cwd()}/tests/data/empty_files`
   })
 
@@ -56,14 +58,15 @@ describe('validateMisc', () => {
       filelist = files
     })
   })
-  it('returns issues for empty files (0kb)', done => {
+  it('returns issues for empty files (0kb), accepting a limited set of exceptions', done => {
     const files = groupFileTypes(filelist, {})
     utils.collectSummary(filelist, {})
 
     validateMisc(files.misc).then(issues => {
-      assert.ok(issues.length > 0)
+      assert.ok(issues.length == 1) // the meg4 file is empty
       assert.ok(issues.every(issue => issue instanceof utils.issues.Issue))
       assert.notStrictEqual(issues.findIndex(issue => issue.code === 99), -1)
+      assert.ok(issues[0].file.name == 'sub-0001_task-AEF_run-01_meg.meg4') // BadChannels is empty as well: but it is not an issue
       done()
     })
   })

--- a/tests/utils/files.spec.js
+++ b/tests/utils/files.spec.js
@@ -48,8 +48,9 @@ describe('validateMisc', () => {
   let filelist, dir
 
   beforeAll(() => {
-    // contains stripped down CTF format dataset: BadChannels and bad.segments
-    // can be empty and valid. Everything else must not be empty
+    // contains stripped down CTF format dataset: Both, BadChannels and
+    // bad.segments files can be empty and still valid. Everything else must
+    // not be empty.
     dir = `${process.cwd()}/tests/data/empty_files`
   })
 
@@ -63,10 +64,11 @@ describe('validateMisc', () => {
     utils.collectSummary(filelist, {})
 
     validateMisc(files.misc).then(issues => {
-      assert.ok(issues.length == 1) // the meg4 file is empty
+      // *.meg4 and BadChannels files are empty. But only *.meg4 is an issue
+      assert.ok(issues.length == 1)
       assert.ok(issues.every(issue => issue instanceof utils.issues.Issue))
       assert.notStrictEqual(issues.findIndex(issue => issue.code === 99), -1)
-      assert.ok(issues[0].file.name == 'sub-0001_task-AEF_run-01_meg.meg4') // BadChannels is empty as well: but it is not an issue
+      assert.ok(issues[0].file.name == 'sub-0001_task-AEF_run-01_meg.meg4')
       done()
     })
   })

--- a/utils/files/validateMisc.js
+++ b/utils/files/validateMisc.js
@@ -2,7 +2,15 @@ const Issue = require('../issues/issue')
 
 function createIssueForEmpty(file) {
   const size = typeof window !== 'undefined' ? file.size : file.stats.size
-  return size <= 0 && new Issue({ code: 99, file: file })
+  var failSizeRequirement = size <= 0
+  // Exception misc files that can be valid although size==0
+  // E.g., BadChannels and bad.segments in CTF data format (MEG modality)
+  const exceptionMiscs = ['BadChannels', 'bad.segments']
+  if (exceptionMiscs.indexOf(file.name) > -1) {
+    failSizeRequirement = false
+  }
+
+  return failSizeRequirement && new Issue({ code: 99, file: file })
 }
 function clearNonIssues(x) {
   return x instanceof Issue

--- a/utils/files/validateMisc.js
+++ b/utils/files/validateMisc.js
@@ -2,15 +2,15 @@ const Issue = require('../issues/issue')
 
 function createIssueForEmpty(file) {
   const size = typeof window !== 'undefined' ? file.size : file.stats.size
-  var failSizeRequirement = size <= 0
+  var failsSizeRequirement = size <= 0
   // Exception misc files that can be valid although size==0
   // E.g., BadChannels and bad.segments in CTF data format (MEG modality)
   const exceptionMiscs = ['BadChannels', 'bad.segments']
   if (exceptionMiscs.indexOf(file.name) > -1) {
-    failSizeRequirement = false
+    failsSizeRequirement = false
   }
 
-  return failSizeRequirement && new Issue({ code: 99, file: file })
+  return failsSizeRequirement && new Issue({ code: 99, file: file })
 }
 function clearNonIssues(x) {
   return x instanceof Issue


### PR DESCRIPTION
fixes #651 

This addresses the original issue in #651: We are raising empty file issues for files of 0kb ... but in the CTF data format, there are two files that are valid when they are 0kb: "BadChannels" and "bad.segments".

These two files are "misc" files in BIDS-validator terms, so I have added the relevant code to `validateMisc`.