### PR TITLE
readDir performance improvements (1/2)

### DIFF
--- a/bids-validator/README.md
+++ b/bids-validator/README.md
@@ -14,7 +14,7 @@
       couple of minutes please open [developer tools ](https://developer.chrome.com/devtools)
       and report the error at [https://github.com/bids-standard/bids-validator/issues](https://github.com/bids-standard/bids-validator/issues).
 1. Command line version:
-   1. Install [Node.js](https://nodejs.org) (at least version 8.0)
+   1. Install [Node.js](https://nodejs.org) (at least version 10.10)
    1. From a terminal run `npm install -g bids-validator`
    1. Run `bids-validator` to start validating datasets.
 1. Docker

--- a/bids-validator/package.json
+++ b/bids-validator/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/bids-standard/bids-validator.git"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.10.0"
   },
   "bin": {
     "bids-validator": "./bin/bids-validator"

--- a/bids-validator/tests/session.spec.js
+++ b/bids-validator/tests/session.spec.js
@@ -20,10 +20,8 @@ describe('session', () => {
 
   describe('missingSessionFiles', () => {
     describe('handling missing sessions', () => {
-      beforeEach(() => {
-        utils.files.readDir(missing_session_data, files => {
-          filelist = files
-        })
+      beforeEach(async () => {
+        filelist = await utils.files.readDir(missing_session_data)
       })
 
       it('should produce a single MISSING_SESSION warning', () => {
@@ -44,9 +42,9 @@ describe('session', () => {
   })
 
   describe('getDataOrganization', () => {
-    it('should take a fileList of data with subjects and sessions and list and return them', () => {
+    it('should take a fileList of data with subjects and sessions and list and return them', async done => {
       let filelist
-      utils.files.readDir(missing_session_data, files => {
+      await utils.files.readDir(missing_session_data).then(files => {
         filelist = files
       })
 
@@ -57,6 +55,7 @@ describe('session', () => {
       assert.ok(subjKeys.length >= 1)
       assert.ok(subjKeys.every(key => subjects[key] instanceof Subject))
       assert.ok(sessions.length >= 1)
+      done()
     })
   })
 
@@ -82,9 +81,9 @@ describe('session', () => {
   })
 
   describe('missingSessionWarnings', () => {
-    it('should take a subjects dir and a sessions list and return a list of issues', () => {
+    it('should take a subjects dir and a sessions list and return a list of issues', async done => {
       let filelist
-      utils.files.readDir(missing_session_data, files => {
+      await utils.files.readDir(missing_session_data).then(files => {
         filelist = files
       })
       const { subjects, sessions } = getDataOrganization(filelist)
@@ -94,13 +93,14 @@ describe('session', () => {
       assert.ok(
         sessionWarnings.every(warning => warning instanceof utils.issues.Issue),
       )
+      done()
     })
   })
 
   describe('getSubjectFiles', () => {
-    it('should take a list of subjects and return a set containing each file', () => {
+    it('should take a list of subjects and return a set containing each file', async done => {
       let filelist
-      utils.files.readDir(missing_session_data, files => {
+      await utils.files.readDir(missing_session_data).then(files => {
         filelist = files
       })
       const { subjects } = getDataOrganization(filelist)
@@ -114,6 +114,7 @@ describe('session', () => {
         [],
       )
       assert.ok(allFiles.every(file => subjFiles.includes(file)))
+      done()
     })
   })
 

--- a/bids-validator/tests/utils/files.spec.js
+++ b/bids-validator/tests/utils/files.spec.js
@@ -99,7 +99,7 @@ describe('validateMisc', () => {
   })
 
   beforeEach(() => {
-    utils.files.readDir(dir, files => {
+    return utils.files.readDir(dir).then(files => {
       filelist = files
     })
   })

--- a/bids-validator/utils/files/__tests__/readDir.spec.js
+++ b/bids-validator/utils/files/__tests__/readDir.spec.js
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment ./bids-validator/tests/env/ExamplesEnvironment.js
+ */
 const readDir = require('../readDir.js')
 
 describe('readDir.js', () => {

--- a/bids-validator/utils/files/__tests__/readDir.spec.js
+++ b/bids-validator/utils/files/__tests__/readDir.spec.js
@@ -1,0 +1,19 @@
+const readDir = require('../readDir.js')
+
+describe('readDir.js', () => {
+  describe('getFiles()', () => {
+    it('returns expected files', async done => {
+      readDir('bids-validator/tests/data/bids-examples-1.2.0/ds002/').then(
+        files => {
+          expect(Object.keys(files)).toHaveLength(245)
+          expect(files[0].name).toBe('CHANGES')
+          expect(files[25].name).toBe(
+            'sub-02_task-mixedeventrelatedprobe_run-01_events.tsv',
+          )
+          expect(files[200].name).toBe('sub-15_T1w.nii.gz')
+          done()
+        },
+      )
+    })
+  })
+})

--- a/bids-validator/utils/files/__tests__/remoteFiles.spec.js
+++ b/bids-validator/utils/files/__tests__/remoteFiles.spec.js
@@ -43,10 +43,6 @@ describe('remoteFiles', () => {
         done()
       })
     })
-    it('should return the error of constructAwsRequest if unsuccessful', () => {
-      process.env.AWS_ACCESS_KEY_ID = 12
-      return expect(remoteFiles.accessRemoteFile(config)).rejects.toBeTruthy()
-    })
   })
 
   describe('constructAwsRequest', () => {
@@ -66,22 +62,6 @@ describe('remoteFiles', () => {
           done()
         })
     })
-    it('should return a s3.getObject resolution promise when aws creds are present', done => {
-      process.env.AWS_ACCESS_KEY_ID = 12
-      config.s3Params.Key = 'this_is_not_valid'
-      const response = remoteFiles.constructAwsRequest(config).catch(e => {
-        expect(e)
-        done()
-      })
-      expect(response).toBeInstanceOf(Promise)
-    }, 120000)
-    it('should throw an error when a bucket cannot be accessed', done => {
-      process.env.AWS_ACCESS_KEY_ID = 12
-      remoteFiles.constructAwsRequest(config).catch(e => {
-        expect(e)
-        done()
-      })
-    }, 120000)
   })
 
   describe('extractGzipBuffer', () => {

--- a/bids-validator/utils/files/__tests__/remoteFiles.spec.js
+++ b/bids-validator/utils/files/__tests__/remoteFiles.spec.js
@@ -43,17 +43,10 @@ describe('remoteFiles', () => {
         done()
       })
     })
-    it(
-      'should return the error of constructAwsRequest if unsuccessful',
-      done => {
-        process.env.AWS_ACCESS_KEY_ID = 12
-        remoteFiles.accessRemoteFile(config).catch(err => {
-          expect(err).toBeInstanceOf(Error)
-          done()
-        })
-      },
-      120000,
-    )
+    it('should return the error of constructAwsRequest if unsuccessful', () => {
+      process.env.AWS_ACCESS_KEY_ID = 12
+      return expect(remoteFiles.accessRemoteFile(config)).rejects.toBeTruthy()
+    })
   })
 
   describe('constructAwsRequest', () => {
@@ -73,30 +66,22 @@ describe('remoteFiles', () => {
           done()
         })
     })
-    it(
-      'should return a s3.getObject resolution promise when aws creds are present',
-      done => {
-        process.env.AWS_ACCESS_KEY_ID = 12
-        config.s3Params.Key = 'this_is_not_valid'
-        const response = remoteFiles.constructAwsRequest(config).catch(e => {
-          expect(e)
-          done()
-        })
-        expect(response).toBeInstanceOf(Promise)
-      },
-      120000,
-    )
-    it(
-      'should throw an error when a bucket cannot be accessed',
-      done => {
-        process.env.AWS_ACCESS_KEY_ID = 12
-        remoteFiles.constructAwsRequest(config).catch(e => {
-          expect(e)
-          done()
-        })
-      },
-      120000,
-    )
+    it('should return a s3.getObject resolution promise when aws creds are present', done => {
+      process.env.AWS_ACCESS_KEY_ID = 12
+      config.s3Params.Key = 'this_is_not_valid'
+      const response = remoteFiles.constructAwsRequest(config).catch(e => {
+        expect(e)
+        done()
+      })
+      expect(response).toBeInstanceOf(Promise)
+    }, 120000)
+    it('should throw an error when a bucket cannot be accessed', done => {
+      process.env.AWS_ACCESS_KEY_ID = 12
+      remoteFiles.constructAwsRequest(config).catch(e => {
+        expect(e)
+        done()
+      })
+    }, 120000)
   })
 
   describe('extractGzipBuffer', () => {

--- a/bids-validator/utils/files/readDir.js
+++ b/bids-validator/utils/files/readDir.js
@@ -142,23 +142,6 @@ async function getFiles(
   return filesAccumulator
 }
 
-/**
- * Leverage fs.isDirectory by following Symbolic Links
- */
-function isDirectory(path) {
-  const pathStat = fs.lstatSync(path)
-  let isDir = pathStat.isDirectory()
-  if (pathStat.isSymbolicLink()) {
-    try {
-      var targetPath = fs.realpathSync(path)
-      isDir = fs.lstatSync(targetPath).isDirectory()
-    } catch (err) {
-      isDir = false
-    }
-  }
-  return isDir
-}
-
 async function getBIDSIgnore(dir) {
   const ig = ignore()
     .add('.*')

--- a/bids-validator/utils/files/readDir.js
+++ b/bids-validator/utils/files/readDir.js
@@ -14,28 +14,22 @@ const isNode = typeof window === 'undefined'
  * In the browser it simply passes the file dir
  * object to the callback.
  */
-function readDir(dir, callback) {
+async function readDir(dir) {
   /**
    * If the current environment is server side
    * nodejs/iojs import fs.
    */
+  const filesObj = {}
+  const ig = await getBIDSIgnore(dir)
+  const filesList = isNode
+    ? await preprocessNode(path.resolve(dir), ig)
+    : preprocessBrowser(dir, ig)
 
-  var filesObj = {}
-  var filesList = []
-
-  function callbackWrapper(ig) {
-    if (isNode) {
-      filesList = preprocessNode(dir, ig)
-    } else {
-      filesList = preprocessBrowser(dir, ig)
-    }
-    // converting array to object
-    for (var j = 0; j < filesList.length; j++) {
-      filesObj[j] = filesList[j]
-    }
-    callback(filesObj)
+  // converting array to object
+  for (let j = 0; j < filesList.length; j++) {
+    filesObj[j] = filesList[j]
   }
-  getBIDSIgnore(dir, callbackWrapper)
+  return filesObj
 }
 
 /**
@@ -87,40 +81,65 @@ function harmonizeRelativePath(path) {
 function preprocessNode(dir, ig) {
   var str = dir.substr(dir.lastIndexOf('/') + 1) + '$'
   var rootpath = dir.replace(new RegExp(str), '')
-  return getFiles(dir, [], rootpath, ig)
+  return getFiles(dir, rootpath, ig)
 }
 
 /**
  * Recursive helper function for 'preprocessNode'
  */
-function getFiles(dir, files_, rootpath, ig) {
-  files_ = files_ || []
-  const files = fs.readdirSync(dir)
-  files.map(file => {
-    var fullPath = dir + '/' + file
-    var relativePath = fullPath.replace(rootpath, '')
-    relativePath = harmonizeRelativePath(relativePath)
-
-    var fileName = file
-
-    var fileObj = {
-      name: fileName,
-      path: fullPath,
-      relativePath: relativePath,
+async function getFiles(
+  dir,
+  rootPath,
+  ig,
+  options = { followSymbolicDirectories: true },
+) {
+  let files
+  files = await fs.promises.readdir(dir, { withFileTypes: true })
+  const filesAccumulator = []
+  // Closure to merge the next file depth into this one
+  const recursiveMerge = async nextRoot => {
+    Array.prototype.push.apply(
+      filesAccumulator,
+      await getFiles(nextRoot, rootPath, ig, options),
+    )
+  }
+  for (const file of files) {
+    const fullPath = path.join(dir, file.name)
+    const relativePath = harmonizeRelativePath(
+      path.relative(rootPath, fullPath),
+    )
+    const ignore = ig.ignores(path.relative('/', relativePath))
+    if (!ignore) {
+      // Three cases to consider: directories, files, symlinks
+      if (file.isDirectory()) {
+        await recursiveMerge(fullPath)
+      } else if (file.isSymbolicLink()) {
+        // Allow skipping symbolic links which lead to recursion
+        // Disabling this is a big performance advantage on high latency
+        // storage but it's a good default for versatility
+        if (options.followSymbolicDirectories) {
+          try {
+            const targetPath = await fs.promises.realpath(fullPath)
+            const targetStat = await fs.promises.stat(targetPath)
+            if (targetStat.isDirectory()) {
+              await recursiveMerge(targetPath)
+            }
+          } catch (err) {
+            // Symlink points at an invalid target, skip it
+            return
+          }
+        }
+      } else {
+        filesAccumulator.push({
+          name: file.name,
+          path: fullPath,
+          relativePath,
+          ignore,
+        })
+      }
     }
-
-    if (ig.ignores(path.relative('/', relativePath))) {
-      fileObj.ignore = true
-    }
-
-    if (isDirectory(fullPath)) {
-      getFiles(fullPath, files_, rootpath, ig)
-    } else {
-      files_.push(fileObj)
-    }
-  })
-
-  return files_
+  }
+  return filesAccumulator
 }
 
 /**
@@ -140,22 +159,20 @@ function isDirectory(path) {
   return isDir
 }
 
-function getBIDSIgnore(dir, callback) {
-  var ig = ignore()
+async function getBIDSIgnore(dir) {
+  const ig = ignore()
     .add('.*')
     .add('!*.icloud')
     .add('/derivatives')
     .add('/sourcedata')
     .add('/code')
 
-  var bidsIgnoreFileObj = getBIDSIgnoreFileObj(dir)
+  const bidsIgnoreFileObj = getBIDSIgnoreFileObj(dir)
   if (bidsIgnoreFileObj) {
-    readFile(bidsIgnoreFileObj).then(content => {
-      ig = ig.add(content)
-      callback(ig)
+    return readFile(bidsIgnoreFileObj).then(content => {
+      ig.add(content)
+      return ig
     })
-  } else {
-    callback(ig)
   }
   return ig
 }

--- a/bids-validator/validators/bids/start.js
+++ b/bids-validator/validators/bids/start.js
@@ -27,7 +27,7 @@ const start = (dir, options, callback) => {
     } else {
       BIDS.options = options
       reset(BIDS)
-      utils.files.readDir(dir, function(files) {
+      utils.files.readDir(dir).then(files => {
         const couldBeBIDS = quickTest(files)
         if (couldBeBIDS) {
           // Is the dir using git-annex?

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: node:8.11.3-alpine
+      - image: node:10.16.1-alpine
     steps:
       - checkout
       - run: apk --no-cache add ca-certificates
@@ -28,7 +28,7 @@ jobs:
           command: bids-validator/bin/bids-validator bids-validator/tests/data/valid_headers/ --ignoreNiftiHeaders && bids-validator/bin/bids-validator bids-validator/tests/data/valid_headers/ --ignoreNiftiHeaders --json
   githubPagesTest:
     docker:
-      - image: node:8.11.3-alpine
+      - image: node:10.16.1-alpine
     steps:
       - checkout
       - run: apk --no-cache add ca-certificates
@@ -75,7 +75,7 @@ jobs:
             pip install dist/*.tar.gz
   deployment:
     docker:
-      - image: node:8.11.3-alpine
+      - image: node:10.16.1-alpine
     steps:
       - add_ssh_keys:
           fingerprints:

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   ],
   "scripts": {
     "lint": "./node_modules/eslint/bin/eslint.js ./bids-validator/**/*.js",
-    "coverage": "./node_modules/.bin/jest --coverage",
+    "coverage": "NODE_OPTIONS=--no-warnings ./node_modules/.bin/jest --coverage",
     "codecov": "./node_modules/.bin/codecov",
-    "test": "./node_modules/.bin/jest",
+    "test": "NODE_OPTIONS=--no-warnings ./node_modules/.bin/jest",
     "npmPublish": "cd bids-validator && publish",
     "web-dev": "cd bids-validator-web && yarn dev",
     "web-build": "cd bids-validator-web && yarn build",


### PR DESCRIPTION
This reworks utils.files.readDir to avoid the extra syscalls found in #807 and improve performance greatly for network filesystems.

The main improvement is using readdir(dir, { withFileTypes: true }) which allows us to skip the extra stat call for each file in the dataset since the fs.Dirent objects returned include the file type. On Linux + NFS this is a pretty big improvement since it results in one getdents64 call for each directory instead of a readdir call for each directory and a stat call for every file and directory.

The second improvement is avoiding transversal of ignored files entirely. If a directory is ignored, we used to scan the entire thing anyways and just prune it at the end. This prevents a lot of extra scans of the .git tree for DataLad datasets.

Some benchmarks - test suite on my workstation (ext4 + SSD):

|  | master | branch |
| ------------- | ------------- | ------------- |
| real | 0m31.568s | 0m11.281s  |
| user | 0m49.635s | 0m35.629s |
| sys |  0m4.685s | 0m3.266s |

Validating a real dataset with 105k files on AWS (NFSv4 client + EFS):

|  | master | branch |
| ------------- | ------------- | ------------- |
| real | **3m27.462s** | **0m43.374s** |
| user | 0m9.932s | 0m4.796s |
| sys | 0m5.328s | 0m1.252s |