### PR TITLE
Fix build environment locking conflict

### DIFF
--- a/bids-validator/package.json
+++ b/bids-validator/package.json
@@ -48,6 +48,7 @@
     "jest": "^23.6.0",
     "jest-environment-jsdom-global": "^1.2.0",
     "jest-environment-node": "^23.4.0",
+    "lockfile": "^1.0.4",
     "npm-cli-login": "^0.0.10",
     "nyc": "^13.0.1",
     "prettier": "^1.14.2",

--- a/bids-validator/tests/env/ExamplesEnvironment.js
+++ b/bids-validator/tests/env/ExamplesEnvironment.js
@@ -6,7 +6,7 @@ const loadExamples = require('./load-examples.js')
 class ExamplesEnvironment extends NodeEnvironment {
   async setup() {
     await super.setup()
-    this.global.test_version = loadExamples()
+    this.global.test_version = await loadExamples()
   }
 
   async teardown() {

--- a/bids-validator/tests/env/ExamplesEnvironmentWeb.js
+++ b/bids-validator/tests/env/ExamplesEnvironmentWeb.js
@@ -6,7 +6,7 @@ const loadExamples = require('./load-examples.js')
 class ExamplesEnvironmentWeb extends JsdomEnvironment {
   async setup() {
     await super.setup()
-    this.global.test_version = loadExamples()
+    this.global.test_version = await loadExamples()
   }
 
   async teardown() {

--- a/bids-validator/tests/env/load-examples.js
+++ b/bids-validator/tests/env/load-examples.js
@@ -1,10 +1,19 @@
 const fs = require('fs')
+const { promisify } = require('util')
 const request = require('sync-request')
 const AdmZip = require('adm-zip')
+const lockfile = require('lockfile')
+
+const lockPromise = promisify(lockfile.lock)
 
 const test_version = '1.1.1u1'
+const examples_lock = 'bids-validator/tests/data/examples.lockfile'
+// Wait for up to five minutes for examples to finish
+// downloading in another test worker
+const examples_lock_opts = { wait: 300000 }
 
-const loadExamples = () => {
+const loadExamples = async () => {
+  await lockPromise(examples_lock, examples_lock_opts)
   if (!fs.existsSync('tests/data/bids-examples-' + test_version + '/')) {
     console.log('downloading test data')
     const response = request(
@@ -21,6 +30,7 @@ const loadExamples = () => {
     console.log('unzipping test data')
     zip.extractAllTo('bids-validator/tests/data/', true)
   }
+  lockfile.unlockSync(examples_lock)
   return test_version
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5067,6 +5067,13 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
+lockfile@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/lockfile/-/lockfile-1.0.4.tgz#07f819d25ae48f87e538e6578b6964a4981a5609"
+  integrity sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==
+  dependencies:
+    signal-exit "^3.0.2"
+
 lodash.assign@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"


### PR DESCRIPTION
This fixes the CI build issue introduced in #753 - we now wait up to 5 minutes for examples to finish downloading in another thread to prevent extra downloads conflicting with each other in multiple test suites.