### PR TITLE
820 participant rows bugfix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,10 +9,10 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - npm-deps-{{ checksum "package.json" }}
+            - npm-deps-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
       - run: yarn
       - save_cache:
-          key: npm-deps-{{ checksum "package.json" }}
+          key: npm-deps-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
           paths: node_modules
       - run:
           name: Eslint
@@ -49,7 +49,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - npm-deps-{{ checksum "package.json" }}
+            - npm-deps-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
       - run: apk --no-cache add rsync git python build-base openssh
       - run:
           name: Install bids-validator and bids-validator-web dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: node:12.14.1-alpine
+      - image: node:13.7.0-alpine
     steps:
       - run: apk --no-cache add ca-certificates git openssh-client
       - checkout

--- a/bids-validator/tests/tsv.spec.js
+++ b/bids-validator/tests/tsv.spec.js
@@ -127,7 +127,7 @@ describe('TSV', function() {
   it('should not allow participants.tsv files without participant_id columns', function() {
     var tsv =
       'subject_id\theader-two\theader-three\n' +
-      'value-one\tvalue-two\tvalue-three'
+      'sub-one\tvalue-two\tvalue-three'
     validate.TSV.TSV(participantsFile, tsv, [], function(issues) {
       assert(issues.length === 1 && issues[0].code === 48)
     })
@@ -136,7 +136,7 @@ describe('TSV', function() {
   it('should allow a valid participants.tsv file', function() {
     var tsv =
       'participant_id\theader-two\theader-three\n' +
-      'value-one\tvalue-two\tvalue-three'
+      'sub-one\tvalue-two\tvalue-three'
     validate.TSV.TSV(participantsFile, tsv, [], function(issues) {
       assert.deepEqual(issues, [])
     })
@@ -149,13 +149,23 @@ describe('TSV', function() {
     })
   })
 
+  it('should ensure all subjects in the participant_id column include prefix `sub-`', function() {
+    var tsv =
+      'participant_id\theader-two\tage\n' +
+      'sub-01\tvalue-two\t7\n' +
+      '02\tvalue-three\t8'
+    validate.TSV.TSV(participantsFile, tsv, [], function(issues) {
+      assert(issues.length === 1 && issues[0].code === 125)
+    })
+  })
+
   it('should not allow duplicate participant_ids in participants.tsv file', function() {
     var tsv =
       'participant_id\theader-two\tage\n' +
       'sub-01\tvalue-two\t7\n' +
       'sub-01\tvalue-three\t8'
     validate.TSV.TSV(participantsFile, tsv, [], function(issues) {
-      assert(issues.length === 1 && issues[0].code === 125)
+      assert(issues.length === 1 && issues[0].code === 126)
     })
   })
 

--- a/bids-validator/tests/tsv.spec.js
+++ b/bids-validator/tests/tsv.spec.js
@@ -149,6 +149,16 @@ describe('TSV', function() {
     })
   })
 
+  it('should not allow duplicate participant_ids in participants.tsv file', function() {
+    var tsv =
+      'participant_id\theader-two\tage\n' +
+      'sub-01\tvalue-two\t7\n' +
+      'sub-01\tvalue-three\t8'
+    validate.TSV.TSV(participantsFile, tsv, [], function(issues) {
+      assert(issues.length === 1 && issues[0].code === 125)
+    })
+  })
+
   // _scans checks -----------------------------------------------------------------
 
   var scansFile = {

--- a/bids-validator/tests/tsv.spec.js
+++ b/bids-validator/tests/tsv.spec.js
@@ -155,7 +155,7 @@ describe('TSV', function() {
       'sub-01\tvalue-two\t7\n' +
       '02\tvalue-three\t8'
     validate.TSV.TSV(participantsFile, tsv, [], function(issues) {
-      assert(issues.length === 1 && issues[0].code === 125)
+      assert(issues.length === 1 && issues[0].code === 126)
     })
   })
 
@@ -165,7 +165,7 @@ describe('TSV', function() {
       'sub-01\tvalue-two\t7\n' +
       'sub-01\tvalue-three\t8'
     validate.TSV.TSV(participantsFile, tsv, [], function(issues) {
-      assert(issues.length === 1 && issues[0].code === 126)
+      assert(issues.length === 1 && issues[0].code === 127)
     })
   })
 

--- a/bids-validator/utils/issues/list.js
+++ b/bids-validator/utils/issues/list.js
@@ -697,4 +697,10 @@ export default {
     reason:
       'Units in .tsv files must be valid SI units as described in the BIDS spec Appendix V (https://bids-specification.readthedocs.io/en/stable/99-appendices/05-units.html).'
   },
+  125: {
+    key: 'DUPLICATE ',
+    severity: 'error',
+    reason:
+      'Each participant needs to be described by one and only one row. If the dataset includes multiple sets of participant level measurements (e.g. responses from multiple questionnaires), they can be split into individual files separate from participants.tsv. More Info: (https://bids-specification.readthedocs.io/en/stable/03-modality-agnostic-files.html#participants-file).'
+  },
 }

--- a/bids-validator/utils/issues/list.js
+++ b/bids-validator/utils/issues/list.js
@@ -698,12 +698,18 @@ export default {
       'Units in .tsv files must be valid SI units as described in the BIDS spec Appendix V (https://bids-specification.readthedocs.io/en/stable/99-appendices/05-units.html).'
   },
   125: {
+    key: 'CHANNELS_COLUMN_STATUS',
+    severity: 'error',
+    reason:
+      'Status column in channels.tsv files must contain only one of two values: good or bad. Per the BIDS spec: (https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/04-intracranial-electroencephalography.html#channels-description-_channelstsv).'
+  },
+  126: {
     key: 'MISSING_SUB_PREFIX',
     severity: 'error',
     reason:
       'All subject IDs in the participant_id column must be prefixed `sub-`, as follows: `sub-<label>`. More Info: (https://bids-specification.readthedocs.io/en/stable/03-modality-agnostic-files.html#participants-file).'
   },
-  126: {
+  127: {
     key: 'DUPLICATE_PARTICIPANT_ID',
     severity: 'error',
     reason:

--- a/bids-validator/utils/issues/list.js
+++ b/bids-validator/utils/issues/list.js
@@ -698,7 +698,13 @@ export default {
       'Units in .tsv files must be valid SI units as described in the BIDS spec Appendix V (https://bids-specification.readthedocs.io/en/stable/99-appendices/05-units.html).'
   },
   125: {
-    key: 'DUPLICATE ',
+    key: 'MISSING_SUB_PREFIX',
+    severity: 'error',
+    reason:
+      'All subject IDs in the participant_id column must be prefixed `sub-`, as follows: `sub-<label>`. More Info: (https://bids-specification.readthedocs.io/en/stable/03-modality-agnostic-files.html#participants-file).'
+  },
+  126: {
+    key: 'DUPLICATE_PARTICIPANT_ID',
     severity: 'error',
     reason:
       'Each participant needs to be described by one and only one row. If the dataset includes multiple sets of participant level measurements (e.g. responses from multiple questionnaires), they can be split into individual files separate from participants.tsv. More Info: (https://bids-specification.readthedocs.io/en/stable/03-modality-agnostic-files.html#participants-file).'

--- a/bids-validator/validators/tsv/tsv.js
+++ b/bids-validator/validators/tsv/tsv.js
@@ -193,13 +193,14 @@ const TSV = (file, contents, fileList, callback) => {
         if (!row || /^\s*$/.test(row)) {
           continue
         }
+        // participant_id must begin with prefix 'sub-'
         if (!row[participantIdColumn].startsWith('sub-')) {
           issues.push(
             new Issue({
               file: file,
               evidence: row[participantIdColumn],
               line: l,
-              code: 125,
+              code: 126,
             }),
           )
         }
@@ -207,13 +208,14 @@ const TSV = (file, contents, fileList, callback) => {
         if (participant == 'emptyroom') {
           continue
         }
+        // enforce one row per participant_id
         participants.includes(participant)
           ? issues.push(
               new Issue({
                 file: file,
                 evidence: participant,
                 line: l,
-                code: 126,
+                code: 127,
               }),
             )
           : participants.push(participant)

--- a/bids-validator/validators/tsv/tsv.js
+++ b/bids-validator/validators/tsv/tsv.js
@@ -193,6 +193,16 @@ const TSV = (file, contents, fileList, callback) => {
         if (!row || /^\s*$/.test(row)) {
           continue
         }
+        if (!row[participantIdColumn].startsWith('sub-')) {
+          issues.push(
+            new Issue({
+              file: file,
+              evidence: row[participantIdColumn],
+              line: l,
+              code: 125,
+            }),
+          )
+        }
         const participant = row[participantIdColumn].replace('sub-', '')
         if (participant == 'emptyroom') {
           continue
@@ -203,7 +213,7 @@ const TSV = (file, contents, fileList, callback) => {
                 file: file,
                 evidence: participant,
                 line: l,
-                code: 125,
+                code: 126,
               }),
             )
           : participants.push(participant)

--- a/bids-validator/validators/tsv/tsv.js
+++ b/bids-validator/validators/tsv/tsv.js
@@ -197,7 +197,16 @@ const TSV = (file, contents, fileList, callback) => {
         if (participant == 'emptyroom') {
           continue
         }
-        participants.push(participant)
+        participants.includes(participant)
+          ? issues.push(
+              new Issue({
+                file: file,
+                evidence: participant,
+                line: l,
+                code: 125,
+              }),
+            )
+          : participants.push(participant)
       }
     }
   }


### PR DESCRIPTION
1. Disallows duplicate `participant_id`s in `participants.tsv`.
2. Requires `sub-` prefix on all `participant_id`s in `participants.tsv`.

NOTE: Per Ross' comment, the most recent commit preemptively resolves the merge conflict with #787 by including issue id no.125 as a shared entry among both branches.