### PR TITLE
Update MEG regexps and testsuite to comply with father level specification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+yarn-error.log
 node_modules/
 .DS_Store
 bids-validator/tests/data/bids-examples-*

--- a/bids-validator/bids_validator/rules/file_level_rules.json
+++ b/bids-validator/bids_validator/rules/file_level_rules.json
@@ -200,7 +200,7 @@
   "meg": {
     "regexp": "^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)\\/)?meg\\/\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_proc-[a-zA-Z0-9]+)?(?:_part-[0-9]+)?(_meg(@@@_meg_type_@@@\\/.*|\\/.*)|(@@@_meg_ext_@@@))$",
     "tokens": {
-      "@@@_meg_type_@@@": ["\\.fif", "\\.(?:sqd|con)", "\\.ds"],
+      "@@@_meg_type_@@@": ["\\.fif", "\\.(?:con|sqd)", "\\.ds"],
       "@@@_meg_ext_@@@": [
         "_events\\.json",
         "_events\\.tsv",
@@ -210,7 +210,7 @@
         "_coordsystem\\.json",
         "_photo\\.jpg",
         "_headshape\\.pos",
-        "_markers\\.(?:con|sqd)"
+        "_markers\\.(?:mrk|sqd)"
       ]
     }
   },

--- a/bids-validator/bids_validator/rules/file_level_rules.json
+++ b/bids-validator/bids_validator/rules/file_level_rules.json
@@ -198,9 +198,9 @@
   },
 
   "meg": {
-    "regexp": "^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)\\/)?meg\\/\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_proc-[a-zA-Z0-9]+)?(?:_part-[0-9]+)?(_meg(@@@_meg_type_@@@\\/.*|\\/.*)|(@@@_meg_ext_@@@))$",
+    "regexp": "^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)\\/)?meg\\/\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_proc-[a-zA-Z0-9]+)?(?:_part-[0-9]+)?(_meg(@@@_meg_type_@@@\\/(.(?!\\.(sqd|con|fif|raw|raw\\.mhd|trg|kdf|chn)$))*|\\/(.(?!\\.(sqd|con|fif|raw|raw\\.mhd|trg|kdf|chn)$))*)|(@@@_meg_ext_@@@))$",
     "tokens": {
-      "@@@_meg_type_@@@": ["\\.fif", "\\.(?:con|sqd)", "\\.ds"],
+      "@@@_meg_type_@@@": ["\\.ds", "\\.(?:chn|kdf|trg)", "\\.(?:raw|raw\\.mhd)", "\\.fif", "\\.(?:con|sqd)", "\\.(?:kdf|chn|trg)"],
       "@@@_meg_ext_@@@": [
         "_events\\.json",
         "_events\\.tsv",

--- a/bids-validator/bids_validator/rules/file_level_rules.json
+++ b/bids-validator/bids_validator/rules/file_level_rules.json
@@ -198,7 +198,7 @@
   },
 
   "meg": {
-    "regexp": "^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)\\/)?meg\\/\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_proc-[a-zA-Z0-9]+)?(?:_part-[0-9]+)?(_meg(@@@_meg_type_@@@\\/(.(?!\\.(sqd|con|fif|raw|raw\\.mhd|trg|kdf|chn)$))*|\\/(.(?!\\.(sqd|con|fif|raw|raw\\.mhd|trg|kdf|chn)$))*)|(@@@_meg_ext_@@@))$",
+    "regexp": "^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)\\/)?meg\\/\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_proc-[a-zA-Z0-9]+)?(?:_part-[0-9]+)?(_digitizer.txt|_meg(@@@_meg_type_@@@\\/(.(?!\\.(sqd|con|fif|raw|raw\\.mhd|trg|kdf|chn)$))*|\\/(.(?!\\.(sqd|con|fif|raw|raw\\.mhd|trg|kdf|chn)$))*)|(@@@_meg_ext_@@@))$",
     "tokens": {
       "@@@_meg_type_@@@": ["\\.ds/.*", "\\.(?:chn|kdf|trg)", "\\.(?:raw|raw\\.mhd)", "\\.fif", "\\.(?:con|sqd)", "\\.(?:kdf|chn|trg)"],
       "@@@_meg_ext_@@@": [

--- a/bids-validator/bids_validator/rules/file_level_rules.json
+++ b/bids-validator/bids_validator/rules/file_level_rules.json
@@ -85,24 +85,6 @@
     }
   },
 
-  "eeg": {
-    "regexp": "^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)\\/)?eeg\\/\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_proc-[a-zA-Z0-9]+)?(?:_part-[0-9]+)?(_eeg\\.(@@@_eeg_type_@@@)|(@@@_eeg_ext_@@@))$",
-    "tokens": {
-      "@@@_eeg_type_@@@": ["vhdr", "vmrk", "eeg", "edf", "bdf", "set", "fdt"],
-      "@@@_eeg_ext_@@@": [
-        "_events\\.json",
-        "_events\\.tsv",
-        "_electrodes\\.json",
-        "_electrodes\\.tsv",
-        "_channels\\.json",
-        "_channels\\.tsv",
-        "_eeg\\.json",
-        "_coordsystem\\.json",
-        "_photo\\.jpg"
-      ]
-    }
-  },
-
   "field_map": {
     "regexp": "^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)\\/)?fmap\\/\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_dir-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?_(?:@@@_field_map_type_@@@)\\.(@@@_field_map_ext_@@@)$",
     "tokens": {
@@ -170,6 +152,24 @@
     }
   },
 
+  "eeg": {
+    "regexp": "^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)\\/)?eeg\\/\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_proc-[a-zA-Z0-9]+)?(?:_part-[0-9]+)?(_eeg\\.(@@@_eeg_type_@@@)|(@@@_eeg_ext_@@@))$",
+    "tokens": {
+      "@@@_eeg_type_@@@": ["vhdr", "vmrk", "eeg", "edf", "bdf", "set", "fdt"],
+      "@@@_eeg_ext_@@@": [
+        "_events\\.json",
+        "_events\\.tsv",
+        "_electrodes\\.json",
+        "_electrodes\\.tsv",
+        "_channels\\.json",
+        "_channels\\.tsv",
+        "_eeg\\.json",
+        "_coordsystem\\.json",
+        "_photo\\.jpg"
+      ]
+    }
+  },
+
   "ieeg": {
     "regexp": "^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)\\/)?ieeg\\/\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_proc-[a-zA-Z0-9]+)?(?:_part-[0-9]+)?(?:_space-[a-zA-Z0-9]+)?(_ieeg\\.(@@@_ieeg_type_@@@)|(@@@_ieeg_ext_@@@))$",
     "tokens": {
@@ -200,7 +200,7 @@
   "meg": {
     "regexp": "^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)\\/)?meg\\/\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_proc-[a-zA-Z0-9]+)?(?:_part-[0-9]+)?(_meg(@@@_meg_type_@@@\\/.*|\\/.*)|(@@@_meg_ext_@@@))$",
     "tokens": {
-      "@@@_meg_type_@@@": ["\\.fif", "\\.ds"],
+      "@@@_meg_type_@@@": ["\\.fif", "\\.(?:sqd|con)", "\\.ds"],
       "@@@_meg_ext_@@@": [
         "_events\\.json",
         "_events\\.tsv",
@@ -209,7 +209,8 @@
         "_meg\\.json",
         "_coordsystem\\.json",
         "_photo\\.jpg",
-        "_headshape\\.pos"
+        "_headshape\\.pos",
+        "_markers\\.(?:con|sqd)"
       ]
     }
   },

--- a/bids-validator/bids_validator/rules/file_level_rules.json
+++ b/bids-validator/bids_validator/rules/file_level_rules.json
@@ -200,7 +200,7 @@
   "meg": {
     "regexp": "^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)\\/)?meg\\/\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_proc-[a-zA-Z0-9]+)?(?:_part-[0-9]+)?(_meg(@@@_meg_type_@@@\\/(.(?!\\.(sqd|con|fif|raw|raw\\.mhd|trg|kdf|chn)$))*|\\/(.(?!\\.(sqd|con|fif|raw|raw\\.mhd|trg|kdf|chn)$))*)|(@@@_meg_ext_@@@))$",
     "tokens": {
-      "@@@_meg_type_@@@": ["\\.ds", "\\.(?:chn|kdf|trg)", "\\.(?:raw|raw\\.mhd)", "\\.fif", "\\.(?:con|sqd)", "\\.(?:kdf|chn|trg)"],
+      "@@@_meg_type_@@@": ["\\.ds/.*", "\\.(?:chn|kdf|trg)", "\\.(?:raw|raw\\.mhd)", "\\.fif", "\\.(?:con|sqd)", "\\.(?:kdf|chn|trg)"],
       "@@@_meg_ext_@@@": [
         "_events\\.json",
         "_events\\.tsv",

--- a/bids-validator/tests/type.spec.js
+++ b/bids-validator/tests/type.spec.js
@@ -188,6 +188,7 @@ describe('utils.type.file.isMEG', function() {
     '/sub-control01/ses-001/meg/sub-control01_ses-001_task-rest_run-01_meg.chn',
     '/sub-control01/ses-001/meg/sub-control01_ses-001_task-rest_run-01_meg.kdf',
     '/sub-control01/ses-001/meg/sub-control01_ses-001_task-rest_run-01_meg.trg',
+    '/sub-control01/ses-001/meg/sub-control01_ses-001_task-rest_digitizer.txt',
     // NO father dir: KIT data
     '/sub-01/ses-001/meg/sub-01_ses-001_markers.sqd',
     '/sub-01/ses-001/meg/sub-01_ses-001_markers.mrk',

--- a/bids-validator/tests/type.spec.js
+++ b/bids-validator/tests/type.spec.js
@@ -222,7 +222,7 @@ describe('utils.type.file.isMEG', function() {
     '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg/sub-01_ses-001_markers.sqd',
     '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg/sub-01_ses-001_markers.con',
     '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg/sub-01_ses-001_task-rest_run-01_meg.sqd',
-    // fif with a father dir ... should not have a father dir
+    // FIF with a father dir ... should not have a father dir
     '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg/sub-01_ses-001_task-rest_meg.fif',
     // ITAB with a father dir ... should not have a father dir
     '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg/sub-01_ses-001_task-rest_run-01_meg.raw',

--- a/bids-validator/tests/type.spec.js
+++ b/bids-validator/tests/type.spec.js
@@ -176,6 +176,10 @@ describe('utils.type.file.isMEG', function() {
     '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg/sub-01_ses-001_task-rest_run-01_meg.raw.mhd',
     '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg/xyz', // for e.g., BTi files
     '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg/sub-01_ses-001_markers.sqd',
+    '/sub-01/ses-001/meg/sub-01_ses-001_markers.sqd', // KIT with removed father level directory
+    '/sub-01/ses-001/meg/sub-01_ses-001_markers.mrk', // KIT with removed father level directory
+    '/sub-01/ses-001/meg/sub-01_ses-001_meg.sqd', // KIT with removed father level directory
+    '/sub-01/ses-001/meg/sub-01_ses-001_meg.con', // KIT with removed father level directory
     '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg.json',
     '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_part-01_meg.fif',
     '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_channels.tsv',

--- a/bids-validator/tests/type.spec.js
+++ b/bids-validator/tests/type.spec.js
@@ -172,17 +172,32 @@ describe('utils.type.file.isDWI', function() {
 
 describe('utils.type.file.isMEG', function() {
   const goodFilenames = [
-    '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg/sub-01_ses-001_task-rest_run-01_meg.sqd',
-    '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg/sub-01_ses-001_task-rest_run-01_meg.raw.mhd',
-    '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg/xyz', // for e.g., BTi files
-    '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg/sub-01_ses-001_markers.sqd',
-    '/sub-01/ses-001/meg/sub-01_ses-001_markers.sqd', // KIT with removed father level directory
-    '/sub-01/ses-001/meg/sub-01_ses-001_markers.mrk', // KIT with removed father level directory
-    '/sub-01/ses-001/meg/sub-01_ses-001_meg.sqd', // KIT with removed father level directory
-    '/sub-01/ses-001/meg/sub-01_ses-001_meg.con', // KIT with removed father level directory
+    // Metadata MEG files
     '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg.json',
-    '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_part-01_meg.fif',
     '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_channels.tsv',
+    // Father directory files are fine for some file formats:
+    // Father dir: CTF data with a .ds ... the contents within .ds are not checked
+    '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg.ds/catch-alp-good-f.meg4',
+    '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg.ds/xyz',
+    // Father dir: BTi/4D ... again: within contents not checked
+    '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg/config',
+    '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg/hs_file',
+    '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg/e,rfhp1.0Hz.COH',
+    '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg/c,rfDC',
+    // NO father dir: KRISS data
+    '/sub-control01/ses-001/meg/sub-control01_ses-001_task-rest_run-01_meg.chn',
+    '/sub-control01/ses-001/meg/sub-control01_ses-001_task-rest_run-01_meg.kdf',
+    '/sub-control01/ses-001/meg/sub-control01_ses-001_task-rest_run-01_meg.trg',
+    // NO father dir: KIT data
+    '/sub-01/ses-001/meg/sub-01_ses-001_markers.sqd',
+    '/sub-01/ses-001/meg/sub-01_ses-001_markers.mrk',
+    '/sub-01/ses-001/meg/sub-01_ses-001_meg.sqd',
+    '/sub-01/ses-001/meg/sub-01_ses-001_meg.con',
+    // NO father dir: ITAB data
+    '/sub-control01/ses-001/meg/sub-control01_ses-001_task-rest_run-01_meg.raw',
+    '/sub-control01/ses-001/meg/sub-control01_ses-001_task-rest_run-01_meg.raw.mhd',
+    // NO father dir: fif data
+    '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_part-01_meg.fif',
   ]
 
   goodFilenames.forEach(function(path) {
@@ -193,11 +208,29 @@ describe('utils.type.file.isMEG', function() {
   })
 
   const badFilenames = [
-    // only parent directory name matters for KIT/BTi systems
-    '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_megggg/sub-01_ses-001_task-rest_run-01_meg.sqd',
+    // missing session directory
     '/sub-01/meg/sub-01_ses-001_task-rest_run-01_meg.json',
+    // subject not matching
     '/sub-01/ses-001/meg/sub-12_ses-001_task-rest_run-01_part-01_meg.fif',
+    // invalid file endings
     '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg.tsv',
+    '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg.bogus',
+    // only parent directory name matters for BTi and CTF systems
+    '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meggg/config',
+    '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg.dd/xyz',
+    // KIT with a father dir ... should not have a father dir
+    '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg/sub-01_ses-001_markers.sqd',
+    '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg/sub-01_ses-001_markers.con',
+    '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg/sub-01_ses-001_task-rest_run-01_meg.sqd',
+    // fif with a father dir ... should not have a father dir
+    '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg/sub-01_ses-001_task-rest_meg.fif',
+    // ITAB with a father dir ... should not have a father dir
+    '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg/sub-01_ses-001_task-rest_run-01_meg.raw',
+    '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg/sub-01_ses-001_task-rest_run-01_meg.raw.mhd',
+    // KRISS with a father dir ... should not have a father dir
+    '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg/sub-01_ses-001_task-rest_run-01_meg.kdf',
+    '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg/sub-01_ses-001_task-rest_run-01_meg.trg',
+    '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg/sub-01_ses-001_task-rest_run-01_meg.chn',
   ]
 
   badFilenames.forEach(function(path) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3697,6 +3697,11 @@ hasha@^3.0.0:
   dependencies:
     is-stream "^1.0.1"
 
+hed-validator@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/hed-validator/-/hed-validator-0.3.0.tgz#53e80420c3e24209e5fbcd45156b29be429b6a99"
+  integrity sha512-yQLR+S2HPtb9dMQQISBamdcYa+0ShJl2vf/0D5xDqjFM6QrAmtXZYBsBwnPRy1HR0RCiBubRoBUG92veqRl54w==
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"


### PR DESCRIPTION
**EDIT** --> I now take over all MEG data formats, not just KIT

---

In this PR I add to the MEG regexp so that `_markers.<sqd, mrk>)` can be accepted, as well as general MEG data files in the KIT format ending either with `.sqd` or `.con`. see the [specification](https://bids-specification.readthedocs.io/en/latest/99-appendices/06-meg-file-formats.html#kityokogawaricoh)

This is BIDS since these PRs:
- https://github.com/bids-standard/bids-specification/pull/19
- https://github.com/bids-standard/bids-specification/pull/62

cc @monkeyman192

I furthermore update the `yarn.lock` file to include the hed validator, which has recently been added (but no to the lock file yet)

This is based on a use case, where the validator throws an error for a correct KIT BIDS dataset, see: https://github.com/mne-tools/mne-bids/pull/209#issuecomment-504356977

# Interesting observations (i.e., I don't know what's happening and why)

- the error based on the use case did only show up for the recent validator version `1.2.4` ... but not for previous versions. Yet, I cannot find any commit leading up to `1.2.4` that should have changed the way the validator looks at MEG files ...
- for the MEG regexp, looking at this line: https://github.com/bids-standard/bids-validator/blob/e3c6e4635f077d4b01e7c13baee4a0cf44199c69/bids-validator/bids_validator/rules/file_level_rules.json#L203

--> when I added my addition: `"\\.(?:sqd|con)"` to the END of the line ... it did not work (i.e., did not resolve the use case error) ... however, adding it to the MIDDLE, or the START of the line did work - without breaking any tests.

- works: `["\\.(?:sqd|con)", "\\.fif", "\\.ds"]`
- works: `["\\.fif", "\\.(?:sqd|con)", "\\.ds"]`
- does NOT work: `["\\.fif", "\\.ds", "\\.(?:sqd|con)"]`

Can somebody shed some light on this?

