### PR TITLE
Avoid extra bids-examples downloads

### DIFF
--- a/bids-validator/tests/env/load-examples.js
+++ b/bids-validator/tests/env/load-examples.js
@@ -14,7 +14,11 @@ const examples_lock_opts = { wait: 300000 }
 
 const loadExamples = async () => {
   await lockPromise(examples_lock, examples_lock_opts)
-  if (!fs.existsSync('tests/data/bids-examples-' + test_version + '/')) {
+  if (
+    !fs.existsSync(
+      'bids-validator/tests/data/bids-examples-' + test_version + '/',
+    )
+  ) {
     console.log('downloading test data')
     const response = request(
       'GET',


### PR DESCRIPTION
This path was not updated when the repo was rearranged, noticed this while profiling the test suite.