### PR TITLE
Added MANIFEST.in to add required files to tarballs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ npm-debug.log
 package-lock.json
 .nyc_output/
 coverage/
+__pycache__/
+dist/
+*.egg-info/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include CODE_OF_CONDUCT.md LICENSE MANIFEST.in README.md
+include versioneer.py


### PR DESCRIPTION
This PR fixes #707 by adding a `MANIFEST.in` file and listing extra files to include in the tarball distributions created for PyPI.

I also added some python-related entries to `.gitignore`.