### PR TITLE
DOC: Add Zenodo badge and initial .zenodo.json

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,13 @@
+{
+  "title": "bids-validator",
+  "description": "The bids-validator is a software tool to check neuroimaging datasets for adherence to the Brain Imaging Data Structure (BIDS) format. More information about BIDS can be found at <a href=\"https://bids.neuroimaging.io\">bids.neuroimaging.io</a>.",
+  "keywords": [
+    "BIDS",
+    "brain imaging data structure",
+    "neuroscience",
+    "neuroimaging",
+    "neuroinformatics",
+  ],
+  "license": "mit-license",
+  "upload_type": "software"
+}

--- a/bids-validator/README.md
+++ b/bids-validator/README.md
@@ -1,5 +1,7 @@
-![](https://circleci.com/gh/bids-standard/bids-validator.svg?style=shield&circle-token=:circle-token)
-![](https://codecov.io/gh/bids-standard/bids-validator/branch/master/graph/badge.svg)
+![Tests](https://circleci.com/gh/bids-standard/bids-validator.svg?style=shield&circle-token=:circle-token)
+![Coverage](https://codecov.io/gh/bids-standard/bids-validator/branch/master/graph/badge.svg)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3688707.svg)](https://doi.org/10.5281/zenodo.3688707)
+
 
 # BIDS-Validator
 


### PR DESCRIPTION
closes #781 

what's missing from `.zenodo.json` is the `creators` field to determine authors, their order, affiliations, and possibly ORCIDs.

We should probably use a script like this one in pybids: https://github.com/bids-standard/pybids/blob/master/tools/prep_zenodo.py

supplinyg a `.zenodo.json` without a `creators` field may result in either:
- zenodo's default creator parsing is preserved and displayed
- zenodo interprets this as "no creators"

I hope it's the first of these options, but I failed to find out for sure, because this is not very well documented anywhere.