### PR TITLE
Fix error with repetitionTime being cast as a number. 

### DIFF
--- a/bids-validator/validators/nifti/nii.js
+++ b/bids-validator/validators/nifti/nii.js
@@ -265,8 +265,8 @@ export default function NIFTI(
             }),
           )
         } else {
-          const niftiTR = Number(repetitionTime.toFixed(3))
-          const jsonTR = Number(mergedDictionary.RepetitionTime.toFixed(3))
+          const niftiTR = Number(repetitionTime).toFixed(3)
+          const jsonTR = Number(mergedDictionary.RepetitionTime).toFixed(3)
           if (niftiTR !== jsonTR) {
             issues.push(
               new Issue({


### PR DESCRIPTION
Cast to number in nifti header validation occurring after calling toFixed, which failed if repetitionTime was a string.

fixes #674