### PR TITLE
Circle: Checkout full bids-examples history for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
           command: yarn lint
       - run:
           name: Test Data
-          command: git submodule update --init --depth 1
+          command: git submodule update --init
       - run:
           name: Jest tests
           command: yarn coverage --maxWorkers=2


### PR DESCRIPTION
This prevents tests from failing if the submodule is changed and CircleCI reuses an existing checkout.

#910 should fix this build on Windows too.