### PR TITLE
Allow derived si units

### DIFF
--- a/bids-validator/utils/__tests__/unit.spec.js
+++ b/bids-validator/utils/__tests__/unit.spec.js
@@ -22,7 +22,7 @@ describe('unit validator', () => {
     expect(badOutput.isValid).toBe(false)
   })
 
-  const validExponents = ['^2', '¹²³', ...unit.superscriptNumbers]
+  const validExponents = ['^2', '^543', '¹²³', ...unit.superscriptNumbers.slice(0, 3)]
   it('handles simple units with exponents', () => {
     validExponents.forEach(exp => {
       const goodOutput = unit.validate(validRoot + exp)

--- a/bids-validator/utils/__tests__/unit.spec.js
+++ b/bids-validator/utils/__tests__/unit.spec.js
@@ -1,0 +1,65 @@
+import unit from '../unit'
+
+const { prefixes, roots } = unit
+const validRoot = roots[0]
+
+describe('unit validator', () => {
+  it('handles simple units', () => {
+    roots.forEach(validRoot => {
+      const goodOutput = unit.validate(validRoot)
+      expect(goodOutput.isValid).toBe(true)
+    })
+    const badOutput = unit.validate('definitielynotavalidroot')
+    expect(badOutput.isValid).toBe(false)
+  })
+
+  it('handles simple units with prefixes', () => {
+    prefixes.forEach(validPrefix => {
+      const goodOutput = unit.validate(validPrefix + validRoot)
+      expect(goodOutput.isValid).toBe(true)
+    })
+    const badOutput = unit.validate('badprefix' + validRoot)
+    expect(badOutput.isValid).toBe(false)
+  })
+
+  const validExponents = ['^2', '¹²³', ...unit.superscriptNumbers]
+  it('handles simple units with exponents', () => {
+    validExponents.forEach(exp => {
+      const goodOutput = unit.validate(validRoot + exp)
+      expect(goodOutput.isValid).toBe(true)
+    })
+    const invalidExponents = ['^^12', '142', '1', '0', '^.1', '^2.1']
+    invalidExponents.forEach(exp => {
+      const badOutput = unit.validate(validRoot + exp)
+      expect(badOutput.isValid).toBe(false)
+    })
+    validExponents.slice(0, 3).forEach(exp => {
+      const badOutput = unit.validate(exp)
+      expect(badOutput.isValid).toBe(false)
+    })
+  })
+
+  it('handles derived units', () => {
+    const validUnits = ['T/m', 'N*m', 'm^2/s^2', 'mm/ms', 'kT³*nm²', 'm²/s²']
+    validUnits.forEach(derivedUnit => {
+      const goodOutput = unit.validate(derivedUnit)
+      expect(goodOutput.isValid).toBe(true)
+    })
+    const invalidUnits = [
+      `/${validRoot}`,
+      `*${validRoot}`,
+      `${validRoot}/`,
+      `${validRoot}*`,
+      `${validRoot}//${validRoot}`,
+      `${validRoot}///${validRoot}`,
+      `${validRoot}**${validRoot}`,
+      `${validRoot}***${validRoot}`,
+      `${roots.slice(0, 3).join('')}`,
+      ...validExponents.slice(0, 3).map(exp => `${exp}${validRoot}`),
+    ]
+    invalidUnits.forEach(derivedUnit => {
+      const badOutput = unit.validate(derivedUnit)
+      expect(badOutput.isValid).toBe(false)
+    })
+  })
+})

--- a/bids-validator/utils/__tests__/unit.spec.js
+++ b/bids-validator/utils/__tests__/unit.spec.js
@@ -22,7 +22,7 @@ describe('unit validator', () => {
     expect(badOutput.isValid).toBe(false)
   })
 
-  const validExponents = ['^2', '^543', '¹²³', ...unit.superscriptNumbers.slice(0, 3)]
+  const validExponents = ['^2', '^543', '¹²³', ...unit.superscriptNumbers.slice(0, 3), '^-2', '⁻³']
   it('handles simple units with exponents', () => {
     validExponents.forEach(exp => {
       const goodOutput = unit.validate(validRoot + exp)
@@ -55,7 +55,7 @@ describe('unit validator', () => {
       `${validRoot}**${validRoot}`,
       `${validRoot}***${validRoot}`,
       `${roots.slice(0, 3).join('')}`,
-      ...validExponents.slice(0, 3).map(exp => `${exp}${validRoot}`),
+      ...validExponents.map(exp => `${exp}${validRoot}`),
     ]
     invalidUnits.forEach(derivedUnit => {
       const badOutput = unit.validate(derivedUnit)

--- a/bids-validator/utils/unit.js
+++ b/bids-validator/utils/unit.js
@@ -102,7 +102,7 @@ const prefixes = [
   'yocto',
   'y',
 ]
-const unitOperators = ['/', '*']
+const unitOperators = ['/', '*', '⋅']
 const exponentOperator = '^'
 const operators = [...unitOperators, exponentOperator]
 

--- a/bids-validator/utils/unit.js
+++ b/bids-validator/utils/unit.js
@@ -119,13 +119,14 @@ const superscriptNumbers = [
   '\u2078',
   '\u2079',
 ]
+const superscriptNegative = '\u207B'
 
 const start = '^'
 const end = '$'
 const prefix = `(${prefixes.join('|')})?`
 const root = `(${roots.join('|')})`
-const superscriptExp = `[${superscriptNumbers}]*`
-const operatorExp = `(\\^[0-9]+)?`
+const superscriptExp = `(${superscriptNegative}?[${superscriptNumbers}]+)?`
+const operatorExp = `(\\^-?[0-9]+)?`
 const unitWithExponentPattern = new RegExp(
   `${start}${prefix}${root}(${superscriptExp}|${operatorExp})${end}`,
 )

--- a/bids-validator/utils/unit.js
+++ b/bids-validator/utils/unit.js
@@ -102,25 +102,75 @@ const prefixes = [
   'yocto',
   'y',
 ]
+const unitOperators = ['/', '*']
+const exponentOperator = '^'
+const operators = [...unitOperators, exponentOperator]
 
-const prefix = `^(${prefixes.join('|')})?`
-const prefixPattern = new RegExp(prefix)
-const root = `(${roots.join('|')})$`
-const rootPattern = new RegExp(root)
-const validSIPattern = new RegExp(prefix + root)
+// from 0-9
+const superscriptNumbers = [
+  '\u2070',
+  '\u00B9',
+  '\u00B2',
+  '\u00B3',
+  '\u2074',
+  '\u2075',
+  '\u2076',
+  '\u2077',
+  '\u2078',
+  '\u2079',
+]
 
-const validate = unit => {
-  const isValid = validSIPattern.test(unit)
-  return {
-    isValid,
-    validPrefix: isValid || prefixPattern.test(unit),
-    validRoot: isValid || rootPattern.test(unit),
-  }
+const start = '^'
+const end = '$'
+const prefix = `(${prefixes.join('|')})?`
+const root = `(${roots.join('|')})`
+const superscriptExp = `[${superscriptNumbers}]*`
+const operatorExp = `(\\^[0-9]+)?`
+const unitWithExponentPattern = new RegExp(
+  `${start}${prefix}${root}(${superscriptExp}|${operatorExp})${end}`,
+)
+
+const unitOperatorPattern = new RegExp(`[${unitOperators.join('')}]`)
+
+/**
+ * validate
+ *
+ * Checks that the SI unit given is valid.
+ * Whitespace characters are not supported.
+ * Unit must include at least one root unit of measuremnt.
+ * Multiple root units must be separated by one of the operators '/' (division) or '*' (multiplication).
+ * Each root unit may or may not pre preceded by a multiplier prefix,
+ *   and may or may not be followed by an exponent.
+ * Exponents may only be to integer powers,
+ *   and may be formatted as either unicode superscript numbers,
+ *   or as integers following the '^' operator.
+ *
+ * @param {string} derivedUnit - a simple or complex SI unit
+ * @returns {object} - { isValid, evidence }
+ */
+const validate = derivedUnit => {
+  const separatedUnits = derivedUnit
+    .split(unitOperatorPattern)
+    .map(str => str.trim())
+  const invalidUnits = separatedUnits.filter(
+    unit => !unitWithExponentPattern.test(unit),
+  )
+
+  const isValid = invalidUnits.length === 0
+  const evidence = isValid
+    ? ''
+    : `Subunit${invalidUnits.length === 1 ? '' : 's'} (${invalidUnits.join(
+        ', ',
+      )}) of unit ${derivedUnit} is invalid. `
+
+  return { isValid, evidence }
 }
 
-export { roots, prefixes, validate }
+export { roots, prefixes, superscriptNumbers, operators, validate }
 export default {
   roots,
   prefixes,
+  superscriptNumbers,
+  operators,
   validate,
 }

--- a/bids-validator/validators/tsv/tsv.js
+++ b/bids-validator/validators/tsv/tsv.js
@@ -266,10 +266,7 @@ const TSV = (file, contents, fileList, callback) => {
         line: i + 2,
       }))
       .forEach(({ unit, line }) => {
-        const { isValid, validPrefix, validRoot } = utils.unit.validate(unit)
-        const evidence = `Unit ${unit} has an invalid ${
-          validPrefix ? '' : 'prefix'
-        }${validPrefix && validRoot ? ' and ' : ''}${validRoot ? '' : 'root'}.`
+        const { isValid, evidence } = utils.unit.validate(unit)
         if (!isValid)
           issues.push(
             new Issue({

--- a/yarn.lock
+++ b/yarn.lock
@@ -4042,6 +4042,11 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
+date-and-time@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/date-and-time/-/date-and-time-0.9.0.tgz#1524579e56dc07675c640b41735a7665c0659240"
+  integrity sha512-4JybB6PbR+EebpFx/KyR5Ybl+TcdXMLIJkyYsCx3P4M4CWGMuDyFF19yh6TyasMAIF5lrsgIxiSHBXh2FFc7Fg==
+
 date-fns@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.7.0.tgz#8271d943cc4636a1f27698f1b8d6a9f1ceb74026"
@@ -5421,10 +5426,14 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
-hed-validator@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/hed-validator/-/hed-validator-0.3.0.tgz#53e80420c3e24209e5fbcd45156b29be429b6a99"
-  integrity sha512-yQLR+S2HPtb9dMQQISBamdcYa+0ShJl2vf/0D5xDqjFM6QrAmtXZYBsBwnPRy1HR0RCiBubRoBUG92veqRl54w==
+hed-validator@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/hed-validator/-/hed-validator-1.1.2.tgz#22dcd87e1c85aa31b2b5e385ba106fec242248ef"
+  integrity sha512-RoLqtSlCtaYnDxpSRA5sqwcOO7dg5nhtGIUrc5OTZDD4JIJ77gDlKIbRhiNtEYCpBvfjq6T/5hdGYvZwykcSVg==
+  dependencies:
+    date-and-time "^0.9.0"
+    then-request "^6.0.2"
+    xml2js "^0.4.23"
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -10045,7 +10054,7 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-then-request@^6.0.0:
+then-request@^6.0.0, then-request@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/then-request/-/then-request-6.0.2.tgz#ec18dd8b5ca43aaee5cb92f7e4c1630e950d4f0c"
   integrity sha512-3ZBiG7JvP3wbDzA9iNY5zJQcHL4jn/0BWtXIkagfz7QgOL/LqjCEOBQuJNZfu0XYnv5JhKh+cDxCPM4ILrqruA==
@@ -10787,6 +10796,19 @@ xml2js@0.4.19:
   dependencies:
     sax ">=0.6.0"
     xmlbuilder "~9.0.1"
+
+xml2js@^0.4.23:
+  version "0.4.23"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
+  integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~11.0.0"
+
+xmlbuilder@~11.0.0:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
+  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
 
 xmlbuilder@~9.0.1:
   version "9.0.7"


### PR DESCRIPTION
Now supported for TSV units:
- '*' or '⋅' for multiplication
- '/' for division
- superscript notation (⁻⁰¹²³⁴⁵⁶⁷⁸⁹) or '^' followed by an integer value for exponentiation