### PR TITLE
BF: fixed regexp for defacemask - should have preceding _

### DIFF
--- a/bids-validator/bids_validator/rules/file_level_rules.json
+++ b/bids-validator/bids_validator/rules/file_level_rules.json
@@ -25,7 +25,7 @@
   },
 
   "anat_defacemask": {
-    "regexp": "^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)\\/)?anat\\/\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_mod-(?:@@@_anat_suffixes_@@@))?defacemask\\.(@@@_anat_ext_@@@)$",
+    "regexp": "^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)\\/)?anat\\/\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_mod-(?:@@@_anat_suffixes_@@@))?_defacemask\\.(@@@_anat_ext_@@@)$",
     "tokens": {
       "@@@_anat_suffixes_@@@": [
         "T1w",


### PR DESCRIPTION
Not sure yet if that is the full fix etc, or would it resolve the
bids-validator (0.21.1) failure for me claiming that

	/sub-rid000043/anat/sub-rid000043_run-02_mod-T1w_defacemask.nii.gz
			This file is not part of the BIDS specification, make sure it isn't included in the dataset by accident. Data derivatives (processed data) should be placed in /derivatives folder.
			Evidence: sub-rid000043_run-02_mod-T1w_defacemask.nii.gz

redid with fresh bids-validator pulled from docker hub's validator not base_validator, so should be more recent version (although claiming being 0.0.0, there is an issue somewhere):
```
                ./sub-rid000043/anat/sub-rid000043_run-02_mod-T1w_defacemask.nii.gz
                        Files with such naming scheme are not part of BIDS specification. This error is most commonly caused by typos in file names that make them not BIDS compatible. Please consult the specification and make sure your files are named correctly. If this is not a file naming issue (for example when including files not yet covered by the BIDS specification) you should include a ".bidsignore" file in your dataset (see https://github.com/bids-standard/bids-validator#bidsignore for details). Please note that derived (processed) data should be placed in /derivatives folder and source data (such as DICOMS or behavioural logs in proprietary formats) should be placed in the /sourcedata folder.
                        Evidence: sub-rid000043_run-02_mod-T1w_defacemask.nii.gz
```
