### PR TITLE
[MRG] accept number instead of integer as type for sampling freq

### DIFF
--- a/bids-validator/validators/json/schemas/ieeg.json
+++ b/bids-validator/validators/json/schemas/ieeg.json
@@ -2,7 +2,7 @@
   "type": "object",
   "properties": {
     "TaskName": { "type": "string", "minLength": 1 },
-    "SamplingFrequency": { "type": "integer" },
+    "SamplingFrequency": { "type": "number" },
     "PowerLineFrequency": { "type": "number" },
     "DCOffsetCorrection": { "type": "string", "minLength": 1 },
     "SoftwareFilters": {


### PR DESCRIPTION
fixes an error we encountered while going over the examples:

https://github.com/bids-standard/bids-examples/pull/144#issuecomment-468640345

This will allow float values in the "SamplingFrequency" field of the `ieeg.json` sidecar file.

cc @dorahermes 