### PR TITLE
Repitition time test: Evidence for Issue type should be a string.

### DIFF
--- a/bids-validator/validators/nifti/nii.js
+++ b/bids-validator/validators/nifti/nii.js
@@ -336,7 +336,7 @@ export default function NIFTI(
             new Issue({
               file: file,
               code: 66,
-              evidence: valuesGreaterThanRepetitionTime,
+              evidence: valuesGreaterThanRepetitionTime.join(', '),
             }),
           )
         }


### PR DESCRIPTION
Validation on OpenNeuro requires the evidence field to be string-like and an array of floats leads to a schema error when validating datasets which fail the SLICETIMING_VALUES_GREATOR_THAN_REPETITION_TIME test. I think we should try to be consistent about evidence being a string.