### PR TITLE
[MRG] Add error message if scans.tsv filenames are not all present in the dataset.

### DIFF
--- a/bids-validator/tests/data/valid_dataset/sub-01/ses-01/sub-01_ses-01_scans.tsv
+++ b/bids-validator/tests/data/valid_dataset/sub-01/ses-01/sub-01_ses-01_scans.tsv
@@ -1,5 +1,5 @@
 filename	acq_time
-anat/sub-01_ses-01_T1w.nii.gz	1880-01-10T05:17:54
-func/sub-01_ses-01_task-nback_run-01_bold.nii.gz	1880-01-10T05:22:54
-func/sub-01_ses-01_task-nback_run-02_bold.nii.gz	1880-01-10T05:37:54
-func/sub-01_ses-01_task-rest_bold.nii.gz	1880-01-10T05:52:54
+anat/sub-01_ses-01_T1w.nii	1880-01-10T05:17:54
+func/sub-01_ses-01_task-nback_run-01_bold.nii	1880-01-10T05:22:54
+func/sub-01_ses-01_task-nback_run-02_bold.nii	1880-01-10T05:37:54
+func/sub-01_ses-01_task-rest_bold.nii	1880-01-10T05:52:54

--- a/bids-validator/tests/data/valid_dataset/sub-01/ses-02/sub-01_ses-02_scans.tsv
+++ b/bids-validator/tests/data/valid_dataset/sub-01/ses-02/sub-01_ses-02_scans.tsv
@@ -1,5 +1,5 @@
 filename	acq_time
-anat/sub-01_ses-02_T1w.nii.gz	1802-06-04T22:54:25
-func/sub-01_ses-02_task-nback_run-01_bold.nii.gz	1802-06-04T22:59:25
-func/sub-01_ses-02_task-nback_run-02_bold.nii.gz	1802-06-04T23:14:25
-func/sub-01_ses-02_task-rest_bold.nii.gz	1802-06-04T23:29:25
+anat/sub-01_ses-02_T1w.nii	1802-06-04T22:54:25
+func/sub-01_ses-02_task-nback_run-01_bold.nii	1802-06-04T22:59:25
+func/sub-01_ses-02_task-nback_run-02_bold.nii	1802-06-04T23:14:25
+func/sub-01_ses-02_task-rest_bold.nii	1802-06-04T23:29:25

--- a/bids-validator/tests/data/valid_dataset/sub-02/ses-01/sub-02_ses-01_scans.tsv
+++ b/bids-validator/tests/data/valid_dataset/sub-02/ses-01/sub-02_ses-01_scans.tsv
@@ -1,5 +1,5 @@
 filename	acq_time
-anat/sub-02_ses-01_T1w.nii.gz	1874-04-12T01:43:17
-func/sub-02_ses-01_task-nback_run-01_bold.nii.gz	1874-04-12T01:48:17
-func/sub-02_ses-01_task-nback_run-02_bold.nii.gz	1874-04-12T02:03:17
-func/sub-02_ses-01_task-rest_bold.nii.gz	1874-04-12T02:18:17
+anat/sub-02_ses-01_T1w.nii	1874-04-12T01:43:17
+func/sub-02_ses-01_task-nback_run-01_bold.nii	1874-04-12T01:48:17
+func/sub-02_ses-01_task-nback_run-02_bold.nii	1874-04-12T02:03:17
+func/sub-02_ses-01_task-rest_bold.nii	1874-04-12T02:18:17

--- a/bids-validator/tests/data/valid_dataset/sub-02/ses-02/sub-02_ses-02_scans.tsv
+++ b/bids-validator/tests/data/valid_dataset/sub-02/ses-02/sub-02_ses-02_scans.tsv
@@ -1,5 +1,5 @@
 filename	acq_time
-anat/sub-02_ses-02_T1w.nii.gz	1814-09-10T07:05:33
-func/sub-02_ses-02_task-nback_run-01_bold.nii.gz	1814-09-10T07:10:33
-func/sub-02_ses-02_task-nback_run-02_bold.nii.gz	1814-09-10T07:25:33
-func/sub-02_ses-02_task-rest_bold.nii.gz	1814-09-10T07:40:33
+anat/sub-02_ses-02_T1w.nii	1814-09-10T07:05:33
+func/sub-02_ses-02_task-nback_run-01_bold.nii	1814-09-10T07:10:33
+func/sub-02_ses-02_task-nback_run-02_bold.nii	1814-09-10T07:25:33
+func/sub-02_ses-02_task-rest_bold.nii	1814-09-10T07:40:33

