### PR TITLE
Add default path for validator configuration

### DIFF
--- a/bids-validator-web/components/App.jsx
+++ b/bids-validator-web/components/App.jsx
@@ -23,7 +23,7 @@ const initState = () => ({
   options: {
     ignoreWarnings: false,
     ignoreNiftiHeaders: false,
-  }
+  },
 })
 
 export default class App extends React.Component {
@@ -35,15 +35,21 @@ export default class App extends React.Component {
   }
 
   _validate(selectedFiles) {
+    const dirName = selectedFiles.list[0].webkitRelativePath.split('/')[0]
+    const defaultConfig = `${dirName}/.bids-validator-config.json`
     this.setState({
       status: 'validating',
       showIssues: true,
       activeKey: 3,
-      dirName: selectedFiles.list[0].webkitRelativePath.split('/')[0],
+      dirName,
     })
     return validate.BIDS(
       selectedFiles.list,
-      { verbose: true, ...this.state.options },
+      {
+        verbose: true,
+        ...this.state.options,
+        config: defaultConfig,
+      },
       (issues, summary) => {
         if (issues === 'Invalid') {
           return this.setState({
@@ -73,8 +79,8 @@ export default class App extends React.Component {
       ...prevState,
       options: {
         ...prevState.options,
-        [name]: !prevState.options[name]
-      }
+        [name]: !prevState.options[name],
+      },
     }))
   }
 
@@ -86,7 +92,10 @@ export default class App extends React.Component {
         <nav className="navbar navbar-dark bg-dark fixed-top">
           <div className="container">
             <div className="navbar-header">
-              <a className="navbar-brand" href="https://www.npmjs.com/package/bids-validator" target="_blank">
+              <a
+                className="navbar-brand"
+                href="https://www.npmjs.com/package/bids-validator"
+                target="_blank">
                 BIDS Validator v{version}
               </a>
             </div>

--- a/bids-validator/README.md
+++ b/bids-validator/README.md
@@ -100,6 +100,8 @@ You can configure the severity of errors by passing a json configuration file
 with a `-c` or `--config` flag to the command line interface or by defining a
 config object on the options object passed during javascript usage.
 
+If no path is specified a default path of `.bids-validator-config.json` will be used. You can add this file to your dataset to share dataset specific validation configuration. To disable this behavior use `--no-config` and the default configuration will be used.
+
 The basic configuration format is outlined below. All configuration is optional.
 
 ```JSON

--- a/bids-validator/bin/bids-validator
+++ b/bids-validator/bin/bids-validator
@@ -43,7 +43,7 @@ var argv = require('yargs')
     alias: 'c',
     describe:
       'Optional configuration file. See https://github.com/bids-standard/bids-validator for more info',
-    default: {},
+    default: '.bids-validator-config.json',
   })
   .epilogue(
     'This tool checks if a dataset in a given directory is \

--- a/bids-validator/utils/files/readFile.js
+++ b/bids-validator/utils/files/readFile.js
@@ -35,9 +35,7 @@ function readFile(file, annexed, dir) {
     if (isNode) {
       testFile(file, annexed, dir, function(issue, stats, remoteBuffer) {
         if (issue) {
-          process.nextTick(function() {
-            return reject(issue)
-          })
+          return reject(issue)
         }
         if (!remoteBuffer) {
           fs.readFile(file.path, function(err, data) {

--- a/bids-validator/utils/options.js
+++ b/bids-validator/utils/options.js
@@ -1,5 +1,7 @@
+import path from 'path'
 import files from './files'
 import json from './json'
+import isNode from '../utils/isNode.js'
 
 let options
 
@@ -7,7 +9,7 @@ export default {
   /**
    * Parse
    */
-  parse: function(args, callback) {
+  parse: function(dir, args, callback) {
     options = args ? args : {}
     options = {
       ignoreWarnings: Boolean(options.ignoreWarnings),
@@ -20,7 +22,7 @@ export default {
       config: options.config || {},
     }
     if (options.config && typeof options.config !== 'boolean') {
-      this.parseConfig(options.config, function(issues, config) {
+      this.parseConfig(dir, options.config, function(issues, config) {
         options.config = config
         callback(issues, options)
       })
@@ -37,17 +39,35 @@ export default {
   /**
    * Load Config
    */
-  loadConfig: function(config, callback) {
+  loadConfig: function(dir, config, callback) {
     if (typeof config === 'string') {
-      var configFile = { path: config }
+      let configFile
+      if (isNode) {
+        const configPath = path.isAbsolute(config)
+          ? config
+          : path.join(dir, config)
+        configFile = { path: configPath }
+      } else {
+        // Grab file from FileList if a path was provided
+        configFile = [...dir].find(f => f.webkitRelativePath === config)
+        // No mathcing config, return a default
+        if (!configFile) {
+          return callback(null, configFile, JSON.stringify({}))
+        }
+      }
       configFile.stats = files.getFileStats(configFile)
       files
         .readFile(configFile)
         .then(contents => {
-          callback(null, { path: config }, contents)
+          callback(null, configFile, contents)
         })
         .catch(issue => {
-          callback([issue], { path: config }, null)
+          // If the config does not exist, issue 44 is returned
+          if (issue.code === 44) {
+            callback(null, configFile, JSON.stringify({}))
+          } else {
+            callback([issue], configFile, null)
+          }
         })
     } else if (typeof config === 'object') {
       callback(null, { path: 'config' }, JSON.stringify(config))
@@ -57,8 +77,8 @@ export default {
   /**
    * Parse Config
    */
-  parseConfig: function(config, callback) {
-    this.loadConfig(config, function(issues, file, contents) {
+  parseConfig: function(dir, config, callback) {
+    this.loadConfig(dir, config, function(issues, file, contents) {
       if (issues) {
         callback(issues, null)
       } else {

--- a/bids-validator/validators/bids/start.js
+++ b/bids-validator/validators/bids/start.js
@@ -20,7 +20,7 @@ const start = (dir, options, callback) => {
   // eslint-disable-next-line
   if (!options.json) console.log(`bids-validator@${version}\n`)
 
-  utils.options.parse(options, function(issues, options) {
+  utils.options.parse(dir, options, function(issues, options) {
     if (issues && issues.length > 0) {
       // option parsing issues
       callback({ config: issues })


### PR DESCRIPTION
This adds a default configuration path which is searched from the dataset root. You can add this configuration file to your dataset `dataset root/.bids-validator-config.json` and share any dataset specific config needed.

The web validator is updated to use this file and override it with the page controls. Other consumers of the bids-validator will pick up this behavior if they do not override the configuration already, but those that do override it will need to decide if they want to ignore this file or merge it with any other overrides (e.g. OpenNeuro will not automatically start parsing this file without changes but other usages may if they do not configure the validator already).

There is one breaking change, the config option path is now relative from the dataset root unless it is an absolute path. Previously it was relative to the working directory where the validator was executed.

Fixes #741 