### PR TITLE
[PYTHON] add cross platform testing and real test case

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,13 +3,29 @@ version: 2
 jobs:
   test_python:
     docker:
-      - image: circleci/python:stretch
+      - image: continuumio/miniconda3
+    environment:
+      BASH_ENV: "/root/.bashrc"
     steps:
       - checkout
-      - run: pip install --user pytest flake8 pydocstyle
-      - run: pytest --doctest-modules bids-validator/bids_validator
-      - run: flake8 bids-validator/bids_validator
-      - run: pydocstyle bids-validator/bids_validator/bids_validator.py
+      - run:
+          name: setup conda
+          command: |
+            conda create -n testenv Python=3.7
+            conda init
+      - run:
+          name: install datalad
+          command: |
+            conda activate testenv
+            conda install -c conda-forge git-annex
+            pip install pytest flake8 pydocstyle datalad
+      - run:
+          name: test python
+          command: |
+            conda activate testenv
+            pytest --doctest-modules bids-validator/bids_validator
+            flake8 bids-validator/bids_validator
+            pydocstyle bids-validator/bids_validator/bids_validator.py
   test:
     docker:
       - image: node:12.16.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,6 @@
 version: 2
 
 jobs:
-  test_python:
-    docker:
-      - image: circleci/python:stretch
-    steps:
-      - checkout
-      - run: pip install --user pytest flake8 pydocstyle
-      - run: pytest --doctest-modules bids-validator/bids_validator
-      - run: flake8 bids-validator/bids_validator
-      - run: pydocstyle bids-validator/bids_validator/bids_validator.py
   test:
     docker:
       - image: node:12.16.1
@@ -154,12 +145,6 @@ workflows:
   version: 2
   build-deploy:
     jobs:
-      - test_python:
-          filters:
-            branches:
-              only: /.*/
-            tags:
-              only: /.*/
       - test:
           filters:
             branches:
@@ -184,7 +169,6 @@ workflows:
               only: /.*/
       - deployment:
           requires:
-            - test_python
             - test
             - test_docker
             - githubPagesTest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,15 @@
 version: 2
 
 jobs:
+  test_python:
+    docker:
+      - image: circleci/python:stretch
+    steps:
+      - checkout
+      - run: pip install --user pytest flake8 pydocstyle
+      - run: pytest --doctest-modules bids-validator/bids_validator
+      - run: flake8 bids-validator/bids_validator
+      - run: pydocstyle bids-validator/bids_validator/bids_validator.py
   test:
     docker:
       - image: node:12.16.1
@@ -145,6 +154,12 @@ workflows:
   version: 2
   build-deploy:
     jobs:
+      - test_python:
+          filters:
+            branches:
+              only: /.*/
+            tags:
+              only: /.*/
       - test:
           filters:
             branches:
@@ -169,6 +184,7 @@ workflows:
               only: /.*/
       - deployment:
           requires:
+            - test_python
             - test
             - test_docker
             - githubPagesTest

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -1,0 +1,44 @@
+name: Python tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.7]
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: goanpeca/setup-miniconda@v1
+      with:
+        auto-update-conda: true
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      shell: bash -l {0}
+      run: |
+        which python
+        conda install -c conda-forge git-annex
+        pip install datalad
+        pip install pytest flake8 pydocstyle
+        pip install -e ./bids-validator
+    - name: Check formatting
+      shell: bash -l {0}
+      run: |
+        which python
+        flake8 bids-validator/bids_validator
+        pydocstyle bids-validator/bids_validator/bids_validator.py
+    - name: Test with pytest
+      shell: bash -l {0}
+      run: |
+        which python
+        pytest --doctest-modules bids-validator/bids_validator

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -23,22 +23,38 @@ jobs:
       with:
         auto-update-conda: true
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+
+    - name: Install git-annex ubuntu
+      if: matrix.platform == 'ubuntu-latest'
+      shell: bash -l {0}
+      run: conda install -c conda-forge git-annex
+
+    - name: Install git-annex macos
+      if: matrix.platform == 'macos-latest'
+      shell: bash -l {0}
+      run: brew install git-annex
+
+    - name: Install git-annex windows
+      if: matrix.platform == 'windows-latest'
+      uses: crazy-max/ghaction-chocolatey@v1
+      with:
+        args: install git-annex --yes --ignore-checksums
+
+    - name: Install remaining dependencies
       shell: bash -l {0}
       run: |
         which python
-        conda install -c conda-forge git-annex
         pip install datalad
         pip install pytest pytest-sugar flake8 pydocstyle
         pip install -e ./bids-validator
+
     - name: Check formatting
       shell: bash -l {0}
       run: |
-        which python
         flake8 bids-validator/bids_validator
         pydocstyle bids-validator/bids_validator/bids_validator.py
+
     - name: Test with pytest
       shell: bash -l {0}
       run: |
-        which python
-        pytest --doctest-modules bids-validator/bids_validator
+        pytest --doctest-modules bids-validator/bids_validator --verbose

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -29,7 +29,7 @@ jobs:
         which python
         conda install -c conda-forge git-annex
         pip install datalad
-        pip install pytest flake8 pydocstyle
+        pip install pytest pytest-sugar flake8 pydocstyle
         pip install -e ./bids-validator
     - name: Check formatting
       shell: bash -l {0}

