### PR TITLE
Don't included `ignore: false` on readDir file objects

### DIFF
--- a/bids-validator/utils/files/__tests__/readDir-examples.spec.js
+++ b/bids-validator/utils/files/__tests__/readDir-examples.spec.js
@@ -56,5 +56,20 @@ describe('readDir.js - examples integration', () => {
         done()
       })
     })
+    it('returns file objects with the expected shape', async done => {
+      readDir('bids-validator/tests/data/symlinked_subject', {
+        followSymbolicDirectories: false,
+      }).then(files => {
+        expect(Object.keys(files)).toHaveLength(6)
+        Object.values(files).forEach(f => {
+          expect(Object.getOwnPropertyNames(f)).toEqual([
+            'name',
+            'path',
+            'relativePath',
+          ])
+        })
+        done()
+      })
+    })
   })
 })

--- a/bids-validator/utils/files/readDir.js
+++ b/bids-validator/utils/files/readDir.js
@@ -125,13 +125,12 @@ async function getFiles(
       path.relative(rootPath, fullPath),
     )
     const ignore = ig.ignores(path.relative('/', relativePath))
-    const fileObj = {
-      name: file.name,
-      path: fullPath,
-      relativePath,
-      ignore,
-    }
     if (!ignore) {
+      const fileObj = {
+        name: file.name,
+        path: fullPath,
+        relativePath,
+      }
       // Three cases to consider: directories, files, symlinks
       if (file.isDirectory()) {
         await recursiveMerge(fullPath)


### PR DESCRIPTION
It will always be false since ignored objects are skipped. This leads to a regression with OpenNeuro where the extra field throws a type error after validation.