### PR TITLE
Add README to bids-validator package via symlink

### DIFF
--- a/bids-validator/README.md
+++ b/bids-validator/README.md
@@ -1,0 +1,1 @@
+../README.md


### PR DESCRIPTION
This fixes the missing README on npm / pypi following #710 