### PR TITLE
Include helpful neurostars search with each issue

### DIFF
--- a/bids-validator-web/components/Issues.jsx
+++ b/bids-validator-web/components/Issues.jsx
@@ -11,7 +11,6 @@ import Summary from '../components/Summary'
 class Issues extends React.Component {
   constructor(props) {
     super(props)
-    console.log('props:', props)
     this._reset = this.props.reset.bind(this)
   }
   // life cycle events --------------------------------------------------

--- a/bids-validator-web/components/results/Issues.jsx
+++ b/bids-validator-web/components/results/Issues.jsx
@@ -97,9 +97,18 @@ class Issues extends React.Component {
             {type} {index + 1}: [Code {issue.code}] {issue.key}
           </strong>
         </h4>
+        {this._issueLink(issue)}
         {issue.reason}
         {fileCount}
       </span>
+    )
+  }
+
+  _issueLink(issue) {
+    return (
+      <p>
+        <a target='_blank' href={issue.help}>Click here for more information about this issue</a>
+      </p>
     )
   }
 

--- a/bids-validator-web/components/results/Issues.jsx
+++ b/bids-validator-web/components/results/Issues.jsx
@@ -105,11 +105,15 @@ class Issues extends React.Component {
   }
 
   _issueLink(issue) {
-    return (
-      <p>
-        <a target='_blank' href={issue.helpUrl}>Click here for more information about this issue</a>
-      </p>
-    )
+    if (issue && issue.helpUrl) {
+      return (
+        <p>
+          <a target='_blank' href={issue.helpUrl}>Click here for more information about this issue</a>
+        </p>
+      )
+    } else {
+      return null
+    }
   }
 
   _viewMore(files, index) {

--- a/bids-validator-web/components/results/Issues.jsx
+++ b/bids-validator-web/components/results/Issues.jsx
@@ -107,7 +107,7 @@ class Issues extends React.Component {
   _issueLink(issue) {
     return (
       <p>
-        <a target='_blank' href={issue.help}>Click here for more information about this issue</a>
+        <a target='_blank' href={issue.helpUrl}>Click here for more information about this issue</a>
       </p>
     )
   }

--- a/bids-validator/utils/consoleFormat.js
+++ b/bids-validator/utils/consoleFormat.js
@@ -87,12 +87,12 @@ function logIssues(issues, color, options) {
       )
     }
     output.push('')
-    if (issue.help) {
+    if (issue.helpUrl) {
       output.push(
         colors.cyan(
           '\t' +
             'Please visit ' +
-            issue.help +
+            issue.helpUrl +
             ' for existing conversations about this issue.',
         ),
       )

--- a/bids-validator/utils/consoleFormat.js
+++ b/bids-validator/utils/consoleFormat.js
@@ -87,6 +87,17 @@ function logIssues(issues, color, options) {
       )
     }
     output.push('')
+    if (issue.help) {
+      output.push(
+        colors.cyan(
+          '\t' +
+            'Please visit ' +
+            issue.help +
+            ' for existing conversations about this issue.',
+        ),
+      )
+      output.push('')
+    }
   }
   return output
 }
@@ -148,8 +159,8 @@ function formatSummary(summary) {
 
     //Neurostars message
     output.push(
-      colors.white(
-        'If you have any questions please post on https://neurostars.org/tags/bids',
+      colors.cyan(
+        '\tIf you have any questions, please post on https://neurostars.org/tags/bids.',
       ),
     )
 

--- a/bids-validator/utils/issues/index.js
+++ b/bids-validator/utils/issues/index.js
@@ -73,7 +73,7 @@ var issues = {
         categorized[issue.code] = list[issue.code]
         categorized[issue.code].files = []
         categorized[issue.code].additionalFileCount = 0
-        categorized[issue.code].help = issue.help
+        categorized[issue.code].helpUrl = issue.helpUrl
       }
       if (options.verbose || categorized[issue.code].files.length < 10) {
         categorized[issue.code].files.push(issue)

--- a/bids-validator/utils/issues/index.js
+++ b/bids-validator/utils/issues/index.js
@@ -73,6 +73,7 @@ var issues = {
         categorized[issue.code] = list[issue.code]
         categorized[issue.code].files = []
         categorized[issue.code].additionalFileCount = 0
+        categorized[issue.code].help = issue.help
       }
       if (options.verbose || categorized[issue.code].files.length < 10) {
         categorized[issue.code].files.push(issue)
@@ -98,7 +99,6 @@ var issues = {
         if (severityMap.hasOwnProperty(issue.key)) {
           issue.severity = severityMap[issue.key]
         }
-
         if (issue.severity === 'error') {
           // Schema validation issues will yield the JSON file invalid, we should display them first to attract
           // user attention.

--- a/bids-validator/utils/issues/issue.js
+++ b/bids-validator/utils/issues/issue.js
@@ -1,4 +1,17 @@
-var issues = require('./list')
+const issues = require('./list')
+
+/**
+ * Help Url
+ *
+ * Construct a link to a helpful neurostars query, based on the
+ * issue key
+ */
+const constructHelpUrl = issue => {
+  const neurostarsPrefix = 'https://neurostars.org/'
+  const searchQuery = issue && issue.key ? 'search?q=' + issue.key : ''
+  const helpUrl = neurostarsPrefix + searchQuery
+  return helpUrl
+}
 
 /**
  * Issue
@@ -6,8 +19,8 @@ var issues = require('./list')
  * A constructor for BIDS issues.
  */
 module.exports = function(options) {
-  var code = options.hasOwnProperty('code') ? options.code : null
-  var issue = issues[code]
+  const code = options.hasOwnProperty('code') ? options.code : null
+  const issue = issues[code]
 
   this.key = issue.key
   this.code = code
@@ -21,4 +34,5 @@ module.exports = function(options) {
     ? options.severity
     : issue.severity
   this.reason = options.hasOwnProperty('reason') ? options.reason : issue.reason
+  this.help = constructHelpUrl(issue)
 }

--- a/bids-validator/utils/issues/issue.js
+++ b/bids-validator/utils/issues/issue.js
@@ -34,5 +34,5 @@ module.exports = function(options) {
     ? options.severity
     : issue.severity
   this.reason = options.hasOwnProperty('reason') ? options.reason : issue.reason
-  this.help = constructHelpUrl(issue)
+  this.helpUrl = constructHelpUrl(issue)
 }


### PR DESCRIPTION
fixes #628. Makes it easier to find conversations about specific issues on neurostars.

* Each issue has an additional property, `.helpUrl`, which is `https://neurostars.org/search?q=%ISSUE_KEY%`
* Console output now shows the help links associated with each issue in cyan - pretty!
* Web validator shows the help link in the header of each categorized issue - helpful!