### PR TITLE
make all env checks rely on isNode util

### DIFF
--- a/bids-validator/utils/files/collectDirectorySize.js
+++ b/bids-validator/utils/files/collectDirectorySize.js
@@ -1,4 +1,5 @@
 const fs = require('fs')
+const isNode = require('../isNode')
 
 const collectDirectorySize = fileList => {
   let size = 0
@@ -10,7 +11,7 @@ const collectDirectorySize = fileList => {
       // from File api in browser
       size += file.size
       // or from git-annex metadata when in gitTreeMode
-      if (typeof window === 'undefined') file.stats = { size: file.size }
+      if (isNode) file.stats = { size: file.size }
     } else {
       file.stats = getFileStats(file)
       size += file.stats.size

--- a/bids-validator/utils/files/remoteFiles.js
+++ b/bids-validator/utils/files/remoteFiles.js
@@ -225,8 +225,7 @@ const remoteFiles = {
   },
   // Check if a local directory is a git-annex repo
   isGitAnnex: function(path) {
-    if (typeof window === 'undefined')
-      return fs.existsSync(path + '/.git/annex')
+    if (isNode) return fs.existsSync(path + '/.git/annex')
     return false
   },
 }

--- a/bids-validator/utils/files/validateMisc.js
+++ b/bids-validator/utils/files/validateMisc.js
@@ -1,7 +1,8 @@
 const Issue = require('../issues/issue')
+const isNode = require('../isNode')
 
 function createIssueForEmpty(file) {
-  const size = typeof window !== 'undefined' ? file.size : file.stats.size
+  const size = !isNode ? file.size : file.stats.size
   var failsSizeRequirement = size <= 0
   // Exception misc files that can be valid although size==0
   // E.g., BadChannels and bad.segments in CTF data format (MEG modality)

--- a/bids-validator/validators/bids/quickTestError.js
+++ b/bids-validator/validators/bids/quickTestError.js
@@ -1,13 +1,14 @@
 const path = require('path')
 const utils = require('../../utils')
 const Issue = utils.issues.Issue
+const isNode = require('../../utils/isNode')
 
 /*
  * Generates an error for quickTest failures
  */
 const quickTestError = function(dir) {
   let filename
-  if (typeof window === 'undefined') {
+  if (isNode) {
     // For Node, grab the path from the dir string
     filename = path.basename(dir)
   } else {

--- a/bids-validator/validators/headerFields.js
+++ b/bids-validator/validators/headerFields.js
@@ -1,5 +1,6 @@
 var utils = require('../utils')
 var Issue = utils.issues.Issue
+const isNode = require('../utils/isNode')
 
 /**
  * dimensions and resolution
@@ -176,7 +177,7 @@ const headerField = (headers, field) => {
       return
     }
 
-    if (!file || (typeof window != 'undefined' && !file.webkitRelativePath)) {
+    if (!file || (!isNode && !file.webkitRelativePath)) {
       continue
     }
 

--- a/bids-validator/validators/session.js
+++ b/bids-validator/validators/session.js
@@ -35,8 +35,7 @@ function getDataOrganization(fileList) {
     if (fileList.hasOwnProperty(key)) {
       const file = fileList[key]
 
-      if (!file || (!isNode && !file.webkitRelativePath))
-        continue
+      if (!file || (!isNode && !file.webkitRelativePath)) continue
 
       const path = file.relativePath
       if (!utils.type.isBIDS(path) || utils.type.file.isStimuliData(path))

--- a/bids-validator/validators/session.js
+++ b/bids-validator/validators/session.js
@@ -1,6 +1,7 @@
 var utils = require('../utils')
 const sesUtils = utils.files.sessions
 var Issue = utils.issues.Issue
+const isNode = require('../utils/isNode')
 
 /**
  * session
@@ -34,7 +35,7 @@ function getDataOrganization(fileList) {
     if (fileList.hasOwnProperty(key)) {
       const file = fileList[key]
 
-      if (!file || (typeof window != 'undefined' && !file.webkitRelativePath))
+      if (!file || (!isNode && !file.webkitRelativePath))
         continue
 
       const path = file.relativePath


### PR DESCRIPTION
I missed a few inline checks in the last PR, this should catch the rest of them.