### PR TITLE
fix gh-pages cleanup in circle config

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -109,7 +109,7 @@ jobs:
           command: mv bids-validator-web/out/* .
       - run:
           name: Remove files not related to build
-          command: rm -r bids-validator-web node_modules tests
+          command: rm -r bids-validator bids-validator-web node_modules
       - run:
           name: Create a nojekyll file (gh-pages specific)
           command: touch .nojekyll


### PR DESCRIPTION
fixes #728.

the gh-pages deployment git commands can be verified by performing locally, starting with `git checkout --orphan gh-pages`. 