### PR TITLE
Remove erroneous CJS module export from collectDirectorySize

### DIFF
--- a/bids-validator/utils/files/collectDirectorySize.js
+++ b/bids-validator/utils/files/collectDirectorySize.js
@@ -21,6 +21,4 @@ const collectDirectorySize = fileList => {
   return size
 }
 
-module.exports = collectDirectorySize
-
 export default collectDirectorySize


### PR DESCRIPTION
Looks like this was accidentally introduced in cc5d0a442f83890bc9bb59df2d0963609dbae6de