### PR TITLE
revert #701

### DIFF
--- a/bids-validator/package.json
+++ b/bids-validator/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "ajv": "^6.5.2",
     "aws-sdk": "^2.327.0",
-    "brainvision-validator": "^1.2.1",
     "bytes": "^3.0.0",
     "cliff": "^0.1.10",
     "colors": "^1.3.1",

--- a/bids-validator/tests/bids.spec.js
+++ b/bids-validator/tests/bids.spec.js
@@ -225,14 +225,4 @@ describe('BIDS example datasets ', function() {
       },
     )
   })
-
-  it('should throw an error is BrainVision triplets have broken internal links', function(isdone) {
-    var options = { bep006: true }
-    validate.BIDS(dataDirectory + 'broken_brainvision_data', options, function(
-      issues,
-    ) {
-      assertErrorCode(issues.errors, '100')
-      isdone()
-    })
-  })
 })

--- a/bids-validator/validators/bids/fullTest.js
+++ b/bids-validator/validators/bids/fullTest.js
@@ -16,7 +16,6 @@ const subjects = require('./subjects')
 const checkDatasetDescription = require('./checkDatasetDescription')
 const checkReadme = require('./checkReadme')
 const validateMisc = require('../../utils/files/validateMisc')
-const validateBrainVision = require('brainvision-validator').validateBrainVision
 
 /**
  * Full Test
@@ -78,30 +77,6 @@ const fullTest = (fileList, options, annexed, dir, callback) => {
       }),
     )
   }
-
-  // Validate BrainVision EEG files (file triplets: .eeg, .vhdr, .vmrk)
-  var vhdrFiles = files.ephys.filter(file => file.name.endsWith('.vhdr'))
-  var vhdrIssues = []
-  vhdrFiles.forEach(function(vhdrFile) {
-    var issues = validateBrainVision(vhdrFile.path)
-    // brainvision-validator returns an array of strings as issues
-    // if no issues: empty array
-    // Currently only catching a problem of internal file links.
-    if (issues.toString().includes('Internal links are broken')) {
-      vhdrIssues = vhdrIssues.concat(
-        new Issue({
-          file: vhdrFile,
-          evidence: [
-            vhdrFile.name,
-            vhdrFile.name.substr(0, vhdrFile.name.lastIndexOf('.')) + '.eeg',
-            vhdrFile.name.substr(0, vhdrFile.name.lastIndexOf('.')) + '.vmrk',
-          ],
-          code: 100,
-        }),
-      )
-    }
-  })
-  self.issues = self.issues.concat(vhdrIssues)
 
   validateMisc(files.misc)
     .then(miscIssues => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1708,14 +1708,6 @@ braces@^2.3.1, braces@^2.3.2:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-brainvision-validator@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/brainvision-validator/-/brainvision-validator-1.2.1.tgz#d1234007f4ff87df6e5f7430db769ca999309c10"
-  integrity sha512-ZML0lwNSq7Zi6QRYP2gfRGgtXJ/XmOJhBUvDyT85X7O0J2Ho9XUIdcqYvNLSF5e6MOQWOAXIwnBzcDbrWN6YmA==
-  dependencies:
-    colors "^1.3.1"
-    yargs "^12.0.1"
-
 brorand@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"


### PR DESCRIPTION
fixes #718 by reverting the changes to `/bids-validator/validators/fullTest.js` which introduced breaking changes to the web validator. however, the test dataset remains in the codebase for future solutions to this issue.