### PR TITLE
Lerna fix: Use shared versioning for packages

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
     "bids-validator",
     "bids-validator-web"
   ],
-  "version": "independent"
+  "version": "1.3.12"
 }


### PR DESCRIPTION
I saw #882 and I believe Lerna is misconfigured for the project. This switches to managing one version across multiple packages which was the original benefit of using Lerna in the first place. With this change, `lerna publish` will push one GitHub tag and manage the package version for both packages.