### PR TITLE
Add JSON schema for events.json files

### DIFF
--- a/bids-validator/validators/json/json.js
+++ b/bids-validator/validators/json/json.js
@@ -73,7 +73,6 @@ const compareSidecarProperties = (file, sidecar) => {
   return issues
 }
 
-// TODO: add /events.json schema loading/validation
 const selectSchema = file => {
   let schema = null
   if (file.name) {
@@ -107,15 +106,15 @@ const selectSchema = file => {
       file.name.endsWith('coordsystem.json')
     ) {
       schema = require('./schemas/coordsystem_eeg.json')
-    } else if (
-        file.name.endsWith('genetic_info.json')
-    ) {
+    } else if (file.name.endsWith('genetic_info.json')) {
       schema = require('./schemas/genetic_info.json')
     } else if (
         file.name.endsWith('physio.json') ||
         file.name.endsWith('stim.json')
     ) {
       schema = require('./schemas/physio.json')
+    } else if (file.name.endsWith('events.json')) {
+      schema = require('./schemas/events.json')
     }
   }
   return schema

--- a/bids-validator/validators/json/schemas/events.json
+++ b/bids-validator/validators/json/schemas/events.json
@@ -61,7 +61,8 @@
           "type": "string"
         },
         "Code": {
-          "type": "string"
+          "type": "string",
+          "format": "uri"
         }
       }
     }

--- a/bids-validator/validators/json/schemas/events.json
+++ b/bids-validator/validators/json/schemas/events.json
@@ -64,7 +64,8 @@
           "type": "string"
         },
         "SoftwareRRID": {
-          "type": "string"
+          "type": "string",
+          "pattern": ".+_.+"
         },
         "SoftwareVersion": {
           "type": "string"

--- a/bids-validator/validators/json/schemas/events.json
+++ b/bids-validator/validators/json/schemas/events.json
@@ -32,14 +32,23 @@
           }
         },
         "HED": {
-          "type": "object",
-          "title": "HED",
-          "description": "For categorical variables: a dictionary of possible values (keys) and their HED strings (values).",
-          "patternProperties": {
-            "^.+$": {
-              "type": "string"
+          "anyOf": [
+            {
+              "type": "object",
+              "title": "HED",
+              "description": "For categorical variables: a dictionary of possible values (keys) and their HED strings (values).",
+              "patternProperties": {
+                "^.+$": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "string",
+              "title": "HED",
+              "description": "For value variables: a string with a single '#' character where the cell value is to be interpolated.",
             }
-          }
+          ]
         }
       }
     }

--- a/bids-validator/validators/json/schemas/events.json
+++ b/bids-validator/validators/json/schemas/events.json
@@ -1,0 +1,69 @@
+{
+  "type": "object",
+  "patternProperties": {
+    "^.+$": {
+      "type": "object",
+      "title": "Column",
+      "description": "Column of a corresponding tabular file.",
+      "properties": {
+        "LongName": {
+          "title": "LongName",
+          "description": " Long (unabbreviated) name of column.",
+          "type": "string"
+        },
+        "Description": {
+          "title": "Description",
+          "description": "Description of the column.",
+          "type": "string"
+        },
+        "Units": {
+          "title": "Units",
+          "description": "Measurement units.",
+          "type": "string"
+        },
+        "Levels": {
+          "type": "object",
+          "title": "Levels",
+          "description": "For categorical variables: a dictionary of possible values (keys) and their descriptions (values).",
+          "patternProperties": {
+            "^.+$": {
+              "type": "string"
+            }
+          }
+        },
+        "HED": {
+          "type": "object",
+          "title": "HED",
+          "description": "For categorical variables: a dictionary of possible values (keys) and their HED strings (values).",
+          "patternProperties": {
+            "^.+$": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  },
+  "properties": {
+    "StimulusPresentation": {
+      "type": "object",
+      "properties": {
+        "OperatingSystem": {
+          "type": "string"
+        },
+        "SoftwareName": {
+          "type": "string"
+        },
+        "SoftwareRRID": {
+          "type": "string"
+        },
+        "SoftwareVersion": {
+          "type": "string"
+        },
+        "Code": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/bids-validator/validators/json/schemas/events.json
+++ b/bids-validator/validators/json/schemas/events.json
@@ -46,7 +46,7 @@
             {
               "type": "string",
               "title": "HED",
-              "description": "For value variables: a string with a single '#' character where the cell value is to be interpolated.",
+              "description": "For value variables: a string with a single '#' character where the cell value is to be interpolated."
             }
           ]
         }


### PR DESCRIPTION
Most of the TSV-related data was copied from `data_dictionary.json`.

This does not include the changes currently in progress to add value HED tags to complement the categorical tags (currently in https://github.com/VisLab/bids-specification/blob/hed-update/src/99-appendices/03-hed.md).

Fixes #1032