### PR TITLE
Fix null pointer error in HED sidecar loading code

### DIFF
--- a/bids-validator/validators/events/hed.js
+++ b/bids-validator/validators/events/hed.js
@@ -28,7 +28,11 @@ export default function checkHedStrings(events, headers, jsonContents) {
 
     for (const sidecarKey in mergedDictionary) {
       const sidecarValue = mergedDictionary[sidecarKey]
-      if (sidecarValue.HED !== undefined) {
+      if (
+        sidecarValue !== null &&
+        typeof sidecarValue === 'object' &&
+        sidecarValue.HED !== undefined
+      ) {
         sidecarHedTags[sidecarKey] = sidecarValue.HED
       }
     }


### PR DESCRIPTION
This commit fixes an error in the HED sidecar search code where a sidecar entry has a `null` value.

Fixes #956