### PR TITLE
Implement HED value-taking strings

### DIFF
--- a/bids-validator/tests/events.spec.js
+++ b/bids-validator/tests/events.spec.js
@@ -583,6 +583,161 @@ describe('Events', function() {
       })
     })
 
+    it('should not throw an issue if all sidecar HED columns in a single row contain valid HED value data', () => {
+      const events = [
+        {
+          file: { path: '/sub01/sub01_task-test_events.tsv' },
+          path: '/sub01/sub01_task-test_events.tsv',
+          contents:
+            'onset\tduration\ttestingCodes\tmyValue\n' +
+            '7\tsomething\tfirst\tRed\n',
+        },
+      ]
+      const jsonDictionary = {
+        '/sub01/sub01_task-test_events.json': {
+          testingCodes: {
+            HED: {
+              first:
+                'Event/Label/Test,Event/Category/Miscellaneous/Test,Event/Description/Test',
+              second:
+                'Event/Label/Test,Event/Category/Miscellaneous/Test,Event/Description/Test',
+            },
+          },
+          myValue: {
+            HED: 'Attribute/Visual/Color/#,Item/Object/Vehicle/Bus',
+          },
+        },
+        '/dataset_description.json': { HEDVersion: '7.1.1' },
+      }
+
+      return validate.Events.validateEvents(
+        events,
+        [],
+        headers,
+        jsonDictionary,
+        '',
+      ).then(issues => {
+        assert.deepStrictEqual(issues, [])
+      })
+    })
+
+    it('should not throw an issue if all sidecar HED columns in multiple rows contain valid HED value data', () => {
+      const events = [
+        {
+          file: { path: '/sub01/sub01_task-test_events.tsv' },
+          path: '/sub01/sub01_task-test_events.tsv',
+          contents:
+            'onset\tduration\ttestingCodes\tmyValue\n' +
+            '7\tsomething\tfirst\tRed\n' +
+            '8\tsomething\tsecond\tBlue\n',
+        },
+      ]
+      const jsonDictionary = {
+        '/sub01/sub01_task-test_events.json': {
+          testingCodes: {
+            HED: {
+              first:
+                'Event/Label/Test,Event/Category/Miscellaneous/Test,Event/Description/Test',
+              second:
+                'Event/Label/Test,Event/Category/Miscellaneous/Test,Event/Description/Test',
+            },
+          },
+          myCodes: {
+            HED: 'Attribute/Visual/Color/#,Item/Object/Vehicle/Bus',
+          },
+        },
+        '/dataset_description.json': { HEDVersion: '7.1.1' },
+      }
+
+      return validate.Events.validateEvents(
+        events,
+        [],
+        headers,
+        jsonDictionary,
+        '',
+      ).then(issues => {
+        assert.deepStrictEqual(issues, [])
+      })
+    })
+
+    it('should throw an issue if a sidecar HED value column has no number signs', () => {
+      const events = [
+        {
+          file: { path: '/sub01/sub01_task-test_events.tsv' },
+          path: '/sub01/sub01_task-test_events.tsv',
+          contents:
+            'onset\tduration\ttestingCodes\tmyValue\n' +
+            '7\tsomething\tfirst\tRed\n',
+        },
+      ]
+      const jsonDictionary = {
+        '/sub01/sub01_task-test_events.json': {
+          testingCodes: {
+            HED: {
+              first:
+                'Event/Label/Test,Event/Category/Miscellaneous/Test,Event/Description/Test',
+              second:
+                'Event/Label/Test,Event/Category/Miscellaneous/Test,Event/Description/Test',
+            },
+          },
+          myValue: {
+            HED: 'Attribute/Visual/Color,Item/Object/Vehicle/Bus',
+          },
+        },
+        '/dataset_description.json': { HEDVersion: '7.1.1' },
+      }
+
+      return validate.Events.validateEvents(
+        events,
+        [],
+        headers,
+        jsonDictionary,
+        '',
+      ).then(issues => {
+        assert.strictEqual(issues.length, 1)
+        assert.strictEqual(issues[0].code, 134)
+      })
+    })
+
+    it('should throw an issue if a sidecar HED value column has too many number signs', () => {
+      const events = [
+        {
+          file: { path: '/sub01/sub01_task-test_events.tsv' },
+          path: '/sub01/sub01_task-test_events.tsv',
+          contents:
+            'onset\tduration\ttestingCodes\tmyValue\n' +
+            '7\tsomething\tfirst\tRed\n',
+        },
+      ]
+      const jsonDictionary = {
+        '/sub01/sub01_task-test_events.json': {
+          testingCodes: {
+            HED: {
+              first:
+                'Event/Label/Test,Event/Category/Miscellaneous/Test,Event/Description/Test',
+              second:
+                'Event/Label/Test,Event/Category/Miscellaneous/Test,Event/Description/Test',
+            },
+          },
+          myValue: {
+            HED: 'Attribute/Visual/Color/#,Item/Object/Vehicle/#',
+          },
+        },
+        '/dataset_description.json': { HEDVersion: '7.1.1' },
+      }
+
+      return validate.Events.validateEvents(
+        events,
+        [],
+        headers,
+        jsonDictionary,
+        '',
+      ).then(issues => {
+        assert.strictEqual(issues.length, 1)
+        assert.strictEqual(issues[0].code, 134)
+      })
+    })
+
     it('should throw an issue if the HED column in a single row contains invalid HED data in the form of an illegal character', () => {
       const events = [
         {

--- a/bids-validator/utils/issues/list.js
+++ b/bids-validator/utils/issues/list.js
@@ -718,12 +718,14 @@ export default {
   130: {
     key: 'CHANNELS_COLUMN_TYPE_UPPER_CASE',
     severity: 'error',
-    reason: 'Type column in channels.tsv files should consist of upper-case characters.'
+    reason:
+      'Type column in channels.tsv files should consist of upper-case characters.',
   },
   131: {
     key: 'CHANNELS_COLUMN_TYPE',
     severity: 'error',
-    reason: 'Type column in channels.tsv files should only consist of values allowed in the specification for MEG/EEG/iEEG data.'
+    reason:
+      'Type column in channels.tsv files should only consist of values allowed in the specification for MEG/EEG/iEEG data.',
   },
   132: {
     key: 'HED_VERSION_NOT_DEFINED',
@@ -735,7 +737,12 @@ export default {
     key: 'CONTINOUS_RECORDING_MISSING_JSON',
     severity: 'error',
     reason:
-      "Continous recording data files are required to have an associated JSON metadata file.",
-  }
-
+      'Continous recording data files are required to have an associated JSON metadata file.',
+  },
+  134: {
+    key: 'HED_WRONG_NUMBER_OF_NUMBER_SIGNS',
+    severity: 'error',
+    reason:
+      'You must have exactly one number sign in a HED value-taking string template.',
+  },
 }

--- a/bids-validator/validators/events/hed.js
+++ b/bids-validator/validators/events/hed.js
@@ -30,7 +30,7 @@ export default function checkHedStrings(events, headers, jsonContents, dir) {
       ) {
         const sidecarHedData = sidecarValue.HED
         if (
-          sidecarHedData instanceof String &&
+          typeof sidecarHedData === 'string' &&
           sidecarHedData.split('#').length !== 2
         ) {
           issues.push(
@@ -40,8 +40,9 @@ export default function checkHedStrings(events, headers, jsonContents, dir) {
               evidence: sidecarHedData,
             }),
           )
+          sidecarHedTags[sidecarKey] = false
         } else {
-          sidecarHedTags[sidecarKey] = sidecarValue.HED
+          sidecarHedTags[sidecarKey] = sidecarHedData
         }
       }
     }
@@ -77,6 +78,9 @@ export default function checkHedStrings(events, headers, jsonContents, dir) {
         const rowCell = rowCells[sidecarHedIndex]
         if (rowCell) {
           let sidecarHedString
+          if (!sidecarHedData) {
+            continue
+          }
           if (sidecarHedData instanceof String) {
             sidecarHedString = sidecarHedData.replace('#', rowCell)
           } else {

--- a/bids-validator/validators/events/hed.js
+++ b/bids-validator/validators/events/hed.js
@@ -81,7 +81,7 @@ export default function checkHedStrings(events, headers, jsonContents, dir) {
           if (!sidecarHedData) {
             continue
           }
-          if (sidecarHedData instanceof String) {
+          if (typeof sidecarHedData === 'string') {
             sidecarHedString = sidecarHedData.replace('#', rowCell)
           } else {
             sidecarHedString = sidecarHedData[rowCell]

--- a/bids-validator/validators/events/hed.js
+++ b/bids-validator/validators/events/hed.js
@@ -28,7 +28,21 @@ export default function checkHedStrings(events, headers, jsonContents, dir) {
         typeof sidecarValue === 'object' &&
         sidecarValue.HED !== undefined
       ) {
-        sidecarHedTags[sidecarKey] = sidecarValue.HED
+        const sidecarHedData = sidecarValue.HED
+        if (
+          sidecarHedData instanceof String &&
+          sidecarHedData.split('#').length !== 2
+        ) {
+          issues.push(
+            new Issue({
+              code: 134,
+              file: eventFile.file,
+              evidence: sidecarHedData,
+            }),
+          )
+        } else {
+          sidecarHedTags[sidecarKey] = sidecarValue.HED
+        }
       }
     }
 
@@ -59,10 +73,15 @@ export default function checkHedStrings(events, headers, jsonContents, dir) {
       }
       for (const sidecarHedColumn in sidecarHedColumnIndices) {
         const sidecarHedIndex = sidecarHedColumnIndices[sidecarHedColumn]
-        const sidecarHedKey = rowCells[sidecarHedIndex]
-        if (sidecarHedKey) {
-          const sidecarHedString =
-            sidecarHedTags[sidecarHedColumn][sidecarHedKey]
+        const sidecarHedData = sidecarHedTags[sidecarHedColumn]
+        const rowCell = rowCells[sidecarHedIndex]
+        if (rowCell) {
+          let sidecarHedString
+          if (sidecarHedData instanceof String) {
+            sidecarHedString = sidecarHedData.replace('#', rowCell)
+          } else {
+            sidecarHedString = sidecarHedData[rowCell]
+          }
           if (sidecarHedString !== undefined) {
             hedStringParts.push(sidecarHedString)
           } else {
@@ -70,7 +89,7 @@ export default function checkHedStrings(events, headers, jsonContents, dir) {
               new Issue({
                 code: 112,
                 file: eventFile.file,
-                evidence: sidecarHedKey,
+                evidence: rowCell,
               }),
             )
           }


### PR DESCRIPTION
This implements HED strings that take values from TSV data as
described in https://github.com/bids-standard/bids-specification/pull/619.
A new issue is added to account for cases where too many or too few
number signs are provided in a string. Tests have been added.