### PR TITLE
Fix CI for GitLab's new Windows runners

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,6 +9,10 @@ tests:
   stage: test
   tags:
     - windows
+  before_script:
+    - Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
+    - choco install -y yarn
+    - refreshenv
   script:
     - yarn
     - yarn jest --testTimeout 30000


### PR DESCRIPTION
This will let us drop the custom runner for Windows builds now that Gitlab offers some [free Windows CI time](https://about.gitlab.com/releases/2020/01/22/gitlab-12-7-released/#windows-shared-runners-on-gitlabcom-beta) to open source projects.