### PR TITLE
CI: Fix PyPI check by separating twine install from install tools upgrade

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -66,10 +66,10 @@ jobs:
       - checkout
       - run:
           name: Set up environment
-          command: apk --no-cache add ca-certificates git build-base
+          command: apk --no-cache add ca-certificates git build-base libffi-dev libressl-dev
       - run:
           name: Install Python 3 and build tools
-          command: apk --no-cache add python3 python3-dev py3-cffi libffi-dev
+          command: apk --no-cache add python3 python3-dev
       - run:
           name: Update Python install tools
           command: python3 -m pip install --upgrade pip setuptools wheel

--- a/circle.yml
+++ b/circle.yml
@@ -66,13 +66,16 @@ jobs:
       - checkout
       - run:
           name: Set up environment
-          command: |
-            apk --no-cache add ca-certificates git build-base
+          command: apk --no-cache add ca-certificates git build-base
       - run:
-          name: Install Python 3 and update setuptools
-          command: |
-            apk --no-cache add python3 python3-dev py3-cffi
-            python3 -m pip install --upgrade pip setuptools wheel twine readme_renderer[md]
+          name: Install Python 3 and build tools
+          command: apk --no-cache add python3 python3-dev py3-cffi libffi-dev
+      - run:
+          name: Update Python install tools
+          command: python3 -m pip install --upgrade pip setuptools wheel
+      - run:
+          name: Install twine, readme renderer
+          command: python3 -m pip install twine readme_renderer[md]
       - run:
           name: Check build and readme rendering
           command: |


### PR DESCRIPTION
PyPI check is failing, and it appears to be due to a `cffi` upgrade. This PR avoids forced upgrades of dependencies of `twine` and `readme_renderer`.