### PR TITLE
the tag prefix changed? 

### DIFF
--- a/bids-validator/bids_validator/_version.py
+++ b/bids-validator/bids_validator/_version.py
@@ -41,7 +41,7 @@ def get_config():
     cfg = VersioneerConfig()
     cfg.VCS = "git"
     cfg.style = "pep440"
-    cfg.tag_prefix = "bids-validator@"
+    cfg.tag_prefix = "v"
     cfg.parentdir_prefix = ""
     cfg.versionfile_source = "bids_validator/_version.py"
     cfg.verbose = False

--- a/bids-validator/setup.cfg
+++ b/bids-validator/setup.cfg
@@ -34,5 +34,5 @@ VCS = git
 style = pep440
 versionfile_source = bids_validator/_version.py
 versionfile_build = bids_validator/_version.py
-tag_prefix = bids-validator@
+tag_prefix = v
 parentdir_prefix =


### PR DESCRIPTION
New tag generation seems to use 'v' as a prefix instead of 'bids-validator@'