### PR TITLE
Fix bad developer instructions for npm global install

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ see available options.
 To develop locally, clone the project and run `yarn` from the project
 root. This will install external dependencies. If you wish to install
 `bids-validator` globally (so that you can run it in other folders), use the
-following command to install it globally: `npm install -g`
+following command to install it globally: `cd bids-validator && npm install -g`
 
 #### Running Locally in a Browser
 


### PR DESCRIPTION
This is needed due to the layout change in #710. We can't substitute a yarn command because yarn does not support global installs of local packages, only those from a registry.

Fixes #723