### PR TITLE
Enable running test suite on Windows

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,10 @@
+stages:
+    - test
+
+tests:
+  stage: test
+  tags:
+    - windows
+  script:
+    - yarn
+    - yarn test

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "./node_modules/eslint/bin/eslint.js ./bids-validator/**/*.js",
     "coverage": "NODE_OPTIONS=--no-warnings ./node_modules/.bin/jest --coverage",
     "codecov": "./node_modules/.bin/codecov",
-    "test": "NODE_OPTIONS=--no-warnings ./node_modules/.bin/jest",
+    "test": "jest",
     "npmPublish": "cd bids-validator && publish",
     "web-dev": "cd bids-validator-web && yarn dev",
     "web-build": "cd bids-validator-web && yarn build",


### PR DESCRIPTION
This adds a GitLab CI configuration to run the test suite on Windows Server 2019 via PowerShell. The test suite does not pass but I think this is due to legitimate bugs on Windows with portions of the test suite assuming Unix paths, even though the validator itself is pretty good about this.