### PR TITLE
allow phsysio and stim tsvs and jsons in *eg directories fixes #990

### DIFF
--- a/bids-validator/bids_validator/rules/file_level_rules.json
+++ b/bids-validator/bids_validator/rules/file_level_rules.json
@@ -169,7 +169,11 @@
         "_channels\\.tsv",
         "_eeg\\.json",
         "_coordsystem\\.json",
-        "_photo\\.jpg"
+        "_photo\\.jpg",
+        "_physio\\.tsv\\.gz",
+        "_physio\\.json",
+        "_stim\\.tsv\\.gz",
+        "_stim\\.json"
       ]
     }
   },
@@ -196,7 +200,11 @@
         "_channels\\.tsv",
         "_ieeg\\.json",
         "_coordsystem\\.json",
-        "_photo\\.jpg"
+        "_photo\\.jpg",
+        "_physio\\.tsv\\.gz",
+        "_physio\\.json",
+        "_stim\\.tsv\\.gz",
+        "_stim\\.json"
       ]
     }
   },
@@ -204,7 +212,14 @@
   "meg": {
     "regexp": "^[\\/\\\\](sub-[a-zA-Z0-9]+)[\\/\\\\](?:(ses-[a-zA-Z0-9]+)[\\/\\\\])?meg[\\/\\\\]\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_proc-[a-zA-Z0-9]+)?(?:_split-[0-9]+)?(_digitizer.txt|_meg(@@@_meg_type_@@@[\\/\\\\](.(?!\\.(sqd|con|fif|raw|raw\\.mhd|trg|kdf|chn)$))*|[\\/\\\\](.(?!\\.(sqd|con|fif|raw|raw\\.mhd|trg|kdf|chn)$))*)|(@@@_meg_ext_@@@))$",
     "tokens": {
-      "@@@_meg_type_@@@": ["\\.ds[\\/\\\\].*", "\\.(?:chn|kdf|trg)", "\\.(?:raw|raw\\.mhd)", "\\.fif", "\\.(?:con|sqd)", "\\.(?:kdf|chn|trg)"],
+      "@@@_meg_type_@@@": [
+        "\\.ds[\\/\\\\].*",
+        "\\.(?:chn|kdf|trg)",
+        "\\.(?:raw|raw\\.mhd)",
+        "\\.fif",
+        "\\.(?:con|sqd)",
+        "\\.(?:kdf|chn|trg)"
+      ],
       "@@@_meg_ext_@@@": [
         "_events\\.json",
         "_events\\.tsv",
@@ -214,7 +229,11 @@
         "_coordsystem\\.json",
         "_photo\\.jpg",
         "_headshape\\.pos",
-        "_markers\\.(?:mrk|sqd)"
+        "_markers\\.(?:mrk|sqd)",
+        "_physio\\.tsv\\.gz",
+        "_physio\\.json",
+        "_stim\\.tsv\\.gz",
+        "_stim\\.json"
       ]
     }
   },

--- a/bids-validator/bids_validator/rules/file_level_rules.json
+++ b/bids-validator/bids_validator/rules/file_level_rules.json
@@ -1,6 +1,6 @@
 {
   "anat": {
-    "regexp": "^[\\/\\\\](sub-[a-zA-Z0-9]+)[\\/\\\\](?:(ses-[a-zA-Z0-9]+)[\\/\\\\])?anat[\\/\\\\]\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_ce-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?_(?:@@@_anat_suffixes_@@@)\\.(@@@_anat_ext_@@@)$",
+    "regexp": "^[\\/\\\\](sub-[a-zA-Z0-9]+)[\\/\\\\](?:(ses-[a-zA-Z0-9]+)[\\/\\\\])?anat[\\/\\\\]\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_ce-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(_(?:@@@_anat_suffixes_@@@)\\.(@@@_anat_ext_@@@)|(?:@@@_cont_ext_@@@))$",
     "tokens": {
       "@@@_anat_suffixes_@@@": [
         "T1w",
@@ -20,7 +20,13 @@
         "PDmap",
         "photo"
       ],
-      "@@@_anat_ext_@@@": ["nii\\.gz", "nii", "json"]
+      "@@@_anat_ext_@@@": ["nii\\.gz", "nii", "json"],
+      "@@@_cont_ext_@@@": [
+        "_physio\\.tsv\\.gz",
+        "_stim\\.tsv\\.gz",
+        "_physio\\.json",
+        "_stim\\.json"
+      ]
     }
   },
 
@@ -78,10 +84,16 @@
   },
 
   "dwi": {
-    "regexp": "^[\\/\\\\](sub-[a-zA-Z0-9]+)[\\/\\\\](?:(ses-[a-zA-Z0-9]+)[\\/\\\\])?dwi[\\/\\\\]\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_dir-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?_(?:@@@_dwi_type_@@@)\\.(@@@_dwi_ext_@@@)$",
+    "regexp": "^[\\/\\\\](sub-[a-zA-Z0-9]+)[\\/\\\\](?:(ses-[a-zA-Z0-9]+)[\\/\\\\])?dwi[\\/\\\\]\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_dir-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(_(?:@@@_dwi_type_@@@)\\.(@@@_dwi_ext_@@@)|(?:@@@_cont_ext_@@@))$",
     "tokens": {
       "@@@_dwi_ext_@@@": ["nii\\.gz", "nii", "json", "bvec", "bval"],
-      "@@@_dwi_type_@@@": ["dwi", "sbref"]
+      "@@@_dwi_type_@@@": ["dwi", "sbref"],
+      "@@@_cont_ext_@@@": [
+        "_physio\\.tsv\\.gz",
+        "_stim\\.tsv\\.gz",
+        "_physio\\.json",
+        "_stim\\.json"
+      ]
     }
   },
 


### PR DESCRIPTION
This is the quick solution. @effigies mentioned abstracting these patterns that are common across func and *eg into their own set of rules.