--- a/bids-validator/tests/data/valid_dataset/sub-03/ses-01/sub-03_ses-01_scans.tsv
+++ b/bids-validator/tests/data/valid_dataset/sub-03/ses-01/sub-03_ses-01_scans.tsv
@@ -1,5 +1,5 @@
 filename	acq_time
-anat/sub-03_ses-01_T1w.nii.gz	1852-10-11T23:35:34
-func/sub-03_ses-01_task-nback_run-01_bold.nii.gz	1852-10-11T23:40:34
-func/sub-03_ses-01_task-nback_run-02_bold.nii.gz	1852-10-11T23:55:34
-func/sub-03_ses-01_task-rest_bold.nii.gz	1852-10-12T00:10:34
+anat/sub-03_ses-01_T1w.nii	1852-10-11T23:35:34
+func/sub-03_ses-01_task-nback_run-01_bold.nii	1852-10-11T23:40:34
+func/sub-03_ses-01_task-nback_run-02_bold.nii	1852-10-11T23:55:34
+func/sub-03_ses-01_task-rest_bold.nii	1852-10-12T00:10:34

--- a/bids-validator/tests/data/valid_dataset/sub-03/ses-02/sub-03_ses-02_scans.tsv
+++ b/bids-validator/tests/data/valid_dataset/sub-03/ses-02/sub-03_ses-02_scans.tsv
@@ -1,5 +1,5 @@
 filename	acq_time
-anat/sub-03_ses-02_T1w.nii.gz	1843-04-22T00:23:54
-func/sub-03_ses-02_task-nback_run-01_bold.nii.gz	1843-04-22T00:28:54
-func/sub-03_ses-02_task-nback_run-02_bold.nii.gz	1843-04-22T00:43:54
-func/sub-03_ses-02_task-rest_bold.nii.gz	1843-04-22T00:58:54
+anat/sub-03_ses-02_T1w.nii	1843-04-22T00:23:54
+func/sub-03_ses-02_task-nback_run-01_bold.nii	1843-04-22T00:28:54
+func/sub-03_ses-02_task-nback_run-02_bold.nii	1843-04-22T00:43:54
+func/sub-03_ses-02_task-rest_bold.nii	1843-04-22T00:58:54

--- a/bids-validator/tests/data/valid_dataset/sub-04/ses-01/sub-04_ses-01_scans.tsv
+++ b/bids-validator/tests/data/valid_dataset/sub-04/ses-01/sub-04_ses-01_scans.tsv
@@ -1,5 +1,5 @@
 filename	acq_time
-anat/sub-04_ses-01_T1w.nii.gz	1800-05-21T11:18:59
-func/sub-04_ses-01_task-nback_run-01_bold.nii.gz	1800-05-21T11:23:59
-func/sub-04_ses-01_task-nback_run-02_bold.nii.gz	1800-05-21T11:38:59
-func/sub-04_ses-01_task-rest_bold.nii.gz	1800-05-21T11:53:59
+anat/sub-04_ses-01_T1w.nii	1800-05-21T11:18:59
+func/sub-04_ses-01_task-nback_run-01_bold.nii	1800-05-21T11:23:59
+func/sub-04_ses-01_task-nback_run-02_bold.nii	1800-05-21T11:38:59
+func/sub-04_ses-01_task-rest_bold.nii	1800-05-21T11:53:59

--- a/bids-validator/tests/data/valid_dataset/sub-04/ses-02/sub-04_ses-02_scans.tsv
+++ b/bids-validator/tests/data/valid_dataset/sub-04/ses-02/sub-04_ses-02_scans.tsv
@@ -1,5 +1,5 @@
 filename	acq_time
