### PR TITLE
Fix cross-talk and fine-calibration extensions

### DIFF
--- a/bids-validator/bids_validator/rules/file_level_rules.json
+++ b/bids-validator/bids_validator/rules/file_level_rules.json
@@ -249,11 +249,11 @@
   },
 
   "meg_calbibration": {
-    "regexp": "^[\\/\\\\](sub-[a-zA-Z0-9]+)[\\/\\\\](?:(ses-[a-zA-Z0-9]+)[\\/\\\\])?meg[\\/]\\1(_\\2)?_acq-calibration_meg\\.fif$"
+    "regexp": "^[\\/\\\\](sub-[a-zA-Z0-9]+)[\\/\\\\](?:(ses-[a-zA-Z0-9]+)[\\/\\\\])?meg[\\/]\\1(_\\2)?_acq-calibration_meg\\.dat$"
   },
 
   "meg_crosstalk": {
-    "regexp": "^[\\/\\\\](sub-[a-zA-Z0-9]+)[\\/\\\\](?:(ses-[a-zA-Z0-9]+)[\\/\\\\])?meg[\\/]\\1(_\\2)?_acq-crosstalk_meg\\.dat$"
+    "regexp": "^[\\/\\\\](sub-[a-zA-Z0-9]+)[\\/\\\\](?:(ses-[a-zA-Z0-9]+)[\\/\\\\])?meg[\\/]\\1(_\\2)?_acq-crosstalk_meg\\.fif$"
   },
 
   "stimuli": {

--- a/bids-validator/tests/type.spec.js
+++ b/bids-validator/tests/type.spec.js
@@ -110,8 +110,8 @@ describe('utils.type.file.isTopLevel', function() {
     '/_task-test_physio.json',
     // cross-talk and fine-calibration files for Neuromag/Elekta/MEGIN data (.fif)
     // must be defined at file level.
-    '/acq-calibration_meg.fif',
-    '/acq-crosstalk_meg.dat',
+    '/acq-calibration_meg.dat',
+    '/acq-crosstalk_meg.fif',
   ]
 
   badFilenames.forEach(function(path) {
@@ -135,14 +135,14 @@ describe('utils.type.file.isSubjectLevel', () => {
   const badFilenames = [
     // cross-talk and fine-calibration files for Neuromag/Elekta/MEGIN data (.fif)
     // must be placed on file level.
-    '/sub-12/sub-12_acq-calibration_meg.fif',
-    '/sub-12/sub-12_acq-crosstalk_meg.dat',
     '/sub-12/sub-12_acq-calibration_meg.dat',
     '/sub-12/sub-12_acq-crosstalk_meg.fif',
-    '/sub-12/acq-calibration_meg.fif',
-    '/sub-12/acq-crosstalk_meg.dat',
-    '/sub-12/acq-calibration.fif',
-    '/sub-12/acq-crosstalk.dat',
+    '/sub-12/sub-12_acq-calibration_meg.dat',
+    '/sub-12/sub-12_acq-crosstalk_meg.fif',
+    '/sub-12/acq-calibration_meg.dat',
+    '/sub-12/acq-crosstalk_meg.fif',
+    '/sub-12/acq-calibration.dat',
+    '/sub-12/acq-crosstalk.fif',
   ]
 
   badFilenames.forEach(path => {
@@ -173,10 +173,10 @@ describe('utils.type.file.isSessionLevel', function() {
     '/sub-12/ses-pre/sub-12_ses-pre_scan.tsv',
     // cross-talk and fine-calibration files for Neuromag/Elekta/MEGIN data (.fif)
     // must be placed at file level.
-    '/sub-12/sub-12_acq-calibration_meg.fif',
-    '/sub-12/sub-12_acq-crosstalk_meg.dat',
-    '/sub-12/ses-pre/sub-12_ses-pre_acq-calibration_meg.fif',
-    '/sub-12/ses-pre/sub-12_ses-pre_acq-crosstalk_meg.dat',
+    '/sub-12/sub-12_acq-calibration_meg.dat',
+    '/sub-12/sub-12_acq-crosstalk_meg.fif',
+    '/sub-12/ses-pre/sub-12_ses-pre_acq-calibration_meg.dat',
+    '/sub-12/ses-pre/sub-12_ses-pre_acq-crosstalk_meg.fif',
   ]
 
   badFilenames.forEach(function(path) {
@@ -248,10 +248,10 @@ describe('utils.type.file.isMEG', function() {
     '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_split-01_meg.fif',
     '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_acq-TEST_run-01_split-01_meg.fif',
     // cross-talk and fine-calibration files for Neuromag/Elekta/MEGIN data (.fif)
-    '/sub-01/meg/sub-01_acq-calibration_meg.fif',
-    '/sub-01/meg/sub-01_acq-crosstalk_meg.dat',
-    '/sub-01/ses-001/meg/sub-01_ses-001_acq-calibration_meg.fif',
-    '/sub-01/ses-001/meg/sub-01_ses-001_acq-crosstalk_meg.dat',
+    '/sub-01/meg/sub-01_acq-calibration_meg.dat',
+    '/sub-01/meg/sub-01_acq-crosstalk_meg.fif',
+    '/sub-01/ses-001/meg/sub-01_ses-001_acq-calibration_meg.dat',
+    '/sub-01/ses-001/meg/sub-01_ses-001_acq-crosstalk_meg.fif',
   ]
 
   goodFilenames.forEach(function(path) {
@@ -288,9 +288,10 @@ describe('utils.type.file.isMEG', function() {
     '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg/sub-01_ses-001_task-rest_run-01_meg.trg',
     '/sub-01/ses-001/meg/sub-01_ses-001_task-rest_run-01_meg/sub-01_ses-001_task-rest_run-01_meg.chn',
     // cross-talk and fine-calibration files for Neuromag/Elekta/MEGIN data (.fif)
-    // .dat in MEG only allowed for "acq-crosstalk"
-    '/acq-notcrosstalk_meg.dat',
-    '/sub-01/ses-001/meg/sub-01_ses-001_acq-notcrosstalk_meg.dat',
+    // .dat in MEG only allowed for "acq-calibration"
+    '/acq-notcalibration_meg.dat',
+    '/sub-01/ses-001/meg/sub-01_ses-001_acq-notcalibration_meg.dat',
+    '/sub-01/ses-001/meg/sub-01_ses-001_acq-crosstalk_meg.dat',
   ]
 
   badFilenames.forEach(function(path) {

--- a/bids-validator/tests/type.spec.js
+++ b/bids-validator/tests/type.spec.js
@@ -137,8 +137,6 @@ describe('utils.type.file.isSubjectLevel', () => {
     // must be placed on file level.
     '/sub-12/sub-12_acq-calibration_meg.dat',
     '/sub-12/sub-12_acq-crosstalk_meg.fif',
-    '/sub-12/sub-12_acq-calibration_meg.dat',
-    '/sub-12/sub-12_acq-crosstalk_meg.fif',
     '/sub-12/acq-calibration_meg.dat',
     '/sub-12/acq-crosstalk_meg.fif',
     '/sub-12/acq-calibration.dat',


### PR DESCRIPTION
We accidentally swapped the Elekta/Neuromag/MEGIN cross-talk and fine-calibration files' extensions, `.fif` and `.dat`, respectively, in #1053.