### PR TITLE
Update link to contributors

### DIFF
--- a/bids-validator/README.md
+++ b/bids-validator/README.md
@@ -371,7 +371,8 @@ Using lerna publish will create a git commit with updated version information an
 ## Acknowledgments
 
 Many contributions to the `bids-validator` were done by members of the
-BIDS community. See the [list of contributors](https://github.com/bids-standard/bids-validator/graphs/contributors).
+BIDS community. See the
+[list of contributors](https://bids-specification.readthedocs.io/en/stable/99-appendices/01-contributors.html).
 
 A large part of the development of `bids-validator` is currently done by
 [Squishymedia](https://squishymedia.com/), who are in turn financed through

--- a/bids-validator/README.md
+++ b/bids-validator/README.md
@@ -78,6 +78,8 @@ Some of our awesome contributors include:
 
 [![](https://sourcerer.io/fame/chrisfilo/bids-standard/bids-validator/images/0)](https://sourcerer.io/fame/chrisfilo/bids-standard/bids-validator/links/0)[![](https://sourcerer.io/fame/chrisfilo/bids-standard/bids-validator/images/1)](https://sourcerer.io/fame/chrisfilo/bids-standard/bids-validator/links/1)[![](https://sourcerer.io/fame/chrisfilo/bids-standard/bids-validator/images/2)](https://sourcerer.io/fame/chrisfilo/bids-standard/bids-validator/links/2)[![](https://sourcerer.io/fame/chrisfilo/bids-standard/bids-validator/images/3)](https://sourcerer.io/fame/chrisfilo/bids-standard/bids-validator/links/3)[![](https://sourcerer.io/fame/chrisfilo/bids-standard/bids-validator/images/4)](https://sourcerer.io/fame/chrisfilo/bids-standard/bids-validator/links/4)[![](https://sourcerer.io/fame/chrisfilo/bids-standard/bids-validator/images/5)](https://sourcerer.io/fame/chrisfilo/bids-standard/bids-validator/links/5)[![](https://sourcerer.io/fame/chrisfilo/bids-standard/bids-validator/images/6)](https://sourcerer.io/fame/chrisfilo/bids-standard/bids-validator/links/6)[![](https://sourcerer.io/fame/chrisfilo/bids-standard/bids-validator/images/7)](https://sourcerer.io/fame/chrisfilo/bids-standard/bids-validator/links/7)
 
+Please also see [Acknowledgments](#acknowledgments).
+
 ## Use
 
 ### API


### PR DESCRIPTION
closes #1020 
closes #1055 

I have decided that using the all-contributors bot is too much of a hassle (at least for me right now).

We track the BIDS contributors in [appendix 1](https://bids-specification.readthedocs.io/en/stable/99-appendices/01-contributors.html), and those who contribute to the bids-validator would note down their contribution over there, e.g., via a "code" emoji. --> so adding all-contributors here as well would feel like a bit of a duplication.

In this PR I update the link to the BIDS contributors in the acknowledgments section ... and link to the acknowledgments section from the contributors section.

That should suffice for now, at least until somebody wants to make a real effort at revamping how we track contributions :-) 