-anat/sub-04_ses-02_T1w.nii.gz	1847-10-17T10:15:19
-func/sub-04_ses-02_task-nback_run-01_bold.nii.gz	1847-10-17T10:20:19
-func/sub-04_ses-02_task-nback_run-02_bold.nii.gz	1847-10-17T10:35:19
-func/sub-04_ses-02_task-rest_bold.nii.gz	1847-10-17T10:50:19
+anat/sub-04_ses-02_T1w.nii	1847-10-17T10:15:19
+func/sub-04_ses-02_task-nback_run-01_bold.nii	1847-10-17T10:20:19
+func/sub-04_ses-02_task-nback_run-02_bold.nii	1847-10-17T10:35:19
+func/sub-04_ses-02_task-rest_bold.nii	1847-10-17T10:50:19

--- a/bids-validator/tests/data/valid_dataset/sub-05/ses-01/sub-05_ses-01_scans.tsv
+++ b/bids-validator/tests/data/valid_dataset/sub-05/ses-01/sub-05_ses-01_scans.tsv
@@ -1,5 +1,5 @@
 filename	acq_time
-anat/sub-05_ses-01_T1w.nii.gz	1899-07-07T16:04:21
-func/sub-05_ses-01_task-nback_run-01_bold.nii.gz	1899-07-07T16:09:21
-func/sub-05_ses-01_task-nback_run-02_bold.nii.gz	1899-07-07T16:24:21
-func/sub-05_ses-01_task-rest_bold.nii.gz	1899-07-07T16:39:21
+anat/sub-05_ses-01_T1w.nii	1899-07-07T16:04:21
+func/sub-05_ses-01_task-nback_run-01_bold.nii	1899-07-07T16:09:21
+func/sub-05_ses-01_task-nback_run-02_bold.nii	1899-07-07T16:24:21
+func/sub-05_ses-01_task-rest_bold.nii	1899-07-07T16:39:21

--- a/bids-validator/tests/data/valid_dataset/sub-05/ses-02/sub-05_ses-02_scans.tsv
+++ b/bids-validator/tests/data/valid_dataset/sub-05/ses-02/sub-05_ses-02_scans.tsv
@@ -1,5 +1,5 @@
 filename	acq_time
-anat/sub-05_ses-02_T1w.nii.gz	1868-01-31T20:57:43
-func/sub-05_ses-02_task-nback_run-01_bold.nii.gz	1868-01-31T21:02:43
-func/sub-05_ses-02_task-nback_run-02_bold.nii.gz	1868-01-31T21:17:43
-func/sub-05_ses-02_task-rest_bold.nii.gz	1868-01-31T21:32:43
+anat/sub-05_ses-02_T1w.nii	1868-01-31T20:57:43
+func/sub-05_ses-02_task-nback_run-01_bold.nii	1868-01-31T21:02:43
+func/sub-05_ses-02_task-nback_run-02_bold.nii	1868-01-31T21:17:43
+func/sub-05_ses-02_task-rest_bold.nii	1868-01-31T21:32:43