--- a/bids-validator/bids_validator/test_bids_validator.py
+++ b/bids-validator/bids_validator/test_bids_validator.py
@@ -5,46 +5,48 @@ actual file contents.
 
 """
 import os
+
+import pytest
 import datalad.api
 
 from bids_validator import BIDSValidator
 
+HOME = os.path.expanduser('~')
 
-def test_is_bids():
-    """Test that is_bids returns true for each file in a valid BIDS dataset."""
-    # Download testing data as git annex dataset
-    HOME = os.path.expanduser('~')
-    dspath = os.path.join(HOME, 'eeg_matchingpennies_git_annex')
-    url = 'https://github.com/sappelhoff/eeg_matchingpennies'
+TEST_DATA_DICT = {
+    'eeg_matchingpennies': 'https://github.com/sappelhoff/eeg_matchingpennies'
+    }
+
+EXCLUDE_KEYWORDS = ['git', 'datalad', 'sourcedata', 'bidsignore', 'LICENSE']
+
+
+def _download_test_data(test_data_dict, dsname):
+    """Download test data using datalad."""
+    url = test_data_dict[dsname]
+    dspath = os.path.join(HOME, dsname)
     datalad.api.install(dspath, url)
+    return dspath
 
-    def _exclude_this(fname):
-        """Help to skip certain files from being validated."""
-        exclude_keywords = ['git', 'datalad', 'sourcedata', 'bidsignore']
-        for keyword in exclude_keywords:
-            if keyword in fname:
-                return True
 
-        return False
-
-    # Gather all files
+def _gather_test_files(dspath, exclude_keywords):
+    """Get test files from dataset path, relative to dataset."""
     files = []
     for r, _, f in os.walk(dspath):
         for file in f:
             fname = os.path.join(r, file)
-            if not _exclude_this(fname):
+            fname = fname.replace(dspath, '')
+            if not any(keyword in fname for keyword in exclude_keywords):
                 files.append(fname)
 
-    # Test all files
+    return files
+
+
+dspath = _download_test_data(TEST_DATA_DICT, 'eeg_matchingpennies')
+files = _gather_test_files(dspath, EXCLUDE_KEYWORDS)
+
+
+@pytest.mark.parametrize('fname', files)
+def test_is_bids(fname):
+    """Test that is_bids returns true for each file in a valid BIDS dataset."""
     validator = BIDSValidator()
-    false_decisions = []
-    for file in files:
-        if not validator.is_bids(file):
-            false_decisions.append(file)
-
-    if len(false_decisions) > 0:
-        raise AssertionError('False decisions for the following files: {}'
-                             .format(false_decisions))
-
-    # Sanity check: Does it raise for wrong files?
-    assert not validator.is_bids('bogus')
+    assert validator.is_bids(fname)

--- a/bids-validator/bids_validator/test_bids_validator.py
+++ b/bids-validator/bids_validator/test_bids_validator.py
@@ -1,0 +1,50 @@
+"""Test BIDSValidator functionality.
+
+git-annex and datalad are used to download a test data structure without the
+actual file contents.
+
+"""
+import os
+import datalad.api
+
+from bids_validator import BIDSValidator
+
+
+def test_is_bids():
+    """Test that is_bids returns true for each file in a valid BIDS dataset."""
+    # Download testing data as git annex dataset
+    HOME = os.path.expanduser('~')
+    dspath = os.path.join(HOME, 'eeg_matchingpennies_git_annex')
+    url = 'https://github.com/sappelhoff/eeg_matchingpennies'
+    datalad.api.install(dataset=dspath, source=url)
+
+    def _exclude_this(fname):
+        """Help to skip certain files from being validated."""
+        exclude_keywords = ['git', 'datalad', 'sourcedata', 'bidsignore']
+        for keyword in exclude_keywords:
+            if keyword in fname:
+                return True
+
+        return False
+
+    # Gather all files
+    files = []
+    for r, _, f in os.walk(dspath):
+        for file in f:
+            fname = os.path.join(r, file)
+            if not _exclude_this(fname):
+                files.append(fname)
+
+    # Test all files
+    validator = BIDSValidator()
+    false_decisions = []
+    for file in files:
+        if not validator.is_bids(file):
+            false_decisions.append(file)
+
+    if len(false_decisions) > 0:
+        raise AssertionError('False decisions for the following files: {}'
+                             .format(false_decisions))
+
+    # Sanity check: Does it raise for wrong files?
+    assert not validator.is_bids('bogus')

--- a/bids-validator/bids_validator/test_bids_validator.py
+++ b/bids-validator/bids_validator/test_bids_validator.py
@@ -16,7 +16,7 @@ def test_is_bids():
     HOME = os.path.expanduser('~')
     dspath = os.path.join(HOME, 'eeg_matchingpennies_git_annex')
     url = 'https://github.com/sappelhoff/eeg_matchingpennies'
-    datalad.api.install(dataset=dspath, source=url)
+    datalad.api.install(dspath, url)
 
     def _exclude_this(fname):
         """Help to skip certain files from being validated."""


### PR DESCRIPTION
This PR makes use of GitHub Action to test the `bids_validator` package on all 3 major platforms.

I also add a "proper" test beyond a doctest, where I use datalad and git annex to get a test data skeleton and then validate the file names.

~Originally I expected this PR to fail on Windows (#959), so that we can start fixing the issue ... but it seems like it works fine?~

EDIT: the reason windows passed was that I let it validate an empty file list :man_facepalming:  ... fixed in https://github.com/bids-standard/bids-validator/pull/966/commits/f715b898fb2c6cc9d2f4248e1f2c6b95bcea97cd --> so now we do replicate the issue from #959 and once we merge this PR we can start fixing it :slightly_smiling_face: 

cc @MaxvandenBoom 