### PR TITLE
Bump version of Node.js in Dockerfile to supported version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.11.3-alpine
+FROM node:10.16.3-alpine
 
 COPY ./bids-validator /src
 


### PR DESCRIPTION
This fixes #822 for Docker and Singularity users.