### PR TITLE
Update how we generate filenames of potential sidecars.

### DIFF
--- a/bids-validator/utils/files/potentialLocations.js
+++ b/bids-validator/utils/files/potentialLocations.js
@@ -36,7 +36,6 @@ const potentialPaths = components => {
   const nonPathSpecificFileComponents = informationalFileComponents.filter(
     component => pathComponents.indexOf(component) < 0,
   )
-  // .filter(component => component.indexOf('run') < 0)
 
   // loop through all the directory levels - root, sub, (ses), (datatype)
   let paths = []

--- a/bids-validator/utils/files/potentialLocations.js
+++ b/bids-validator/utils/files/potentialLocations.js
@@ -33,9 +33,10 @@ const potentialPaths = components => {
   // filter filename components that are allowed only in a lower directory
   // eg if we are root level we will not want sub-* included in the possible
   // paths for this level. Also we do not want to include run in that list.
-  const nonPathSpecificFileComponents = informationalFileComponents
-    .filter(component => pathComponents.indexOf(component) < 0)
-    .filter(component => component.indexOf('run') < 0)
+  const nonPathSpecificFileComponents = informationalFileComponents.filter(
+    component => pathComponents.indexOf(component) < 0,
+  )
+  // .filter(component => component.indexOf('run') < 0)
 
   // loop through all the directory levels - root, sub, (ses), (datatype)
   let paths = []
@@ -48,12 +49,13 @@ const potentialPaths = components => {
     )
 
     const prefix = prefixComponents.join('_')
-    // loop through the non path-specific file components and generate the filename
-    // based on directory + appropriate combinations of filename components
-    for (let j = nonPathSpecificFileComponents.length; j > -1; j--) {
-      // new file name
+    for (
+      let j = 0;
+      j < Math.pow(2, nonPathSpecificFileComponents.length);
+      j++
+    ) {
       const filename = nonPathSpecificFileComponents
-        .slice(0, j)
+        .filter((value, index) => j & (1 << index))
         .concat([file])
         .join('_')
 


### PR DESCRIPTION
We aren't using the run entity when generating lists of potential sidecars. That means 7t_trt in bids-examples top level json files are not considered in potential sidecars. 

Current validator will build up lists of entities sequentially without ever skipping an entity and use those for filenames. So when we consider the run entity this caused issues finding ds210 top level json files. ds210 top level files look like "task-cuedSGT_echo-1_bold.json" The old way would never consider a filename that had a task entity, and echo entity but no run entity.

Changes in this PR raises the complexity of the function to 2 raised to the length of the list of entities in a filename, instead of the length of the list raised by 2. Since this generates longer lists of possible filenames it will also affect how long merging the existing sidecars takes since there are more potential filenames to try.