### PR TITLE
[MRG] add brainvision-validator to validate BrainVision data triplets

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "ajv": "^6.5.2",
     "aws-sdk": "^2.327.0",
+    "brainvision-validator": "^1.2.1",
     "bytes": "^3.0.0",
     "cliff": "^0.1.10",
     "colors": "^1.3.1",

--- a/tests/bids.spec.js
+++ b/tests/bids.spec.js
@@ -206,4 +206,14 @@ describe('BIDS example datasets ', function() {
       isdone()
     })
   })
+
+  it('should throw an error is BrainVision triplets have broken internal links', function(isdone) {
+    var options = { bep006: true }
+    validate.BIDS('tests/data/broken_brainvision_data', options, function(
+      issues,
+    ) {
+      assertErrorCode(issues.errors, '100')
+      isdone()
+    })
+  })
 })

--- a/tests/data/broken_brainvision_data/dataset_description.json
+++ b/tests/data/broken_brainvision_data/dataset_description.json
@@ -1,0 +1,4 @@
+{
+  "Name": "broken_brainvision_data",
+  "BIDSVersion": "1.1.1"
+}

--- a/tests/data/broken_brainvision_data/sub-01/eeg/sub-01_task-test_eeg.eeg
+++ b/tests/data/broken_brainvision_data/sub-01/eeg/sub-01_task-test_eeg.eeg
@@ -1,0 +1,1 @@
+*binary data*

--- a/tests/data/broken_brainvision_data/sub-01/eeg/sub-01_task-test_eeg.vhdr
+++ b/tests/data/broken_brainvision_data/sub-01/eeg/sub-01_task-test_eeg.vhdr
@@ -1,0 +1,34 @@
+Brain Vision Data Exchange Header File Version 1.0
+; manually created and inserted an error into DataFile field
+
+[Common Infos]
+Codepage=UTF-8
+DataFile=sub-01_task-ERROR-test_eeg.eeg
+MarkerFile=sub-01_task-test_eeg.vmrk
+DataFormat=BINARY
+Data orientation: MULTIPLEXED=ch1,pt1, ch2,pt1 ...
+DataOrientation=MULTIPLEXED
+NumberOfChannels=10
+; Sampling interval in microseconds
+SamplingInterval=200
+
+[Binary Infos]
+BinaryFormat=IEEE_FLOAT_32
+
+[Channel Infos]
+; Each entry: Ch<Channel number>=<Name>,<Reference channel name>,
+; <Resolution in microvolts>,<Future extensions..
+; Fields are delimited by commas, some fields might be omitted (empty).
+; Commas in channel names are coded as "\1".
+Ch1=FC5,,0.1
+Ch2=FC1,,0.1
+Ch3=C3,,0.1
+Ch4=CP5,,0.1
+Ch5=CP1,,0.1
+Ch6=FC2,,0.1
+Ch7=FC6,,0.1
+Ch8=C4,,0.1
+Ch9=CP2,,0.1
+Ch10=CP6,,0.1
+
+[Comment]

--- a/tests/data/broken_brainvision_data/sub-01/eeg/sub-01_task-test_eeg.vmrk
+++ b/tests/data/broken_brainvision_data/sub-01/eeg/sub-01_task-test_eeg.vmrk
@@ -1,0 +1,13 @@
+Brain Vision Data Exchange Marker File, Version 1.0
+; manually created and inserted an error into DataFile field
+
+[Common Infos]
+Codepage=UTF-8
+DataFile=sub-01_task-ERROR-test_eeg.eeg
+
+[Marker Infos]
+; Each entry: Mk<Marker number>=<Type>,<Description>,<Position in data points>,
+; <Size in data points>, <Channel number (0 = marker is related to all channels)>
+; Fields are delimited by commas, some fields might be omitted (empty).
+; Commas in type or description text are coded as "\1".
+Mk1=New Segment,,1,1,0,0

--- a/tests/data/broken_brainvision_data/sub-01/eeg/sub-01_task-test_events.tsv
+++ b/tests/data/broken_brainvision_data/sub-01/eeg/sub-01_task-test_events.tsv
@@ -1,0 +1,2 @@
+onset	duration
+1	1

--- a/utils/issues/list.js
+++ b/utils/issues/list.js
@@ -558,6 +558,6 @@ module.exports = {
     key: 'BRAINVISION_LINKS_BROKEN',
     severity: 'error',
     reason:
-      'Internal file pointers in BrainVision file triplet (*.eeg, *.vhdr, and *.vmrk) broken or some files do not exist.',
+      'Internal file pointers in BrainVision file triplet (*.eeg, *.vhdr, and *.vmrk) are broken or some files do not exist.',
   },
 }

