### PR TITLE
[Help Wanted] [BUG] Symbol encoding such as micro causing errors in web validator

### DIFF
--- a/bids-validator/tests/tsv.spec.js
+++ b/bids-validator/tests/tsv.spec.js
@@ -37,7 +37,7 @@ describe('TSV', function() {
   it('should not allow non-SI units', function() {
     var tsv =
       'header-one\tunits\theader-three\n' +
-      'value-one\t\u03BCV\tvalue-three\n' +
+      'value-one\t\xB5V\tvalue-three\n' +
       'value-one\tuV\tvalue-three'
 
     validate.TSV.TSV(file, tsv, [], function(issues) {

--- a/bids-validator/tests/tsv.spec.js
+++ b/bids-validator/tests/tsv.spec.js
@@ -37,7 +37,7 @@ describe('TSV', function() {
   it('should not allow non-SI units', function() {
     var tsv =
       'header-one\tunits\theader-three\n' +
-      'value-one\tµV\tvalue-three\n' +
+      'value-one\t\u03BCV\tvalue-three\n' +
       'value-one\tuV\tvalue-three'
 
     validate.TSV.TSV(file, tsv, [], function(issues) {

--- a/bids-validator/utils/unit.js
+++ b/bids-validator/utils/unit.js
@@ -34,7 +34,7 @@ const roots = [
   'farad',
   'F',
   'ohm',
-  'Ω',
+  '\u03A9',  // Ω
   'siemens',
   'S',
   'weber',
@@ -45,7 +45,7 @@ const roots = [
   'H',
   'degree',
   'Celsius',
-  '°C',
+  '\xB0C',  // °C
   'lumen',
   'lm',
   'lux',
@@ -89,7 +89,7 @@ const prefixes = [
   'milli',
   'm',
   'micro',
-  'µ',
+  '\u03BC',  // µ
   'nano',
   'n',
   'pico',

--- a/bids-validator/utils/unit.js
+++ b/bids-validator/utils/unit.js
@@ -89,7 +89,7 @@ const prefixes = [
   'milli',
   'm',
   'micro',
-  '\xB5C', // µ (micro)
+  '\xB5', // µ (micro)
   'nano',
   'n',
   'pico',

--- a/bids-validator/utils/unit.js
+++ b/bids-validator/utils/unit.js
@@ -89,7 +89,7 @@ const prefixes = [
   'milli',
   'm',
   'micro',
-  '\u03BC', // µ
+  '\xB5C', // µ (micro)
   'nano',
   'n',
   'pico',

--- a/bids-validator/utils/unit.js
+++ b/bids-validator/utils/unit.js
@@ -34,7 +34,7 @@ const roots = [
   'farad',
   'F',
   'ohm',
-  '\u03A9',  // Ω
+  '\u03A9', // Ω
   'siemens',
   'S',
   'weber',
@@ -45,7 +45,7 @@ const roots = [
   'H',
   'degree',
   'Celsius',
-  '\xB0C',  // °C
+  '\xB0C', // °C
   'lumen',
   'lm',
   'lux',
@@ -89,7 +89,7 @@ const prefixes = [
   'milli',
   'm',
   'micro',
-  '\u03BC',  // µ
+  '\u03BC', // µ
   'nano',
   'n',
   'pico',


### PR DESCRIPTION
Resolves https://github.com/mne-tools/mne-bids/issues/394 and some of https://github.com/bids-standard/bids-specification/pull/411#issuecomment-617036529

μV as a unit was throwing an error on the BIDS validators. While I was there, I also changed Ω and ° (in °C) to unicode.