### PR TITLE
Fix CI-only test failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,8 @@ version: 2
 jobs:
   test:
     docker:
-      - image: node:12.14.1-alpine
+      - image: node:12.16.1
     steps:
-      - run: apk --no-cache add ca-certificates git openssh-client
       - checkout
       - restore_cache:
           keys:

--- a/bids-validator/tests/bids.spec.js
+++ b/bids-validator/tests/bids.spec.js
@@ -128,7 +128,7 @@ describe('BIDS example datasets ', function() {
       assert.isFalse(summary.dataProcessed)
       assert(summary.modalities.includes('T1w'))
       assert(summary.modalities.includes('bold'))
-      assert(summary.totalFiles === 8)
+      expect(summary.totalFiles).toEqual(8)
       assert(
         errors.findIndex(error => error.code === 60) > -1,
         'errors do not contain a code 60',

--- a/bids-validator/utils/files/readDir.js
+++ b/bids-validator/utils/files/readDir.js
@@ -260,8 +260,7 @@ async function getFilesFromGitTree(dir, ig, options) {
  * Recursive helper function for 'preprocessNode'
  */
 async function getFilesFromFs(dir, rootPath, ig, options) {
-  let files
-  files = await fs.promises.readdir(dir, { withFileTypes: true })
+  const files = await fs.promises.readdir(dir, { withFileTypes: true })
   const filesAccumulator = []
   // Closure to merge the next file depth into this one
   const recursiveMerge = async nextRoot => {
@@ -325,10 +324,8 @@ async function getBIDSIgnore(dir) {
 
   const bidsIgnoreFileObj = getBIDSIgnoreFileObj(dir)
   if (bidsIgnoreFileObj) {
-    return readFile(bidsIgnoreFileObj).then(content => {
-      ig.add(content)
-      return ig
-    })
+    const content = await readFile(bidsIgnoreFileObj)
+    ig.add(content)
   }
   return ig
 }
@@ -339,35 +336,31 @@ async function getBIDSIgnore(dir) {
  * @returns File object or null if not found
  */
 function getBIDSIgnoreFileObj(dir) {
-  var bidsIgnoreFileObj = null
   if (isNode) {
-    bidsIgnoreFileObj = getBIDSIgnoreFileObjNode(dir)
+    return getBIDSIgnoreFileObjNode(dir)
   } else {
-    bidsIgnoreFileObj = getBIDSIgnoreFileObjBrowser(dir)
+    return getBIDSIgnoreFileObjBrowser(dir)
   }
-  return bidsIgnoreFileObj
 }
 
 function getBIDSIgnoreFileObjNode(dir) {
-  var bidsIgnoreFileObj = null
-  var path = dir + '/.bidsignore'
-  if (fs.existsSync(path)) {
-    bidsIgnoreFileObj = { path: path, stats: { size: null } }
+  const path = dir + '/.bidsignore'
+  try {
+    fs.accessSync(path)
+    return { path: path, stats: { size: null } }
+  } catch (err) {
+    return null
   }
-  return bidsIgnoreFileObj
 }
 
 function getBIDSIgnoreFileObjBrowser(dir) {
-  var bidsIgnoreFileObj = null
   for (var i = 0; i < dir.length; i++) {
-    var fileObj = dir[i]
-    var relativePath = harmonizeRelativePath(fileObj.webkitRelativePath)
+    const fileObj = dir[i]
+    const relativePath = harmonizeRelativePath(fileObj.webkitRelativePath)
     if (relativePath === '/.bidsignore') {
-      bidsIgnoreFileObj = fileObj
-      break
+      return fileObj
     }
   }
-  return bidsIgnoreFileObj
 }
 
 export {

--- a/bids-validator/utils/files/readFile.js
+++ b/bids-validator/utils/files/readFile.js
@@ -39,18 +39,17 @@ function readFile(file, annexed, dir) {
         }
         if (!remoteBuffer) {
           fs.readFile(file.path, function(err, data) {
-            process.nextTick(function() {
-              checkEncoding(file, data, ({ isUtf8 }) => {
-                if (!isUtf8) reject(new Issue({ code: 123, file }))
-              })
-              return resolve(data.toString('utf8'))
+            if (err) {
+              return reject(err)
+            }
+            checkEncoding(file, data, ({ isUtf8 }) => {
+              if (!isUtf8) reject(new Issue({ code: 123, file }))
             })
+            return resolve(data.toString('utf8'))
           })
         }
         if (remoteBuffer) {
-          process.nextTick(function() {
-            return resolve(remoteBuffer.toString('utf8'))
-          })
+          return resolve(remoteBuffer.toString('utf8'))
         }
       })
     } else {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "scripts": {
     "lint": "./node_modules/eslint/bin/eslint.js ./bids-validator/**/*.js",
-    "coverage": "NODE_OPTIONS=--no-warnings ./node_modules/.bin/jest --coverage",
+    "coverage": "./node_modules/.bin/jest --coverage",
     "codecov": "./node_modules/.bin/codecov",
     "test": "bids-validator/bin/test-submodule-exists && jest",
     "npmPublish": "cd bids-validator && publish",


### PR DESCRIPTION
Resolves #909 

I narrowed this down to the fs.existsSync call in getBIDSIgnoreFileObjNode returning undefined intermittently on CircleCI. It's supposed to return true or false, and not bubble up any underlying errors. So this seems like a Node.js bug but the recommended approach is to use fs.access with F_OK (the default) option instead. Switching this test to fs.access does seem to resolve this issue without hacky timer workarounds.

This PR also includes a few simplifications of the call path for loading .bidsignore under Node.js, enables Node warnings for the test suite, and switches CI over to a newer Debian based Node LTS container image.