### PR TITLE
Actually validate HED input

### DIFF
--- a/bids-validator/tests/events.spec.js
+++ b/bids-validator/tests/events.spec.js
@@ -22,7 +22,8 @@ describe('Events', function() {
       directory: [{ relativePath: '/stimuli/images/blue-square.jpg' }],
     }
     return validate.Events.validateEvents([], stimuli, [], {}).then(issues => {
-      assert(issues.length === 1 && issues[0].code === 77)
+      assert.strictEqual(issues.length, 1)
+      assert.strictEqual(issues[0].code, 77)
     })
   })
 
@@ -32,7 +33,7 @@ describe('Events', function() {
       directory: [{ relativePath: '/stimuli/images/red-square.jpg' }],
     }
     return validate.Events.validateEvents([], stimuli, [], {}).then(issues => {
-      assert(issues.length === 0)
+      assert.deepStrictEqual(issues, [])
     })
   })
 
@@ -56,7 +57,8 @@ describe('Events', function() {
       headers,
       jsonDictionary,
     ).then(issues => {
-      assert(issues.length === 1 && issues[0].code === 85)
+      assert.strictEqual(issues.length, 1)
+      assert.strictEqual(issues[0].code, 85)
     })
   })
 
@@ -80,7 +82,8 @@ describe('Events', function() {
       headers,
       jsonDictionary,
     ).then(issues => {
-      assert(issues.length === 1 && issues[0].code === 86)
+      assert.strictEqual(issues.length, 1)
+      assert.strictEqual(issues[0].code, 86)
     })
   })
 
@@ -104,7 +107,7 @@ describe('Events', function() {
       headers,
       jsonDictionary,
     ).then(issues => {
-      assert.deepEqual(issues, [])
+      assert.deepStrictEqual(issues, [])
     })
   })
 
