### PR TITLE
Add EthicsApprovals to dataset_description schema

### DIFF
--- a/bids-validator/validators/json/schemas/dataset_description.json
+++ b/bids-validator/validators/json/schemas/dataset_description.json
@@ -35,6 +35,12 @@
       },
       "type": "array"
     },
+    "EthicsApprovals": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
     "ReferencesAndLinks": {
       "items": {
         "type": "string"


### PR DESCRIPTION
closes #1030 

The EthicsApprovals field has been added to the bids specification.