### PR TITLE
Remove conflicting package name from root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,5 @@
   },
   "devDependencies": {
     "lerna": "^3.15.0"
-  },
-  "name": "bids-validator"
-
+  }
 }


### PR DESCRIPTION
This was throwing a warning on tests, if the root package does have a name it should be distinct from all the packages.