### PR TITLE
check for excessive commas in dataset_description.json Authors field

### DIFF
--- a/bids-validator/tests/utils/files.spec.js
+++ b/bids-validator/tests/utils/files.spec.js
@@ -48,9 +48,20 @@ describe('files utils in browsers', () => {
 
 describe('dataset_description.json', () => {
   it('throws warning if it does not exist in proper location', () => {
-    const fileList = {}
-    const issues = checkDatasetDescription(fileList)
+    const jsonFileContents = {}
+    const issues = checkDatasetDescription(jsonFileContents)
     assert(issues[0].key === 'DATASET_DESCRIPTION_JSON_MISSING')
+  })
+  it('throws a warning if the Authors field of the dataset description has too many commas', () => {
+    const jsonFileContents = {
+      '/dataset_description.json': {
+        Authors: [
+          'Too many, Commas, Indicate, That the user, May not have, Separated authors, Into an array',
+        ],
+      },
+    }
+    const issues = checkDatasetDescription(jsonFileContents)
+    assert(issues[0].key === 'IMPROPERLY_FORMATTED_AUTHORS')
   })
 })
 

--- a/bids-validator/tests/utils/files.spec.js
+++ b/bids-validator/tests/utils/files.spec.js
@@ -52,7 +52,16 @@ describe('dataset_description.json', () => {
     const issues = checkDatasetDescription(jsonFileContents)
     assert(issues[0].key === 'DATASET_DESCRIPTION_JSON_MISSING')
   })
-  it('throws a warning if the Authors field of the dataset description has too many commas', () => {
+  it('throws a warning if the Authors field of the dataset description has a single entry and less than two commas', () => {
+    const jsonFileContents = {
+      '/dataset_description.json': {
+        Authors: ['An, Author'],
+      },
+    }
+    const issues = checkDatasetDescription(jsonFileContents)
+    assert(issues[0].key === 'TOO_FEW_AUTHORS')
+  })
+  it('throws an error if the Authors field of the dataset description has a single field and multiple commas', () => {
     const jsonFileContents = {
       '/dataset_description.json': {
         Authors: [
@@ -61,7 +70,7 @@ describe('dataset_description.json', () => {
       },
     }
     const issues = checkDatasetDescription(jsonFileContents)
-    assert(issues[0].key === 'IMPROPERLY_FORMATTED_AUTHORS')
+    assert(issues[0].key === 'MULTIPLE_COMMAS_IN_AUTHOR_FIELD')
   })
 })
 

--- a/bids-validator/utils/issues/list.js
+++ b/bids-validator/utils/issues/list.js
@@ -566,4 +566,10 @@ module.exports = {
     reason:
       'The recommended file /README is missing. See Section 03 (Modality agnostic files) of the BIDS specification.',
   },
+  102: {
+    key: 'IMPROPERLY_FORMATTED_AUTHORS',
+    severity: 'warning',
+    reason:
+      'The Authors field of dataset_description.json should contain an array of fields - with one author per field. This was triggered based on the high number of commas in an authors field. Please ignore if your authors are already properly formatted.',
+  },
 }

--- a/bids-validator/utils/issues/list.js
+++ b/bids-validator/utils/issues/list.js
@@ -567,9 +567,15 @@ module.exports = {
       'The recommended file /README is missing. See Section 03 (Modality agnostic files) of the BIDS specification.',
   },
   102: {
-    key: 'IMPROPERLY_FORMATTED_AUTHORS',
+    key: 'TOO_FEW_AUTHORS',
     severity: 'warning',
     reason:
-      'The Authors field of dataset_description.json should contain an array of fields - with one author per field. This was triggered based on the high number of commas in an authors field. Please ignore if your authors are already properly formatted.',
+      'The Authors field of dataset_description.json should contain an array of fields - with one author per field. This was triggered based on the presence of only one author field. Please ignore if all contributors are already properly listed.',
+  },
+  103: {
+    key: 'MULTIPLE_COMMAS_IN_AUTHOR_FIELD',
+    severity: 'error',
+    reason:
+      'The Authors field of dataset_description.json should contain an array of fields - with one author per field. This was triggered based on the presence of multiple commas in a single author field. Please ensure your authors are properly formatted.',
   },
 }

--- a/bids-validator/validators/bids/checkDatasetDescription.js
+++ b/bids-validator/validators/bids/checkDatasetDescription.js
@@ -1,14 +1,34 @@
 const Issue = require('../../utils').issues.Issue
 
-const checkDatasetDescription = fileList => {
-  const issues = []
-  const fileKeys = Object.keys(fileList)
-  const hasDatasetDescription = fileKeys.some(key => {
-    const file = fileList[key]
-    return file.relativePath && file.relativePath == '/dataset_description.json'
+const checkDatasetDescription = jsonContentsDict => {
+  let issues = []
+  const jsonFilePaths = Object.keys(jsonContentsDict)
+  const hasDatasetDescription = jsonFilePaths.some(path => {
+    return path == '/dataset_description.json'
   })
   if (!hasDatasetDescription) {
     issues.push(new Issue({ code: 57 }))
+  } else {
+    const datasetDescription = jsonContentsDict['/dataset_description.json']
+
+    // check to ensure that the dataset description Authors are
+    // properly formatted
+    issues = issues.concat(checkAuthorField(datasetDescription.Authors))
+  }
+  return issues
+}
+
+const checkAuthorField = authors => {
+  const issues = []
+  // because this test happens before schema validation,
+  // we have to make sure that authors is an array with length > 0
+  if (authors && typeof authors == 'object' && authors.length) {
+    authors.forEach(author => {
+      // each author field should have no more than one comma
+      if (author.split(',').length >= 2) {
+        issues.push(new Issue({ code: 102 }))
+      }
+    })
   }
   return issues
 }

--- a/bids-validator/validators/bids/checkDatasetDescription.js
+++ b/bids-validator/validators/bids/checkDatasetDescription.js
@@ -21,14 +21,30 @@ const checkDatasetDescription = jsonContentsDict => {
 const checkAuthorField = authors => {
   const issues = []
   // because this test happens before schema validation,
-  // we have to make sure that authors is an array with length > 0
+  // we have to make sure that authors is an array
   if (authors && typeof authors == 'object' && authors.length) {
+    // if any author has more than one comma, throw an error
     authors.forEach(author => {
-      // each author field should have no more than one comma
-      if (author.split(',').length >= 2) {
-        issues.push(new Issue({ code: 102 }))
+      if (author.split(',').length > 2) {
+        issues.push(new Issue({ code: 103, evidence: author }))
       }
     })
+    // if authors is length 1, we want a warning for a single comma
+    // and an error for multiple commas
+    if (authors.length == 1) {
+      const author = authors[0]
+      // check the number of commas in the single author field
+      if (author.split(',').length <= 2) {
+        // if there is one or less comma in the author field,
+        // we suspect that the curator has not listed everyone involved
+        issues.push(new Issue({ code: 102, evidence: author }))
+      } else if (author.split(',').length > 2) {
+        // if there are too many commas in the author field,
+        // we suspect that the curator has listed all authors in a single
+        // entry in the authors array... which is against bids spec
+        issues.push(new Issue({ code: 103, evidence: author }))
+      }
+    }
   }
   return issues
 }

--- a/bids-validator/validators/bids/fullTest.js
+++ b/bids-validator/validators/bids/fullTest.js
@@ -119,7 +119,7 @@ const fullTest = (fileList, options, annexed, dir, callback) => {
       self.issues = self.issues.concat(noSubjectIssues)
 
       // Check for datasetDescription file in the proper place
-      const datasetDescriptionIssues = checkDatasetDescription(fileList)
+      const datasetDescriptionIssues = checkDatasetDescription(jsonContentsDict)
       self.issues = self.issues.concat(datasetDescriptionIssues)
 
       // Check for README file in the proper place


### PR DESCRIPTION
fixes #629.

* if any field of the Authors array in dataset_description.json contains more than one comma, throw a warning that gently suggests they make sure the field is properly formatted.