### PR TITLE
create modality-specific file extension check

### DIFF
--- a/bids-validator/utils/summary/collectModalities.js
+++ b/bids-validator/utils/summary/collectModalities.js
@@ -11,7 +11,7 @@ const collectModalities = fileList => {
 
     // check modality by data file extension ...
     // and capture data files for later sanity checks (when available)
-    if (type.file.isDatafile(file.relativePath)) {
+    if (type.file.hasModality(file.relativePath)) {
       // collect modality summary
       const modality = suffix.slice(0, suffix.indexOf('.'))
       if (modalities.indexOf(modality) === -1) {

--- a/bids-validator/utils/type.js
+++ b/bids-validator/utils/type.js
@@ -226,6 +226,22 @@ module.exports = {
     isCont: function(path) {
       return conditionalMatch(contData, path)
     },
+
+    hasModality: function(path) {
+      return (
+        this.isAnat(path) ||
+        this.isDWI(path) ||
+        this.isFieldMap(path) ||
+        this.isFieldMapMainNii(path) ||
+        this.isFunc(path) ||
+        this.isMeg(path) ||
+        this.isEEG(path) ||
+        this.isIEEG(path) ||
+        this.isBehavioral(path) ||
+        this.isFuncBold(path) ||
+        this.isCont(path)
+      )
+    },
   },
 
   checkType(obj, typeString) {

--- a/bids-validator/utils/type.js
+++ b/bids-validator/utils/type.js
@@ -112,17 +112,7 @@ module.exports = {
         this.isTSV(path) ||
         this.isStimuliData(path) ||
         this.isPhenotypic(path) ||
-        this.isAnat(path) ||
-        this.isDWI(path) ||
-        this.isFieldMap(path) ||
-        this.isFieldMapMainNii(path) ||
-        this.isFunc(path) ||
-        this.isMeg(path) ||
-        this.isEEG(path) ||
-        this.isIEEG(path) ||
-        this.isBehavioral(path) ||
-        this.isFuncBold(path) ||
-        this.isCont(path)
+        this.hasModality(path)
       )
     },
     /**


### PR DESCRIPTION
fixes #704. 

Incorporates new file extension check function - `bids-validator/utils/files/type.js:file.hasModality`. This function is more accurate than the previously implemented `bids-validator/utils/files/type.js:file.isDataFile` for obtaining modalities from file extensions.