### PR TITLE
Fix TSV checks returning arrays for evidence values

### DIFF
--- a/bids-validator/utils/issues/issue.js
+++ b/bids-validator/utils/issues/issue.js
@@ -17,8 +17,20 @@ const constructHelpUrl = issue => {
  * Issue
  *
  * A constructor for BIDS issues.
+ *
+ * @param {Object} options
+ * @param {string} options.key The descriptive string matching the issue code
+ * @param {number} options.code Issue code - see 'list.js' for definitions
+ * @param {string} [options.file] The relative path of the affected file
+ * @param {string} [options.evidence] The value throwing this issue
+ * @param {number} [options.line] The line of the affected file (if within a file)
+ * @param {number} [options.character] The character offset in the affected line
+ * @param {string} [options.severity] Is this an error or warning?
+ * @param {string} [options.reason] A descriptive
+ * @param {string} [options.helpUrl] A URL providing documentation to help solve this error
+ * @returns {Object} Issue object
  */
-export default function(options) {
+function Issue(options) {
   const code = options.hasOwnProperty('code') ? options.code : null
   const issue = issues[code]
 
@@ -36,3 +48,5 @@ export default function(options) {
   this.reason = options.hasOwnProperty('reason') ? options.reason : issue.reason
   this.helpUrl = constructHelpUrl(issue)
 }
+
+export default Issue

--- a/bids-validator/validators/tsv/tsv.js
+++ b/bids-validator/validators/tsv/tsv.js
@@ -1,9 +1,16 @@
 import utils from '../../utils'
-const Issue = utils.issues.Issue
+import Issue from '../../utils/issues/issue'
 import checkAcqTimeFormat from './checkAcqTimeFormat'
 import checkAge89 from './checkAge89'
 import checkStatusCol from './checkStatusCol'
 import parseTSV from './tsvParser'
+
+/**
+ * Format TSV headers for evidence string
+ * @param {Array[string]} headers
+ * @returns {string}
+ */
+const headersEvidence = headers => `Column headers: ${headers.join(', ')}`
 
 /**
  * TSV
@@ -98,7 +105,7 @@ const TSV = (file, contents, fileList, callback) => {
       issues.push(
         new Issue({
           file: file,
-          evidence: headers,
+          evidence: headersEvidence(headers),
           line: 1,
           character: rows[0].indexOf(headers[idx]),
           code: code,
@@ -113,7 +120,7 @@ const TSV = (file, contents, fileList, callback) => {
       issues.push(
         new Issue({
           file: file,
-          evidence: headers,
+          evidence: headersEvidence(headers),
           line: 1,
           code: 20,
         }),
@@ -123,7 +130,7 @@ const TSV = (file, contents, fileList, callback) => {
       issues.push(
         new Issue({
           file: file,
-          evidence: headers,
+          evidence: headersEvidence(headers),
           line: 1,
           code: 21,
         }),
@@ -181,7 +188,7 @@ const TSV = (file, contents, fileList, callback) => {
       issues.push(
         new Issue({
           file: file,
-          evidence: headers.join('\t'),
+          evidence: headersEvidence(headers),
           line: 1,
           code: 48,
         }),
@@ -287,7 +294,6 @@ const TSV = (file, contents, fileList, callback) => {
   if (file.name === 'participants.tsv') {
     checkAge89(rows, file, issues)
   }
- 
 
   if (file.name.endsWith('_scans.tsv')) {
     // check _scans.tsv for column filename
@@ -296,7 +302,7 @@ const TSV = (file, contents, fileList, callback) => {
         new Issue({
           line: 1,
           file: file,
-          evidence: headers.join('\t'),
+          evidence: headersEvidence(headers),
           code: 68,
         }),
       )


### PR DESCRIPTION
Fixes #943 and related issues found in the TSV checks usage of the evidence field.

I added some documentation to the Issue constructor as well with the hope of enabling JSDoc eslint checks but it's not in this PR as it throws a lot of linting warnings at the moment.