### PR TITLE
680 misleading potential locations for bold files

### DIFF
--- a/bids-validator/tests/potentialLocations.spec.js
+++ b/bids-validator/tests/potentialLocations.spec.js
@@ -2,10 +2,18 @@ const assert = require('assert')
 const potentialLocations = require('../utils/files/potentialLocations')
 const test_version = '1.1.1u1'
 
-describe('potentialLocations', function() {
-  it('should not return duplicate paths', function() {
+describe('potentialLocations', () => {
+  it('should not return duplicate paths', () => {
     const path = 'data/BIDS-examples-' + test_version + '/ds001'
     const pLs = potentialLocations(path)
     assert.deepEqual(pLs.length, new Set(pLs).size)
+  })
+  it('.bold files should only return potential locations that include tasknames', () => {
+    const path = 'dsTest/sub-01/func/sub-01_task-testing_run-01_bold.json'
+    const pLs = potentialLocations(path)
+    const anyNonTaskSpecific = pLs.some(
+      location => location.indexOf('task') < 0,
+    )
+    assert.equal(anyNonTaskSpecific, false)
   })
 })

--- a/bids-validator/utils/files/potentialLocations.js
+++ b/bids-validator/utils/files/potentialLocations.js
@@ -48,7 +48,6 @@ const potentialPaths = components => {
     )
 
     const prefix = prefixComponents.join('_')
-
     // loop through the non path-specific file components and generate the filename
     // based on directory + appropriate combinations of filename components
     for (let j = nonPathSpecificFileComponents.length; j > -1; j--) {
@@ -63,6 +62,13 @@ const potentialPaths = components => {
     }
   })
 
+  // There is an exception to the inheritance principle when it comes
+  // to bold data .json sidecars - the potential locations *must* include
+  // the task-<taskname> keyword.
+  if (filenameComponents.indexOf('bold.json') > -1) {
+    paths = removePathsWithoutTasknames(paths)
+  }
+
   return paths
 }
 
@@ -71,6 +77,12 @@ const constructFileName = (directoryString, filename, prefix) => {
   const filePathString = prefix ? [prefix, filename].join('_') : filename
   const newPath = directoryString + '/' + filePathString
   return newPath
+}
+
+const removePathsWithoutTasknames = paths => {
+  return paths.filter(path => {
+    return path.indexOf('task') > -1
+  })
 }
 
 module.exports = potentialLocations


### PR DESCRIPTION
fixes #680 

* suggested locations for bold files are special, in that they require a `task-<taskname>` keyword in the filename. this patch updates `utils/files/potentialLocations.js` to ensure that suggested sidecar locations for bold files include this keyword.