### PR TITLE
prefix for micro can be either 'GREEK SMALL LETTER MU' or 'MICRO SIGN'

### DIFF
--- a/bids-validator/utils/unit.js
+++ b/bids-validator/utils/unit.js
@@ -89,6 +89,7 @@ const prefixes = [
   'milli',
   'm',
   'micro',
+  'μ',
   'µ',
   'nano',
   'n',


### PR DESCRIPTION
I'm getting an error from the validator regarding the SI units in a _channels.tsv file:
`Subunit (μV) of unit μV is invalid.`

The units in my channels.tsv file are in the from `μV` (`'GREEK SMALL LETTER MU'` in Unicode) while the BIDS validator only allows for `µV` (`'MICRO SIGN'`). However according to the [Unicode consortium](https://unicode.org/reports/tr25/) (and the [page linked](https://www.wikiwand.com/en/Micro-) on the bids-specification), the preferred sign is `μ` (`'GREEK SMALL LETTER MU'`) while `µ` (`'MICRO SIGN'`) should also be recognized.

This PR adds `μ` (`'GREEK SMALL LETTER MU'`) to the list of acceptable prefixes.