--- a/bids-validator/tests/tsv.spec.js
+++ b/bids-validator/tests/tsv.spec.js
@@ -154,7 +154,24 @@ describe('TSV', function() {
   var scansFile = {
     name: 'sub-08_ses-test_task-linebisection_scans.tsv',
     relativePath:
-      '/sub-08/ses-test/func/sub-08_ses-test_task-linebisection_scans.tsv',
+      '/sub-08/ses-test/sub-08_ses-test_task-linebisection_scans.tsv',
+  }
+
+  var niftiFile = {
+    name: 'sub-08_ses-test_task-linebisection_run-01_bold.nii.gz',
+    relativePath:
+      '/sub-08/ses-test/func/sub-08_ses-test_task-linebisection_run-01_bold.nii.gz',
+  }
+
+  var eegFile = {
+    name: 'sub-08_ses-test_task-linebisection_run-01_eeg.fif',
+    relativePath:
+      '/sub-08/ses-test/eeg/sub-08_ses-test_task-linebisection_run-01_eeg.fif',
+  }
+  var ieegFile = {
+    name: 'sub-08_ses-test_task-linebisection_run-01_ieeg.edf',
+    relativePath:
+      '/sub-08/ses-test/eeg/sub-08_ses-test_task-linebisection_run-01_ieeg.edf',
   }
 
   it('should not allow _scans.tsv files without filename column', function() {
@@ -169,29 +186,57 @@ describe('TSV', function() {
   it('should allow _scans.tsv files with filename column', function() {
     var tsv =
       'header-one\tfilename\theader-three\n' +
-      'value-one\tvalue-two\tvalue-three'
-    validate.TSV.TSV(scansFile, tsv, [], function(issues) {
+      'value-one\tfunc/sub-08_ses-test_task-linebisection_run-01_bold.nii.gz\tvalue-three'
+    validate.TSV.TSV(scansFile, tsv, [niftiFile], function(issues) {
       assert.deepEqual(issues, [])
     })
   })
 
   it('should not allow improperly formatted acq_time column entries', function() {
-    const tsv = 'filename\tacq_time\n' + 'value-one\t000001'
-    validate.TSV.TSV(scansFile, tsv, [], function(issues) {
+    const tsv =
+      'filename\tacq_time\n' +
+      'func/sub-08_ses-test_task-linebisection_run-01_bold.nii.gz\t000001'
+    validate.TSV.TSV(scansFile, tsv, [niftiFile], function(issues) {
       assert(issues.length === 1 && issues[0].code === 84)
     })
   })
 
   it('should allow n/a as acq_time column entries', function() {
-    const tsv = 'filename\tacq_time\n' + 'value-one\tn/a'
-    validate.TSV.TSV(scansFile, tsv, [], function(issues) {
+    const tsv =
+      'filename\tacq_time\n' +
+      'func/sub-08_ses-test_task-linebisection_run-01_bold.nii.gz\tn/a'
+    validate.TSV.TSV(scansFile, tsv, [niftiFile], function(issues) {
       assert.deepEqual(issues, [])
     })
   })
 
   it('should allow properly formatted acq_time column entries', function() {
-    const tsv = 'filename\tacq_time\n' + 'value-one\t2017-05-03T06:45:45'
-    validate.TSV.TSV(scansFile, tsv, [], function(issues) {
+    const tsv =
+      'filename\tacq_time\n' +
+      'func/sub-08_ses-test_task-linebisection_run-01_bold.nii.gz\t2017-05-03T06:45:45'
+    validate.TSV.TSV(scansFile, tsv, [niftiFile], function(issues) {
+      assert.deepEqual(issues, [])
+    })
+  })
+
+  it('should not allow mismatched filename entries', function() {
+    const fileList = [niftiFile, eegFile, ieegFile]
+    const tsv =
+      'filename\tacq_time\n' +
+      'func/sub-08_ses-test_task-linebisection_run-01_bold.nii.gz\t2017-05-03T06:45:45'
+    validate.TSV.TSV(scansFile, tsv, fileList, function(issues) {
+      assert(issues.length === 2 && issues[0].code === 129)
+    })
+  })
+
+  it('should allow matching filename entries', function() {
+    const fileList = [niftiFile, eegFile, ieegFile]
+    const tsv =
+      'filename\tacq_time\n' +
+      'func/sub-08_ses-test_task-linebisection_run-01_bold.nii.gz\t2017-05-03T06:45:45' +
+      'eeg/sub-08_ses-test_task-linebisection_run-01_eeg.fif\t2017-05-03T06:45:45' +
+      'ieeg/sub-08_ses-test_task-linebisection_run-01_ieeg.edf\t2017-05-03T06:45:45' +
+    validate.TSV.TSV(scansFile, tsv, fileList, function(issues) {
       assert.deepEqual(issues, [])
     })
   })

--- a/bids-validator/tests/tsv.spec.js
+++ b/bids-validator/tests/tsv.spec.js
@@ -171,7 +171,7 @@ describe('TSV', function() {
   var ieegFile = {
     name: 'sub-08_ses-test_task-linebisection_run-01_ieeg.edf',
     relativePath:
-      '/sub-08/ses-test/eeg/sub-08_ses-test_task-linebisection_run-01_ieeg.edf',
+      '/sub-08/ses-test/ieeg/sub-08_ses-test_task-linebisection_run-01_ieeg.edf',
   }
 
   it('should not allow _scans.tsv files without filename column', function() {
@@ -220,12 +220,12 @@ describe('TSV', function() {
   })
 
   it('should not allow mismatched filename entries', function() {
-    const fileList = [niftiFile, eegFile, ieegFile]
+    const fileList = [eegFile]
     const tsv =
       'filename\tacq_time\n' +
       'func/sub-08_ses-test_task-linebisection_run-01_bold.nii.gz\t2017-05-03T06:45:45'
     validate.TSV.TSV(scansFile, tsv, fileList, function(issues) {
-      assert(issues.length === 2 && issues[0].code === 129)
+      assert(issues.length === 1 && issues[0].code === 129)
     })
   })
 
@@ -233,9 +233,9 @@ describe('TSV', function() {
     const fileList = [niftiFile, eegFile, ieegFile]
     const tsv =
       'filename\tacq_time\n' +
-      'func/sub-08_ses-test_task-linebisection_run-01_bold.nii.gz\t2017-05-03T06:45:45' +
-      'eeg/sub-08_ses-test_task-linebisection_run-01_eeg.fif\t2017-05-03T06:45:45' +
-      'ieeg/sub-08_ses-test_task-linebisection_run-01_ieeg.edf\t2017-05-03T06:45:45' +
+      'func/sub-08_ses-test_task-linebisection_run-01_bold.nii.gz\t2017-05-03T06:45:45\n' +
+      'eeg/sub-08_ses-test_task-linebisection_run-01_eeg.fif\t2017-05-03T06:45:45\n' +
+      'ieeg/sub-08_ses-test_task-linebisection_run-01_ieeg.edf\t2017-05-03T06:45:45'
     validate.TSV.TSV(scansFile, tsv, fileList, function(issues) {
       assert.deepEqual(issues, [])
     })

--- a/bids-validator/utils/issues/list.js
+++ b/bids-validator/utils/issues/list.js
@@ -709,4 +709,9 @@ export default {
     reason:
       'A genetic_info.json file is present but no Database field present in Genetics object in dataset_description.json.',
   },
+  129: {
+    key: 'SCANS_FILENAME_NOT_MATCH_DATASET',
+    severity: 'error',
+    reason: 'The filename in scans.tsv file does not match what is present in the BIDS dataset.'
+  }
 }

--- a/bids-validator/validators/tsv/tsv.js
+++ b/bids-validator/validators/tsv/tsv.js
@@ -329,9 +329,9 @@ const TSV = (file, contents, fileList, callback) => {
         const row = rows[l]
         const scanRelativePath = row[filenameColumn]
         const scanFullPath = sesPath + '/' + scanRelativePath
-
+        
         // check if scan matches full dataset path list
-        if (!(scanFullPath in pathList)) {
+        if (!(pathList.includes(scanFullPath))) {
           issues.push(
             new Issue({
               line: l,

--- a/bids-validator/validators/tsv/tsv.js
+++ b/bids-validator/validators/tsv/tsv.js
@@ -315,8 +315,8 @@ const TSV = (file, contents, fileList, callback) => {
 
     // check filename match fileList
     var idx = 0;
-    for (file in headers('filename')) {
-      if (!(file in fileList)) {
+    for (let relative_fpath in headers('filename')) {
+      if (!(relative_fpath in fileList)) {
         issues.push(
           new Issue({
             line: idx,

--- a/bids-validator/validators/tsv/tsv.js
+++ b/bids-validator/validators/tsv/tsv.js
@@ -312,6 +312,22 @@ const TSV = (file, contents, fileList, callback) => {
     if (headers.indexOf('acq_time') > -1) {
       checkAcqTimeFormat(rows, file, issues)
     }
+
+    // check filename match fileList
+    var idx = 0;
+    for (file in headers('filename')) {
+      if (!(file in fileList)) {
+        issues.push(
+          new Issue({
+            line: idx,
+            file: file,
+            code: 129,
+            evidence,
+          })
+        )
+      }
+      idx += 1;
+    }
   }
 
   callback(issues, participants, stimPaths)


### PR DESCRIPTION
Closes: bids-standard/legacy-validator#971 

Add an error message to validator if the `scans.tsv` does not match the actual files listed for that subject.
