### PR TITLE
add links to CI badges

### DIFF
--- a/bids-validator/README.md
+++ b/bids-validator/README.md
@@ -1,5 +1,5 @@
-![Tests](https://circleci.com/gh/bids-standard/bids-validator.svg?style=shield&circle-token=:circle-token)
-![Coverage](https://codecov.io/gh/bids-standard/bids-validator/branch/master/graph/badge.svg)
+[![CircleCI](https://circleci.com/gh/bids-standard/bids-validator.svg?style=svg)](https://circleci.com/gh/bids-standard/bids-validator)
+[![Codecov](https://codecov.io/gh/bids-standard/bids-validator/branch/master/graph/badge.svg)](https://codecov.io/gh/bids-standard/bids-validator)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3688707.svg)](https://doi.org/10.5281/zenodo.3688707)
 
 

--- a/bids-validator/README.md
+++ b/bids-validator/README.md
@@ -1,4 +1,4 @@
-[![CircleCI](https://circleci.com/gh/bids-standard/bids-validator.svg?style=svg)](https://circleci.com/gh/bids-standard/bids-validator)
+[![CircleCI](https://circleci.com/gh/bids-standard/bids-validator.svg?style=shield&circle-token=:circle-token)](https://circleci.com/gh/bids-standard/bids-validator)
 [![Codecov](https://codecov.io/gh/bids-standard/bids-validator/branch/master/graph/badge.svg)](https://codecov.io/gh/bids-standard/bids-validator)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3688707.svg)](https://doi.org/10.5281/zenodo.3688707)
 

--- a/bids-validator/README.md
+++ b/bids-validator/README.md
@@ -1,4 +1,5 @@
 [![CircleCI](https://circleci.com/gh/bids-standard/bids-validator.svg?style=shield&circle-token=:circle-token)](https://circleci.com/gh/bids-standard/bids-validator)
+[![Gitlab pipeline status](https://img.shields.io/gitlab/pipeline/bids-standard/bids-validator?logo=GitLab)](https://gitlab.com/bids-standard/bids-validator/pipelines)
 [![Codecov](https://codecov.io/gh/bids-standard/bids-validator/branch/master/graph/badge.svg)](https://codecov.io/gh/bids-standard/bids-validator)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3688707.svg)](https://doi.org/10.5281/zenodo.3688707)
 


### PR DESCRIPTION
With this PR, the CI badges are now clickable and will direct a user to the CI page.

@nellh is it possible to get a badge for the Windows tests? Is this the right page? https://gitlab.com/bids-standard/bids-validator/-/jobs