@@ -120,9 +123,7 @@ describe('Events', function() {
         },
       ]
       const jsonDictionary = {
-        '/sub01/sub01_task-test_bold.json': {
-          RepetitionTime: 1,
-        },
+        '/sub01/sub01_task-test_events.json': {},
       }
 
       return validate.Events.validateEvents(
@@ -147,9 +148,7 @@ describe('Events', function() {
         },
       ]
       const jsonDictionary = {
-        '/sub01/sub01_task-test_bold.json': {
-          RepetitionTime: 1,
-        },
+        '/sub01/sub01_task-test_events.json': {},
       }
 
       return validate.Events.validateEvents(
@@ -173,9 +172,7 @@ describe('Events', function() {
         },
       ]
       const jsonDictionary = {
-        '/sub01/sub01_task-test_bold.json': {
-          RepetitionTime: 1,
-        },
+        '/sub01/sub01_task-test_events.json': {},
       }
 
       return validate.Events.validateEvents(
@@ -200,9 +197,7 @@ describe('Events', function() {
         },
       ]
       const jsonDictionary = {
-        '/sub01/sub01_task-test_bold.json': {
-          RepetitionTime: 1,
-        },
+        '/sub01/sub01_task-test_events.json': {},
       }
 
       return validate.Events.validateEvents(
@@ -226,8 +221,7 @@ describe('Events', function() {
         },
       ]
       const jsonDictionary = {
-        '/sub01/sub01_task-test_bold.json': {
-          RepetitionTime: 1,
+        '/sub01/sub01_task-test_events.json': {
           mycodes: {
             HED: {
               first: 'Event/Category/Miscellaneous/Test',
@@ -259,8 +253,7 @@ describe('Events', function() {
         },
       ]
       const jsonDictionary = {
-        '/sub01/sub01_task-test_bold.json': {
-          RepetitionTime: 1,
+        '/sub01/sub01_task-test_events.json': {
           mycodes: {
             HED: {
               first: 'Event/Category/Miscellaneous/Test',
@@ -292,8 +285,7 @@ describe('Events', function() {
         },
       ]
       const jsonDictionary = {
-        '/sub01/sub01_task-test_bold.json': {
-          RepetitionTime: 1,
+        '/sub01/sub01_task-test_events.json': {
           mycodes: {
             HED: {
               first:
@@ -323,8 +315,7 @@ describe('Events', function() {
         },
       ]
       const jsonDictionary = {
-        '/sub01/sub01_task-test_bold.json': {
-          RepetitionTime: 1,
+        '/sub01/sub01_task-test_events.json': {
           mycodes: {
             HED: {
               first:
@@ -356,8 +347,7 @@ describe('Events', function() {
         },
       ]
       const jsonDictionary = {
-        '/sub01/sub01_task-test_bold.json': {
-          RepetitionTime: 1,
+        '/sub01/sub01_task-test_events.json': {
           mycodes: {
             HED: {
               first:
@@ -391,8 +381,7 @@ describe('Events', function() {
         },
       ]
       const jsonDictionary = {
-        '/sub01/sub01_task-test_bold.json': {
-          RepetitionTime: 1,
+        '/sub01/sub01_task-test_events.json': {
           mycodes: {
             HED: {
               first:
@@ -425,8 +414,7 @@ describe('Events', function() {
         },
       ]
       const jsonDictionary = {
-        '/sub01/sub01_task-test_bold.json': {
-          RepetitionTime: 1,
+        '/sub01/sub01_task-test_events.json': {
           testingCodes: {
             HED: {
               first:
@@ -466,8 +454,7 @@ describe('Events', function() {
         },
       ]
       const jsonDictionary = {
-        '/sub01/sub01_task-test_bold.json': {
-          RepetitionTime: 1,
+        '/sub01/sub01_task-test_events.json': {
           testingCodes: {
             HED: {
               first:
@@ -507,8 +494,7 @@ describe('Events', function() {
         },
       ]
       const jsonDictionary = {
-        '/sub01/sub01_task-test_bold.json': {
-          RepetitionTime: 1,
+        '/sub01/sub01_task-test_events.json': {
           testingCodes: {
             HED: {
               first:
@@ -545,8 +531,7 @@ describe('Events', function() {
         },
       ]
       const jsonDictionary = {
-        '/sub01/sub01_task-test_bold.json': {
-          RepetitionTime: 1,
+        '/sub01/sub01_task-test_events.json': {
           mycodes: {
             HED: {
               first: 'Event/Category/Experimental stimulus',
@@ -578,9 +563,7 @@ describe('Events', function() {
         },
       ]
       const jsonDictionary = {
-        '/sub01/sub01_task-test_bold.json': {
-          RepetitionTime: 1,
-        },
+        '/sub01/sub01_task-test_events.json': {},
       }
 
       return validate.Events.validateEvents(
@@ -605,9 +588,7 @@ describe('Events', function() {
         },
       ]
       const jsonDictionary = {
-        '/sub01/sub01_task-test_bold.json': {
-          RepetitionTime: 1,
-        },
+        '/sub01/sub01_task-test_events.json': {},
       }
 
       return validate.Events.validateEvents(
@@ -632,9 +613,7 @@ describe('Events', function() {
         },
       ]
       const jsonDictionary = {
-        '/sub01/sub01_task-test_bold.json': {
-          RepetitionTime: 1,
-        },
+        '/sub01/sub01_task-test_events.json': {},
       }
 
       return validate.Events.validateEvents(
@@ -659,9 +638,7 @@ describe('Events', function() {
         },
       ]
       const jsonDictionary = {
-        '/sub01/sub01_task-test_bold.json': {
-          RepetitionTime: 1,
-        },
+        '/sub01/sub01_task-test_events.json': {},
       }
 
       return validate.Events.validateEvents(
@@ -686,9 +663,7 @@ describe('Events', function() {
         },
       ]
       const jsonDictionary = {
-        '/sub01/sub01_task-test_bold.json': {
-          RepetitionTime: 1,
-        },
+        '/sub01/sub01_task-test_events.json': {},
       }
 
       return validate.Events.validateEvents(
@@ -713,9 +688,7 @@ describe('Events', function() {
         },
       ]
       const jsonDictionary = {
-        '/sub01/sub01_task-test_bold.json': {
-          RepetitionTime: 1,
-        },
+        '/sub01/sub01_task-test_events.json': {},
       }
 
       return validate.Events.validateEvents(
@@ -740,9 +713,7 @@ describe('Events', function() {
         },
       ]
       const jsonDictionary = {
-        '/sub01/sub01_task-test_bold.json': {
-          RepetitionTime: 1,
-        },
+        '/sub01/sub01_task-test_events.json': {},
       }
 
       return validate.Events.validateEvents(
@@ -767,9 +738,7 @@ describe('Events', function() {
         },
       ]
       const jsonDictionary = {
-        '/sub01/sub01_task-test_bold.json': {
-          RepetitionTime: 1,
-        },
+        '/sub01/sub01_task-test_events.json': {},
       }
 
       return validate.Events.validateEvents(
@@ -794,9 +763,7 @@ describe('Events', function() {
         },
       ]
       const jsonDictionary = {
-        '/sub01/sub01_task-test_bold.json': {
-          RepetitionTime: 1,
-        },
+        '/sub01/sub01_task-test_events.json': {},
       }
 
       return validate.Events.validateEvents(
@@ -821,9 +788,7 @@ describe('Events', function() {
         },
       ]
       const jsonDictionary = {
-        '/sub01/sub01_task-test_bold.json': {
-          RepetitionTime: 1,
-        },
+        '/sub01/sub01_task-test_events.json': {},
       }
 
       return validate.Events.validateEvents(
@@ -848,9 +813,7 @@ describe('Events', function() {
         },
       ]
       const jsonDictionary = {
-        '/sub01/sub01_task-test_bold.json': {
-          RepetitionTime: 1,
-        },
+        '/sub01/sub01_task-test_events.json': {},
       }
 
       return validate.Events.validateEvents(
@@ -875,9 +838,7 @@ describe('Events', function() {
         },
       ]
       const jsonDictionary = {
-        '/sub01/sub01_task-test_bold.json': {
-          RepetitionTime: 1,
-        },
+        '/sub01/sub01_task-test_events.json': {},
       }
 
       return validate.Events.validateEvents(
@@ -902,9 +863,7 @@ describe('Events', function() {
         },
       ]
       const jsonDictionary = {
-        '/sub01/sub01_task-test_bold.json': {
-          RepetitionTime: 1,
-        },
+        '/sub01/sub01_task-test_events.json': {},
       }
 
       return validate.Events.validateEvents(

--- a/bids-validator/validators/bids/fullTest.js
+++ b/bids-validator/validators/bids/fullTest.js
@@ -176,13 +176,7 @@ const fullTest = (fileList, options, annexed, dir, callback) => {
 
       // Events validation
       stimuli.directory = files.stimuli
-      return Events.validateEvents(
-        events,
-        stimuli,
-        headers,
-        jsonContentsDict,
-        self.issues,
-      )
+      return Events.validateEvents(events, stimuli, headers, jsonContentsDict)
     })
     .then(eventsIssues => {
       self.issues = self.issues.concat(eventsIssues)

--- a/bids-validator/validators/events/hed.js
+++ b/bids-validator/validators/events/hed.js
@@ -4,28 +4,21 @@ const Issue = utils.issues.Issue
 
 export default function checkHedStrings(events, headers, jsonContents) {
   let issues = []
-  // get all headers associated with task data
-  const taskHeaders = headers.filter(header => {
-    const file = header[0]
-    return file.relativePath.includes('_task-')
-  })
 
   const hedStrings = []
 
-  // loop through headers with files that are tasks
-  taskHeaders.forEach(taskHeader => {
-    const file = taskHeader[0]
-
-    // get the json sidecar dictionary associated with that nifti scan
+  // loop through event data files
+  events.forEach(eventFile => {
+    // get the json sidecar dictionary associated with the event data
     const potentialSidecars = utils.files.potentialLocations(
-      file.relativePath.replace('.gz', '').replace('.nii', '.json'),
+      eventFile.path.replace('.tsv', '.json'),
     )
     const mergedDictionary = utils.files.generateMergedSidecarDict(
       potentialSidecars,
       jsonContents,
     )
-    const sidecarHedTags = {}
 
+    const sidecarHedTags = {}
     for (const sidecarKey in mergedDictionary) {
       const sidecarValue = mergedDictionary[sidecarKey]
       if (
@@ -37,66 +30,55 @@ export default function checkHedStrings(events, headers, jsonContents) {
       }
     }
 
-    // get the _events.tsv associated with this task scan
-    const potentialEvents = utils.files.potentialLocations(
-      file.relativePath.replace('.gz', '').replace('bold.nii', 'events.tsv'),
-    )
-    const associatedEvents = events.filter(
-      event => potentialEvents.indexOf(event.path) > -1,
-    )
+    // get all non-empty rows
+    const rows = eventFile.contents
+      .split('\n')
+      .filter(row => !(!row || /^\s*$/.test(row)))
 
-    // loop through all events associated with this task scan
-    for (const event of associatedEvents) {
-      // get all non-empty rows
-      const rows = event.contents
-        .split('\n')
-        .filter(row => !(!row || /^\s*$/.test(row)))
-
-      const columnHeaders = rows[0].trim().split('\t')
-      const hedColumnIndex = columnHeaders.indexOf('HED')
-      const sidecarHedColumnIndices = {}
-      for (const sidecarHedColumn in sidecarHedTags) {
-        const sidecarHedColumnHeader = columnHeaders.indexOf(sidecarHedColumn)
-        if (sidecarHedColumnHeader > -1) {
-          sidecarHedColumnIndices[sidecarHedColumn] = sidecarHedColumnHeader
-        }
+    const columnHeaders = rows[0].trim().split('\t')
+    const hedColumnIndex = columnHeaders.indexOf('HED')
+    const sidecarHedColumnIndices = {}
+    for (const sidecarHedColumn in sidecarHedTags) {
+      const sidecarHedColumnHeader = columnHeaders.indexOf(sidecarHedColumn)
+      if (sidecarHedColumnHeader > -1) {
+        sidecarHedColumnIndices[sidecarHedColumn] = sidecarHedColumnHeader
       }
-      if (hedColumnIndex === -1 && sidecarHedColumnIndices.length === 0) {
-        continue
-      }
+    }
+    if (hedColumnIndex === -1 && sidecarHedColumnIndices.length === 0) {
+      return
+    }
 
-      for (const row of rows.slice(1)) {
-        // get the 'HED' field
-        const rowCells = row.trim().split('\t')
-        const hedStringParts = []
-        if (rowCells[hedColumnIndex]) {
-          hedStringParts.push(rowCells[hedColumnIndex])
-        }
-        for (const sidecarHedColumn in sidecarHedColumnIndices) {
-          const sidecarHedIndex = sidecarHedColumnIndices[sidecarHedColumn]
-          const sidecarHedKey = rowCells[sidecarHedIndex]
-          if (sidecarHedKey) {
-            const sidecarHedString =
-              sidecarHedTags[sidecarHedColumn][sidecarHedKey]
-            if (sidecarHedString !== undefined) {
-              hedStringParts.push(sidecarHedString)
-            } else {
-              issues.push(
-                new Issue({
-                  code: 112,
-                  file: file,
-                  evidence: sidecarHedKey,
-                }),
-              )
-            }
+    for (const row of rows.slice(1)) {
+      // get the 'HED' field
+      const rowCells = row.trim().split('\t')
+      const hedStringParts = []
+      if (rowCells[hedColumnIndex]) {
+        hedStringParts.push(rowCells[hedColumnIndex])
+      }
+      for (const sidecarHedColumn in sidecarHedColumnIndices) {
+        const sidecarHedIndex = sidecarHedColumnIndices[sidecarHedColumn]
+        const sidecarHedKey = rowCells[sidecarHedIndex]
+        if (sidecarHedKey) {
+          const sidecarHedString =
+            sidecarHedTags[sidecarHedColumn][sidecarHedKey]
+          if (sidecarHedString !== undefined) {
+            hedStringParts.push(sidecarHedString)
+          } else {
+            issues.push(
+              new Issue({
+                code: 112,
+                file: eventFile.file,
+                evidence: sidecarHedKey,
+              }),
+            )
           }
         }
-
-        if (hedStringParts.length === 0) {
-          continue
-        }
-        hedStrings.push([file, hedStringParts.join(',')])
       }
+
+      if (hedStringParts.length === 0) {
+        continue
+      }
+      hedStrings.push([eventFile.file, hedStringParts.join(',')])
     }
   })
 


### PR DESCRIPTION
This fixes #967 by using the passed `events` parameter to source the list of event TSV files. It now properly validates HED input with a test dataset provided privately by @VisLab (slightly modified to actually use `HED` as the key for the codes).

I've also taken the liberty of removing the `issues` argument to the event validation call, as it was not listed in the parameter list for that function.