### PR TITLE
allow string n/a for PowerLineFrequency in EEG,MEG,iEEG

### DIFF
--- a/bids-validator/tests/json.spec.js
+++ b/bids-validator/tests/json.spec.js
@@ -84,7 +84,7 @@ describe('JSON', function() {
       SoftwareFilters: {
         HighPass: { HalfAmplitudeCutOffHz: 1, RollOff: '6dB/Octave' },
       },
-      PowerLineFrequency: 50,
+      PowerLineFrequency: "n/a",
     }
     jsonDict[eeg_file.relativePath] = jsonObj
     validate.JSON(eeg_file, jsonDict, function(issues) {

--- a/bids-validator/tests/json.spec.js
+++ b/bids-validator/tests/json.spec.js
@@ -84,7 +84,7 @@ describe('JSON', function() {
       SoftwareFilters: {
         HighPass: { HalfAmplitudeCutOffHz: 1, RollOff: '6dB/Octave' },
       },
-      PowerLineFrequency: "n/a",
+      PowerLineFrequency: 'n/a',
     }
     jsonDict[eeg_file.relativePath] = jsonObj
     validate.JSON(eeg_file, jsonDict, function(issues) {

--- a/bids-validator/validators/json/schemas/eeg.json
+++ b/bids-validator/validators/json/schemas/eeg.json
@@ -13,7 +13,12 @@
     "ManufacturersModelName": { "type": "string", "minLength": 1 },
     "DeviceSerialNumber": { "type": "string" },
     "SoftwareVersions": { "type": "string" },
-    "PowerLineFrequency": { "type": "number" },
+    "PowerLineFrequency": {
+      "anyOf": [
+        { "type": "integer" },
+        { "type": "string", "pattern": "^n/a$" }
+      ]
+    },
     "SamplingFrequency": { "type": "number" },
     "EEGChannelCount": { "type": "integer" },
     "EOGChannelCount": { "type": "integer" },

--- a/bids-validator/validators/json/schemas/ieeg.json
+++ b/bids-validator/validators/json/schemas/ieeg.json
@@ -3,7 +3,12 @@
   "properties": {
     "TaskName": { "type": "string", "minLength": 1 },
     "SamplingFrequency": { "type": "number" },
-    "PowerLineFrequency": { "type": "number" },
+    "PowerLineFrequency": {
+      "anyOf": [
+        { "type": "integer" },
+        { "type": "string", "pattern": "^n/a$" }
+      ]
+    },
     "DCOffsetCorrection": { "type": "string", "minLength": 1 },
     "SoftwareFilters": {
       "anyOf": [

--- a/bids-validator/validators/json/schemas/meg.json
+++ b/bids-validator/validators/json/schemas/meg.json
@@ -13,7 +13,12 @@
     "ManufacturersModelName": { "type": "string", "minLength": 1 },
     "DeviceSerialNumber": { "type": "string" },
     "SoftwareVersions": { "type": "string" },
-    "PowerLineFrequency": { "type": "number" },
+    "PowerLineFrequency": {
+      "anyOf": [
+        { "type": "integer" },
+        { "type": "string", "pattern": "^n/a$" }
+      ]
+    },
     "SamplingFrequency": { "type": "number" },
     "MEGChannelCount": { "type": "integer" },
     "MEGREFChannelCount": { "type": "integer" },


### PR DESCRIPTION
closes  #1046

PowerLineFrequency must now be an "integer" ... not a "number" --> i.e., funky things like `-3.14` are no longer allowed.

We expect this to be 50(Hz) or 60(Hz) in almost all cases.

In some cases, the PowerLineFrequency may not be known anymore and may be hard/noisy to estimate --> for these cases it is now permitted to specify `n/a` as a string.

To preempt a comment that we should not allow `n/a` as a value for a REQUIRED field (which PowerLineFrequency is) --> maybe you are right, but the current state of affairs is that all string fields also permit `n/a` ... PowerLineFrequency was only an "unlucky" field, because it's a number / integer, not a string.

cc @alexrockhill 