### PR TITLE
ENH: allow optional UTC specifier Z in aqc_time

### DIFF
--- a/bids-validator/tests/tsv.spec.js
+++ b/bids-validator/tests/tsv.spec.js
@@ -306,6 +306,15 @@ describe('TSV', function() {
     })
   })
 
+  it('should allow acq_time column entries with optional UTC specifier: "Z"', function() {
+    const tsv =
+      'filename\tacq_time\n' +
+      'func/sub-08_ses-test_task-linebisection_run-01_bold.nii.gz\t2017-05-03T06:45:45.88288Z'
+    validate.TSV.TSV(scansFile, tsv, [niftiFile], function(issues) {
+      assert.deepEqual(issues, [])
+    })
+  })
+
   it('should allow session missing', function() {
     var niftiNoSesFile = {
       name: 'sub-08_task-linebisection_run-01_bold.nii.gz',

--- a/bids-validator/validators/tsv/checkAcqTimeFormat.js
+++ b/bids-validator/validators/tsv/checkAcqTimeFormat.js
@@ -2,7 +2,7 @@ const Issue = require('../../utils').issues.Issue
 import { isValid as dateIsValid, parseISO } from 'date-fns'
 
 const checkAcqTimeFormat = function(rows, file, issues) {
-  const rfc3339ish = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(.\d+)?(Z)?$/
+  const rfc3339ish = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(.\d+)?Z?$/
   const header = rows[0]
   const acqTimeColumn = header.indexOf('acq_time')
   const testRows = rows.slice(1)

--- a/bids-validator/validators/tsv/checkAcqTimeFormat.js
+++ b/bids-validator/validators/tsv/checkAcqTimeFormat.js
@@ -2,7 +2,7 @@ const Issue = require('../../utils').issues.Issue
 import { isValid as dateIsValid, parseISO } from 'date-fns'
 
 const checkAcqTimeFormat = function(rows, file, issues) {
-  const rfc3339ish = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(.\d+)?$/
+  const rfc3339ish = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(.\d+)?(Z)?$/
   const header = rows[0]
   const acqTimeColumn = header.indexOf('acq_time')
   const testRows = rows.slice(1)


### PR DESCRIPTION
follow up to #1019

addresses new feature from https://github.com/bids-standard/bids-specification/pull/546