### PR TITLE
add participants.json to valid_dataset testing data

### DIFF
--- a/bids-validator/tests/data/valid_dataset/participants.json
+++ b/bids-validator/tests/data/valid_dataset/participants.json
@@ -1,0 +1,14 @@
+{
+  "age":{
+    "Description":"Description",
+    "Units":"Units"
+  },
+  "sex":{
+    "LongName":"Long name",
+    "Description":"Description",
+    "Levels":{
+      "M":"M",
+      "F":"F"
+    }
+  }
+}


### PR DESCRIPTION
closes #841 

This PR pacifies a warning in the valid_dataset test data and shows that the concerns from #841 have been addressed.