### PR TITLE
no authors warning

### DIFF
--- a/bids-validator/tests/bids.spec.js
+++ b/bids-validator/tests/bids.spec.js
@@ -94,8 +94,12 @@ describe('BIDS example datasets ', function() {
       assert(summary.modalities.includes('inplaneT2'))
       assert(summary.modalities.includes('bold'))
       assert(summary.totalFiles === 133)
-      assert.deepEqual(errors, [])
-      assert(warnings.length === 2 && warnings[0].code === 13)
+      assert.deepEqual(errors.length, 1)
+      assert(warnings.length === 3)
+      assert(
+        warnings.findIndex(warning => warning.code === 13) > -1,
+        'warnings do not contain a code 13',
+      )
       isdone()
     })
   })
@@ -115,8 +119,15 @@ describe('BIDS example datasets ', function() {
       assert(summary.modalities.includes('T1w'))
       assert(summary.modalities.includes('bold'))
       assert(summary.totalFiles === 8)
-      assert(errors[0].code === 60)
-      assert(warnings.length === 3 && warnings[0].code === 13)
+      assert(
+        errors.findIndex(error => error.code === 60) > -1,
+        'errors do not contain a code 60',
+      )
+      assert.deepEqual(warnings.length, 4)
+      assert(
+        warnings.findIndex(warning => warning.code === 13) > -1,
+        'warnings do not contain a code 13',
+      )
       isdone()
     })
   })
@@ -179,8 +190,12 @@ describe('BIDS example datasets ', function() {
       assert(summary.modalities.includes('inplaneT2'))
       assert(summary.modalities.includes('bold'))
       assert(summary.totalFiles === 133)
-      assert.deepEqual(errors, [])
-      assert(warnings.length === 2 && warnings[0].code === 13)
+      assert.deepEqual(errors.length, 1)
+      assert(warnings.length === 3)
+      assert(
+        warnings.findIndex(warning => warning.code === 13) > -1,
+        'warnings do not contain a code 13',
+      )
       isdone()
     })
   })

--- a/bids-validator/utils/issues/list.js
+++ b/bids-validator/utils/issues/list.js
@@ -630,6 +630,6 @@ module.exports = {
     key: 'NO_AUTHORS',
     severity: 'warning',
     reason:
-      'The Authors field of dataset_description.json should contain an array of fields - with one author per field. This was triggered because there are no authors, which could lead to DOI minting failures and will prevent snapshot creation on OpenNeuro.',
+      'The Authors field of dataset_description.json should contain an array of fields - with one author per field. This was triggered because there are no authors, which will make DOI registration from dataset metadata impossible.',
   },
 }

--- a/bids-validator/utils/issues/list.js
+++ b/bids-validator/utils/issues/list.js
@@ -626,4 +626,10 @@ module.exports = {
     reason:
       'The json sidecar does not contain this column value as a possible key to a HED string.',
   },
+  113: {
+    key: 'NO_AUTHORS',
+    severity: 'warning',
+    reason:
+      'The Authors field of dataset_description.json should contain an array of fields - with one author per field. This was triggered because there are no authors, which could lead to DOI minting failures and will prevent snapshot creation on OpenNeuro.',
+  },
 }

--- a/bids-validator/validators/bids/__tests__/checkDatasetDescription.spec.js
+++ b/bids-validator/validators/bids/__tests__/checkDatasetDescription.spec.js
@@ -1,0 +1,61 @@
+const assert = require('chai').assert
+const checkDatasetDescription = require('../checkDatasetDescription')
+
+describe('checkDatasetDescription', () => {
+  describe('checkAuthorField', () => {
+    it('returns no issues with valid Authors field', () => {
+      const validJsonContentsDict = {
+        '/dataset_description.json': {
+          Authors: ['Benny', 'the Jets'],
+        },
+      }
+      const issues = checkDatasetDescription(validJsonContentsDict)
+      assert.lengthOf(issues, 0)
+    })
+    it('returns code 102 when there is only one author present', () => {
+      const invalidJsonContentsDict = {
+        '/dataset_description.json': {
+          Authors: ['Benny'],
+        },
+      }
+      const issues = checkDatasetDescription(invalidJsonContentsDict)
+      assert(
+        issues.findIndex(issue => issue.code === 102) > -1,
+        'issues include a code 102',
+      )
+    })
+    it('returns code 103 when there an author has more than one comma', () => {
+      const invalidJsonContentsDict = {
+        '/dataset_description.json': {
+          Authors: ['Benny, and the, Jets'],
+        },
+      }
+      const issues = checkDatasetDescription(invalidJsonContentsDict)
+      assert(
+        issues.findIndex(issue => issue.code === 103) > -1,
+        'issues include a code 103',
+      )
+    })
+    it('returns code 113 when there are no Authors', () => {
+      const invalidJsonContentsDict = {
+        '/dataset_description.json': {
+          Authors: [],
+        },
+      }
+      let issues = checkDatasetDescription(invalidJsonContentsDict)
+      assert(
+        issues.findIndex(issue => issue.code === 113) > -1,
+        'issues include a code 113',
+      )
+
+      const invalidJsonContentsDict2 = {
+        '/dataset_description.json': {},
+      }
+      issues = checkDatasetDescription(invalidJsonContentsDict2)
+      assert(
+        issues.findIndex(issue => issue.code === 113) > -1,
+        'issues include a code 113',
+      )
+    })
+  })
+})

--- a/bids-validator/validators/bids/checkDatasetDescription.js
+++ b/bids-validator/validators/bids/checkDatasetDescription.js
@@ -38,11 +38,6 @@ const checkAuthorField = authors => {
         // if there is one or less comma in the author field,
         // we suspect that the curator has not listed everyone involved
         issues.push(new Issue({ code: 102, evidence: author }))
-      } else if (author.split(',').length > 2) {
-        // if there are too many commas in the author field,
-        // we suspect that the curator has listed all authors in a single
-        // entry in the authors array... which is against bids spec
-        issues.push(new Issue({ code: 103, evidence: author }))
       }
     }
   }

--- a/bids-validator/validators/bids/checkDatasetDescription.js
+++ b/bids-validator/validators/bids/checkDatasetDescription.js
@@ -40,6 +40,11 @@ const checkAuthorField = authors => {
         issues.push(new Issue({ code: 102, evidence: author }))
       }
     }
+  } else {
+    // if there are no authors,
+    // warn user that errors could occur during doi minting
+    // and that snapshots on OpenNeuro will not be allowed
+    issues.push(new Issue({ code: 113, evidence: authors }))
   }
   return issues
 }


### PR DESCRIPTION
OpenNeuroOrg/openneuro#1155
throw warning when datasetDescription Authors field is empty.
```
113: {
    key: 'NO_AUTHORS',
    severity: 'warning',
    reason:
      'The Authors field of dataset_description.json should contain an array of fields - with one author per field. This was triggered because there are no authors, which could lead to DOI minting failures and will prevent snapshot creation on OpenNeuro.',
  }
```