### PR TITLE
FIX - replaced old repository name (INCF) with new one

### DIFF
--- a/bids-validator-web/components/Issues.jsx
+++ b/bids-validator-web/components/Issues.jsx
@@ -1,91 +1,92 @@
 // dependencies -------------------------------------------------------
 
-import React from 'react'
-import PropTypes from 'prop-types'
-import pluralize from 'pluralize'
-import Results from './results/Results'
-import Spinner from './Spinner.jsx'
-import ErrorLink from './ErrorLink.jsx'
-import Summary from '../components/Summary'
+import React from "react";
+import PropTypes from "prop-types";
+import pluralize from "pluralize";
+import Results from "./results/Results";
+import Spinner from "./Spinner.jsx";
+import ErrorLink from "./ErrorLink.jsx";
+import Summary from "../components/Summary";
 
 class Issues extends React.Component {
   constructor(props) {
-    super(props)
-    this._reset = this.props.reset.bind(this)
+    super(props);
+    this._reset = this.props.reset.bind(this);
   }
   // life cycle events --------------------------------------------------
 
   render() {
     // short references
-    let errors = this.props.errors
-    let warnings = this.props.warnings
-    let dirName = this.props.dirName
+    let errors = this.props.errors;
+    let warnings = this.props.warnings;
+    let dirName = this.props.dirName;
 
     // counts
-    let totalErrors = 0
-    let totalWarnings = 0
-    let warningCount, errorCount
-    if (errors !== 'Invalid') {
-      totalErrors = errors.length
-      totalWarnings = warnings.length
-      warningCount = totalWarnings + ' ' + pluralize('Warning', totalWarnings)
-      errorCount = totalErrors + ' ' + pluralize('Error', totalErrors)
+    let totalErrors = 0;
+    let totalWarnings = 0;
+    let warningCount, errorCount;
+    if (errors !== "Invalid") {
+      totalErrors = errors.length;
+      totalWarnings = warnings.length;
+      warningCount = totalWarnings + " " + pluralize("Warning", totalWarnings);
+      errorCount = totalErrors + " " + pluralize("Error", totalErrors);
     }
     // messages
     let specLink = (
       <h5>
-        Click to view details on{' '}
+        Click to view details on{" "}
         <a href="http://bids.neuroimaging.io" target="_blank">
           BIDS specification
         </a>
       </h5>
-    )
+    );
     let notBIDSMessage = (
       <h4>
         This directory failed an initial Quick Test. This means the basic names
         and structure of the files and directories do not comply with BIDS
-        specification. <span onClick={this._reset}>Select a new folder</span>{' '}
+        specification. <span onClick={this._reset}>Select a new folder</span>{" "}
         and try again.
       </h4>
-    )
-    let warningsMessage = <h4>We found {warningCount} in your dataset.</h4>
-    let errorMessage = <h4>Your dataset is not a valid BIDS dataset.</h4>
-    let noErrorMessage = <h4>This is a valid BIDS dataset!</h4>
+    );
+    let warningsMessage = <h4>We found {warningCount} in your dataset.</h4>;
+    let errorMessage = <h4>Your dataset is not a valid BIDS dataset.</h4>;
+    let noErrorMessage = <h4>This is a valid BIDS dataset!</h4>;
     let neurostarsLink = (
       <h5>
-        If you have any questions please post on{' '}
+        If you have any questions please post on{" "}
         <a href="https://neurostars.org/tags/bids" target="_blank">
           Neurostars
         </a>
       </h5>
-    )
+    );
     let sourcecode = (
       <h5>
-        The source code for the validator can be found{' '}
+        The source code for the validator can be found{" "}
         <a
-          href="https://github.com/INCF/bids-validator/tree/gh-pages"
-          target="_blank">
+          href="https://github.com/bids-standard/bids-validator/tree/gh-pages"
+          target="_blank"
+        >
           here
         </a>
       </h5>
-    )
+    );
 
     // determine message
-    let message
-    if (errors === 'Invalid') {
-      message = notBIDSMessage
+    let message;
+    if (errors === "Invalid") {
+      message = notBIDSMessage;
     } else if (errors.length > 0) {
-      message = errorMessage
+      message = errorMessage;
     } else if (warnings.length > 0) {
-      message = warningsMessage
+      message = warningsMessage;
     } else {
-      message = noErrorMessage
+      message = noErrorMessage;
     }
 
     // loading animation
     let loading = (
-      <Spinner text="validating" active={this.props.status === 'validating'} />
-    )
+      <Spinner text="validating" active={this.props.status === "validating"} />
+    );
 
     // results
     let results = (
@@ -94,24 +95,25 @@ class Issues extends React.Component {
           type="button"
           className="close"
           aria-label="Close"
-          onClick={this._reset}>
+          onClick={this._reset}
+        >
           <span aria-hidden="true">&times;</span>
         </button>
         <Summary summary={this.props.summary} dirName={this.props.dirName} />
         {message}
-        {errors !== 'Invalid' ? (
+        {errors !== "Invalid" ? (
           <Results errors={errors} warnings={warnings} />
         ) : null}
-        {(errors.length > 0 && errors !== 'Invalid') || warnings.length > 0 ? (
+        {(errors.length > 0 && errors !== "Invalid") || warnings.length > 0 ? (
           <ErrorLink dirName={dirName} errors={errors} warnings={warnings} />
         ) : null}
         {specLink}
         {neurostarsLink}
         {sourcecode}
       </div>
-    )
+    );
 
-    return <div>{this.props.status === 'validating' ? loading : results}</div>
+    return <div>{this.props.status === "validating" ? loading : results}</div>;
   }
 }
 
@@ -120,15 +122,15 @@ Issues.propTypes = {
   errors: PropTypes.array,
   warnings: PropTypes.array,
   dirName: PropTypes.string,
-  status: PropTypes.string,
-}
+  status: PropTypes.string
+};
 
 Issues.defaultProps = {
   reset: () => {},
   errors: [],
   warnings: [],
-  dirName: '',
-  status: '',
-}
+  dirName: "",
+  status: ""
+};
 
-export default Issues
+export default Issues;

--- a/bids-validator-web/components/Issues.jsx
+++ b/bids-validator-web/components/Issues.jsx
@@ -35,7 +35,7 @@ class Issues extends React.Component {
     let specLink = (
       <h5>
         Click to view details on{" "}
-        <a href="http://bids.neuroimaging.io" target="_blank">
+        <a href="https://bids-specification.readthedocs.io/en/stable/" target="_blank">
           BIDS specification
         </a>
       </h5>
@@ -63,7 +63,7 @@ class Issues extends React.Component {
       <h5>
         The source code for the validator can be found{" "}
         <a
-          href="https://github.com/bids-standard/bids-validator/tree/gh-pages"
+          href="https://github.com/bids-standard/bids-validator"
           target="_blank"
         >
           here


### PR DESCRIPTION
The relevant change is on line 66, where the URL now points to https://github.com/bids-standard/bids-validator/tree/gh-pages instead of the old INCF location.

I did *not* change the quotation marks from ' into " on purpose (idem for the ; at the end of the line). My edit was in `vi`, so my only  guess is that the additional update of the quotation marks was done by one of the git hooks. That is something I cannot prevent. 