--- a/utils/issues/list.js
+++ b/utils/issues/list.js
@@ -558,6 +558,6 @@ module.exports = {
     key: 'BRAINVISION_LINKS_BROKEN',
     severity: 'error',
     reason:
-      'The internal file pointers between the present BrainVision file triplet (*.eeg, *.vhdr, and *.vmrk) appear to be broken or some files do not exist.',
+      'Internal file pointers in BrainVision file triplet (*.eeg, *.vhdr, and *.vmrk) broken or some files do not exist.',
   },
 }

--- a/utils/issues/list.js
+++ b/utils/issues/list.js
@@ -554,4 +554,10 @@ module.exports = {
     severity: 'error',
     reason: 'Empty files not allowed.',
   },
+  100: {
+    key: 'BRAINVISION_LINKS_BROKEN',
+    severity: 'error',
+    reason:
+      'The internal file pointers between the present BrainVision file triplet (*.eeg, *.vhdr, and *.vmrk) appear to be broken or some files do not exist.',
+  },
 }

--- a/validators/bids/fullTest.js
+++ b/validators/bids/fullTest.js
@@ -83,10 +83,20 @@ const fullTest = (fileList, options, annexed, dir, callback) => {
   var vhdrIssues = []
   vhdrFiles.forEach(function(vhdrFile) {
     var issues = validateBrainVision(vhdrFile.path)
+    // brainvision-validator returns an array of strings as issues
+    // if no issues: empty array
     // Currently only catching a problem of internal file links.
-    if (issues.includes(2)) {
+    if (issues.toString().includes('Internal links are broken')) {
       vhdrIssues = vhdrIssues.concat(
-        new Issue({ file: vhdrFile, evidence: vhdrFile.name, code: 100 }),
+        new Issue({
+          file: vhdrFile,
+          evidence: [
+            vhdrFile.name,
+            vhdrFile.name.substr(0, vhdrFile.name.lastIndexOf('.')) + '.eeg',
+            vhdrFile.name.substr(0, vhdrFile.name.lastIndexOf('.')) + '.vmrk',
+          ],
+          code: 100,
+        }),
       )
     }
   })

--- a/validators/bids/fullTest.js
+++ b/validators/bids/fullTest.js
@@ -79,11 +79,16 @@ const fullTest = (fileList, options, annexed, dir, callback) => {
   }
 
   // Validate BrainVision EEG files (file triplets: .eeg, .vhdr, .vmrk)
-  var vhdrFiles = files.ephys.filter(file => file.name.endsWith('vhdr'))
+  var vhdrFiles = files.ephys.filter(file => file.name.endsWith('.vhdr'))
   var vhdrIssues = []
   vhdrFiles.forEach(function(vhdrFile) {
     var issues = validateBrainVision(vhdrFile.path)
-    vhdrIssues = vhdrIssues.concat(issues)
+    // Currently only catching a problem of internal file links.
+    if (issues.includes(2)) {
+      vhdrIssues = vhdrIssues.concat(
+        new Issue({ file: vhdrFile, evidence: vhdrFile.name, code: 100 }),
+      )
+    }
   })
   self.issues = self.issues.concat(vhdrIssues)
 

--- a/validators/bids/fullTest.js
+++ b/validators/bids/fullTest.js
@@ -15,6 +15,7 @@ const groupFileTypes = require('./groupFileTypes')
 const subjects = require('./subjects')
 const checkDatasetDescription = require('./checkDatasetDescription')
 const validateMisc = require('../../utils/files/validateMisc')
+const validateBrainVision = require('brainvision-validator').validateBrainVision
 
 /**
  * Full Test
@@ -76,6 +77,15 @@ const fullTest = (fileList, options, annexed, dir, callback) => {
       }),
     )
   }
+
+  // Validate BrainVision EEG files (file triplets: .eeg, .vhdr, .vmrk)
+  var vhdrFiles = files.ephys.filter(file => file.name.endsWith('vhdr'))
+  var vhdrIssues = []
+  vhdrFiles.forEach(function(vhdrFile) {
+    var issues = validateBrainVision(vhdrFile.path)
+    vhdrIssues = vhdrIssues.concat(issues)
+  })
+  self.issues = self.issues.concat(vhdrIssues)
 
   validateMisc(files.misc)
     .then(miscIssues => {


### PR DESCRIPTION
closes #475 

With the EEG extension soon being merged, I want to get started with validating the raw data files.

The BrainVision data format is one of the two core formats of the EEG extension, and using the [`brainvision-validator`](https://github.com/sappelhoff/brainvision-validator) npm module, this should be possible within the bids-validator.

I would greatly appreciate some guidance through the process, or reasons why we should take a different approach and close this PR instead :-)

For the beginning, I have added a snippet of code that would make sense IMO.

Questions:
1. the `validateBrainVision` currently returns an array of strings ... if the array is empty, the validation was successful ... else there are the strings that describe the problem --> How would I best transform these potential strings into the "issues" object used in BIDS-validator?
2. What else should I prepare to get this PR merged?