### PR TITLE
Disable old tsv unit checks.

### DIFF
--- a/bids-validator/tests/tsv.spec.js
+++ b/bids-validator/tests/tsv.spec.js
@@ -34,6 +34,7 @@ describe('TSV', function() {
     })
   })
 
+  /* See utils.unit.validate for comment
   it('should not allow non-SI units', function() {
     var tsv =
       'header-one\tunits\theader-three\n' +
@@ -44,6 +45,7 @@ describe('TSV', function() {
       assert(issues.length === 1 && issues[0].key === 'INVALID_TSV_UNITS')
     })
   })
+  */
 
   // events checks -----------------------------------------------------------------------
 

--- a/bids-validator/utils/unit.js
+++ b/bids-validator/utils/unit.js
@@ -137,6 +137,11 @@ const unitOperatorPattern = new RegExp(`[${unitOperators.join('')}]`)
 const isUnavailable = unit => unit.trim().toLowerCase() === 'n/a'
 const isPercent = unit => unit.trim() === '%'
 
+/* Validate currently not used, out of line with specification:
+ * https://github.com/bids-standard/bids-specification/pull/411
+ * Once updated to use cmixf uncomment section in tsv validator that
+ * calls this function, remove this comment, and uncomment test in tests/tsv.spec.js
+ */
 /**
  * validate
  *

--- a/bids-validator/validators/tsv/tsv.js
+++ b/bids-validator/validators/tsv/tsv.js
@@ -265,6 +265,9 @@ const TSV = (file, contents, fileList, callback) => {
   }
 
   // check for valid SI units
+  /* 
+   * Commenting out call to validation until it is inline with spec:
+   * https://github.com/bids-standard/bids-specification/pull/411
   if (headers.includes('units')) {
     const unitIndex = headers.indexOf('units')
     rows
@@ -288,6 +291,7 @@ const TSV = (file, contents, fileList, callback) => {
           )
       })
   }
+  */
 
   // check partcipants.tsv for age 89+
 


### PR DESCRIPTION
comment out si unit checking call in tsv validation and in tsv tests until it is brought in line with specification. first part of bids-standard/bids-validator#71 