### PR TITLE
Fix symlink test on Windows

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,6 @@
 variables:
   GIT_STRATEGY: fetch
+  GIT_CHECKOUT: "false"
   GIT_SUBMODULE_STRATEGY: normal
   NODE_OPTIONS: --no-warnings
 stages:
@@ -14,5 +15,8 @@ tests:
     - choco install -y yarn
     - refreshenv
   script:
+    - git config core.symlinks true
+    - git checkout $CI_COMMIT_REF_NAME
+    - git submodule update --init --depth 1
     - yarn
     - yarn jest --testTimeout 30000


### PR DESCRIPTION
closes #926

@sappelhoff The reason this would fail hit me when I saw your comment in #926.

This fixes the test suite on Windows by working around GitLab CI's default of `core.symlinks=false` during checkout on Windows.