### PR TITLE
ENH: schema to conditionally require Description

### DIFF
--- a/bids-validator/tests/json.spec.js
+++ b/bids-validator/tests/json.spec.js
@@ -126,6 +126,44 @@ describe('JSON', function() {
     })
   })
 
+  var meg_coordsystem_file = {
+    name: 'sub-01/meg/sub-01_task-testing_coordsystem.json',
+    relativePath: '/sub-01/meg/sub-01_task-testing_coordsystem.json',
+  }
+
+  it('MEG *_coordsystem.json files should have required key/value pairs', function() {
+    var jsonObj = {
+      FiducialsDescription: 'Fiducials were digitized using  ... ',
+      MEGCoordinateSystem: 'CTF',
+      MEGCoordinateUnits: 'mm',
+      MEGCoordinateSystemDescription: 'this is the usual ...',
+      EEGCoordinateSystem: 'Other',
+      EEGCoordinateSystemDescription: 'RAS orientation ...',
+      HeadCoilCoordinateSystem: 'Other',
+      HeadCoilCoordinates: {
+        LPA: [-1, 0, 0],
+        RPA: [1, 0, 0],
+        NAS: [0, 1, 0],
+      },
+      AnatomicalLandmarkCoordinates: {
+        LPA: [-1, 0, 0],
+        RPA: [1, 0, 0],
+        NAS: [0, 1, 0],
+      },
+      AnatomicalLandmarkCoordinateSystem: 'Other',
+      AnatomicalLandmarkCoordinateUnits: 'mm',
+    }
+    jsonDict[meg_coordsystem_file.relativePath] = jsonObj
+    validate.JSON(meg_coordsystem_file, jsonDict, function(issues) {
+      console.log(issues)
+      assert(issues.length === 4)
+      assert(issues[0].evidence == ' should have required property \'HeadCoilCoordinateSystemDescription\'')
+      assert(issues[1].evidence == ' should match "then" schema')
+      assert(issues[2].evidence == ' should have required property \'AnatomicalLandmarkCoordinateSystemDescription\'')
+      assert(issues[3].evidence == ' should match "then" schema')
+    })
+  })
+
   var eeg_coordsystem_file = {
     name: 'sub-01/eeg/sub-01_task-testing_coordsystem.json',
     relativePath: '/sub-01/eeg/sub-01_task-testing_coordsystem.json',
@@ -135,7 +173,7 @@ describe('JSON', function() {
     var jsonObj = {
       IntendedFor: 'sub-01_task-testing_electrodes.tsv',
       FiducialsDescription: 'Fiducials were digitized using  ... ',
-      EEGCoordinateSystem: 'Captrack',
+      EEGCoordinateSystem: 'CapTrak',
       EEGCoordinateUnits: 'mm',
       EEGCoordinateSystemDescription: 'RAS orientation ...',
       AnatomicalLandmarkCoordinates: {
@@ -153,6 +191,39 @@ describe('JSON', function() {
     })
   })
 
+  it('EEG *_coordsystem.json schema should require *Description if *Coordsystem is "Other"', function() {
+    var jsonObj = {
+      EEGCoordinateSystem: 'Other',
+      EEGCoordinateUnits: 'mm',
+      EEGCoordinateSystemDescription: 'we did ...',
+      FiducialsCoordinateSystem: 'Other',
+      AnatomicalLandmarkCoordinateSystem: 'Other',
+      AnatomicalLandmarkCoordinateSystemDescription: 'we did ...',
+    }
+    jsonDict[eeg_coordsystem_file.relativePath] = jsonObj
+    validate.JSON(eeg_coordsystem_file, jsonDict, function(issues) {
+      assert(issues.length === 2)
+      assert(issues[0].evidence == ' should have required property \'FiducialsCoordinateSystemDescription\'')
+      assert(issues[1].evidence == ' should match "then" schema')
+    })
+  })
+
+  it('EEG *_coordsystem.json schema general requirements should not be overridden by conditional requirements', function() {
+    var jsonObj = {
+      EEGCoordinateSystem: 'Other',
+      EEGCoordinateSystemDescription: 'We used a ...',
+      AnatomicalLandmarkCoordinateSystem: 'Other'
+    }
+    jsonDict[eeg_coordsystem_file.relativePath] = jsonObj
+    validate.JSON(eeg_coordsystem_file, jsonDict, function(issues) {
+      assert(issues.length === 3)
+      assert(issues[0].evidence == ' should have required property \'EEGCoordinateUnits\'')
+      assert(issues[1].evidence == ' should have required property \'AnatomicalLandmarkCoordinateSystemDescription\'')
+      assert(issues[2].evidence == ' should match "then" schema')
+    })
+  })
+
+
   var ieeg_coordsystem_file = {
     name: 'sub-01/ieeg/sub-01_task-testing_coordsystem.json',
     relativePath: '/sub-01/ieeg/sub-01_task-testing_coordsystem.json',
@@ -160,7 +231,7 @@ describe('JSON', function() {
 
   it('iEEG *_coordsystem.json files should have required key/value pairs', function() {
     var jsonObj = {
-      iEEGCoordinateSystem: 'Other',
+      iEEGCoordinateSystem: 'pixels',
       iEEGCoordinateUnits: 'mm',
     }
     jsonDict[ieeg_coordsystem_file.relativePath] = jsonObj
@@ -168,6 +239,20 @@ describe('JSON', function() {
       assert(issues.length === 0)
     })
   })
+
+  it('iEEG *_coordsystem.json schema should require *Description if *Coordsystem is "Other"', function() {
+    var jsonObj = {
+      iEEGCoordinateSystem: 'Other',
+      iEEGCoordinateUnits: 'mm',
+    }
+    jsonDict[ieeg_coordsystem_file.relativePath] = jsonObj
+    validate.JSON(ieeg_coordsystem_file, jsonDict, function(issues) {
+      assert(issues.length === 2)
+      assert(issues[0].evidence == ' should have required property \'iEEGCoordinateSystemDescription\'')
+      assert(issues[1].evidence == ' should match "then" schema')
+    })
+  })
+
 
   it('should use inherited sidecars to find missing fields', function() {
     const multiEntryJsonDict = {}

--- a/bids-validator/tests/json.spec.js
+++ b/bids-validator/tests/json.spec.js
@@ -155,11 +155,16 @@ describe('JSON', function() {
     }
     jsonDict[meg_coordsystem_file.relativePath] = jsonObj
     validate.JSON(meg_coordsystem_file, jsonDict, function(issues) {
-      console.log(issues)
       assert(issues.length === 4)
-      assert(issues[0].evidence == ' should have required property \'HeadCoilCoordinateSystemDescription\'')
+      assert(
+        issues[0].evidence ==
+          " should have required property 'HeadCoilCoordinateSystemDescription'",
+      )
       assert(issues[1].evidence == ' should match "then" schema')
-      assert(issues[2].evidence == ' should have required property \'AnatomicalLandmarkCoordinateSystemDescription\'')
+      assert(
+        issues[2].evidence ==
+          " should have required property 'AnatomicalLandmarkCoordinateSystemDescription'",
+      )
       assert(issues[3].evidence == ' should match "then" schema')
     })
   })
@@ -203,7 +208,10 @@ describe('JSON', function() {
     jsonDict[eeg_coordsystem_file.relativePath] = jsonObj
     validate.JSON(eeg_coordsystem_file, jsonDict, function(issues) {
       assert(issues.length === 2)
-      assert(issues[0].evidence == ' should have required property \'FiducialsCoordinateSystemDescription\'')
+      assert(
+        issues[0].evidence ==
+          " should have required property 'FiducialsCoordinateSystemDescription'",
+      )
       assert(issues[1].evidence == ' should match "then" schema')
     })
   })
@@ -212,17 +220,22 @@ describe('JSON', function() {
     var jsonObj = {
       EEGCoordinateSystem: 'Other',
       EEGCoordinateSystemDescription: 'We used a ...',
-      AnatomicalLandmarkCoordinateSystem: 'Other'
+      AnatomicalLandmarkCoordinateSystem: 'Other',
     }
     jsonDict[eeg_coordsystem_file.relativePath] = jsonObj
     validate.JSON(eeg_coordsystem_file, jsonDict, function(issues) {
       assert(issues.length === 3)
-      assert(issues[0].evidence == ' should have required property \'EEGCoordinateUnits\'')
-      assert(issues[1].evidence == ' should have required property \'AnatomicalLandmarkCoordinateSystemDescription\'')
+      assert(
+        issues[0].evidence ==
+          " should have required property 'EEGCoordinateUnits'",
+      )
+      assert(
+        issues[1].evidence ==
+          " should have required property 'AnatomicalLandmarkCoordinateSystemDescription'",
+      )
       assert(issues[2].evidence == ' should match "then" schema')
     })
   })
-
 
   var ieeg_coordsystem_file = {
     name: 'sub-01/ieeg/sub-01_task-testing_coordsystem.json',
@@ -231,7 +244,7 @@ describe('JSON', function() {
 
   it('iEEG *_coordsystem.json files should have required key/value pairs', function() {
     var jsonObj = {
-      iEEGCoordinateSystem: 'pixels',
+      iEEGCoordinateSystem: 'Pixels',
       iEEGCoordinateUnits: 'mm',
     }
     jsonDict[ieeg_coordsystem_file.relativePath] = jsonObj
@@ -248,11 +261,13 @@ describe('JSON', function() {
     jsonDict[ieeg_coordsystem_file.relativePath] = jsonObj
     validate.JSON(ieeg_coordsystem_file, jsonDict, function(issues) {
       assert(issues.length === 2)
-      assert(issues[0].evidence == ' should have required property \'iEEGCoordinateSystemDescription\'')
+      assert(
+        issues[0].evidence ==
+          " should have required property 'iEEGCoordinateSystemDescription'",
+      )
       assert(issues[1].evidence == ' should match "then" schema')
     })
   })
-
 
   it('should use inherited sidecars to find missing fields', function() {
     const multiEntryJsonDict = {}

--- a/bids-validator/validators/json/schemas/coordsystem_eeg.json
+++ b/bids-validator/validators/json/schemas/coordsystem_eeg.json
@@ -16,5 +16,42 @@
     "AnatomicalLandmarkCoordinateSystemDescription": { "type": "string" }
   },
   "required": ["EEGCoordinateSystem", "EEGCoordinateUnits"],
-  "additionalProperties": false
+  "additionalProperties": false,
+  "allOf": [
+    { "$ref": "#/dependency-definitions/if-EEGCoordinateSystem-is-Other-then-Description-is-required" },
+    { "$ref": "#/dependency-definitions/if-FiducialsCoordinateSystem-is-Other-then-Description-is-required" },
+    { "$ref": "#/dependency-definitions/if-AnatomicalLandmarkCoordinateSystem-is-Other-then-Description-is-required" }
+  ],
+  "dependency-definitions": {
+    "if-EEGCoordinateSystem-is-Other-then-Description-is-required": {
+      "if": {
+        "type": "object",
+        "properties": {
+          "EEGCoordinateSystem": { "const": "Other" }
+        },
+        "required": ["EEGCoordinateSystem"]
+      },
+      "then": { "required": ["EEGCoordinateSystemDescription"] }
+    },
+    "if-FiducialsCoordinateSystem-is-Other-then-Description-is-required": {
+      "if": {
+        "type": "object",
+        "properties": {
+          "FiducialsCoordinateSystem": { "const": "Other" }
+        },
+        "required": ["FiducialsCoordinateSystem"]
+      },
+      "then": { "required": ["FiducialsCoordinateSystemDescription"] }
+    },
+    "if-AnatomicalLandmarkCoordinateSystem-is-Other-then-Description-is-required": {
+      "if": {
+        "type": "object",
+        "properties": {
+          "AnatomicalLandmarkCoordinateSystem": { "const": "Other" }
+        },
+        "required": ["AnatomicalLandmarkCoordinateSystem"]
+      },
+      "then": { "required": ["AnatomicalLandmarkCoordinateSystemDescription"] }
+    }
+  }
 }

--- a/bids-validator/validators/json/schemas/coordsystem_eeg.json
+++ b/bids-validator/validators/json/schemas/coordsystem_eeg.json
@@ -5,15 +5,15 @@
     "FiducialsDescription": { "type": "string", "minLength": 1 },
     "FiducialsCoordinates": { "$ref": "common_definitions.json#/definitions/LandmarkCoordinates" },
     "FiducialsCoordinateSystem": { "type": "string", "minLength": 1 },
-    "FiducialsCoordinateSystemDescription": { "type": "string" },
+    "FiducialsCoordinateSystemDescription": { "type": "string", "minLength": 1 },
     "FiducialsCoordinateUnits": { "$ref": "common_definitions.json#/definitions/CoordUnits" },
     "EEGCoordinateSystem": { "type": "string", "minLength": 1 },
     "EEGCoordinateUnits": { "$ref": "common_definitions.json#/definitions/CoordUnits" },
-    "EEGCoordinateSystemDescription": { "type": "string" },
+    "EEGCoordinateSystemDescription": { "type": "string", "minLength": 1 },
     "AnatomicalLandmarkCoordinates": { "$ref": "common_definitions.json#/definitions/LandmarkCoordinates" },
     "AnatomicalLandmarkCoordinateSystem": { "type": "string", "minLength": 1 },
     "AnatomicalLandmarkCoordinateUnits": { "$ref": "common_definitions.json#/definitions/CoordUnits" },
-    "AnatomicalLandmarkCoordinateSystemDescription": { "type": "string" }
+    "AnatomicalLandmarkCoordinateSystemDescription": { "type": "string", "minLength": 1 }
   },
   "required": ["EEGCoordinateSystem", "EEGCoordinateUnits"],
   "additionalProperties": false,

--- a/bids-validator/validators/json/schemas/coordsystem_ieeg.json
+++ b/bids-validator/validators/json/schemas/coordsystem_ieeg.json
@@ -1,13 +1,28 @@
 {
   "type": "object",
   "properties": {
+    "IntendedFor": { "type": "string", "minLength": 1 },
     "iEEGCoordinateSystem": { "type": "string", "minLength": 1 },
     "iEEGCoordinateUnits":  { "$ref": "common_definitions.json#/definitions/CoordUnits" },
     "iEEGCoordinateSystemDescription": { "type": "string", "minLength": 1 },
     "iEEGCoordinateProcessingDescription": { "type": "string", "minLength": 1 },
-    "iEEGCoordinateProcessingReference": { "type": "string", "minLength": 1 },
-    "IntendedFor": { "type": "string", "minLength": 1 }
+    "iEEGCoordinateProcessingReference": { "type": "string", "minLength": 1 }
   },
   "required": ["iEEGCoordinateSystem", "iEEGCoordinateUnits"],
-  "additionalProperties": false
+  "additionalProperties": false,
+  "allOf": [
+    { "$ref": "#/dependency-definitions/if-iEEGCoordinateSystem-is-Other-then-Description-is-required" }
+  ],
+  "dependency-definitions": {
+    "if-iEEGCoordinateSystem-is-Other-then-Description-is-required": {
+      "if": {
+        "type": "object",
+        "properties": {
+          "iEEGCoordinateSystem": { "const": "Other" }
+        },
+        "required": ["iEEGCoordinateSystem"]
+      },
+      "then": { "required": ["iEEGCoordinateSystemDescription"] }
+    }
+  }
 }

--- a/bids-validator/validators/json/schemas/coordsystem_meg.json
+++ b/bids-validator/validators/json/schemas/coordsystem_meg.json
@@ -34,5 +34,64 @@
     "DigitizedHeadPointsCoordinateSystemDescription": { "type": "string" }
   },
   "required": ["MEGCoordinateSystem", "MEGCoordinateUnits"],
-  "additionalProperties": false
+  "additionalProperties": false,
+  "allOf": [
+    { "$ref": "#/dependency-definitions/if-MEGCoordinateSystem-is-Other-then-Description-is-required" },
+    { "$ref": "#/dependency-definitions/if-EEGCoordinateSystem-is-Other-then-Description-is-required" },
+    { "$ref": "#/dependency-definitions/if-HeadCoilCoordinateSystem-is-Other-then-Description-is-required" },
+    { "$ref": "#/dependency-definitions/if-AnatomicalLandmarkCoordinateSystem-is-Other-then-Description-is-required" },
+    { "$ref": "#/dependency-definitions/if-DigitizedHeadPointsCoordinateSystem-is-Other-then-Description-is-required" }
+  ],
+  "dependency-definitions": {
+    "if-MEGCoordinateSystem-is-Other-then-Description-is-required": {
+      "if": {
+        "type": "object",
+        "properties": {
+          "MEGCoordinateSystem": { "const": "Other" }
+        },
+        "required": ["MEGCoordinateSystem"]
+      },
+      "then": { "required": ["MEGCoordinateSystemDescription"] }
+    },
+    "if-EEGCoordinateSystem-is-Other-then-Description-is-required": {
+      "if": {
+        "type": "object",
+        "properties": {
+          "EEGCoordinateSystem": { "const": "Other" }
+        },
+        "required": ["EEGCoordinateSystem"]
+      },
+      "then": { "required": ["EEGCoordinateSystemDescription"] }
+    },
+    "if-HeadCoilCoordinateSystem-is-Other-then-Description-is-required": {
+      "if": {
+        "type": "object",
+        "properties": {
+          "HeadCoilCoordinateSystem": { "const": "Other" }
+        },
+        "required": ["HeadCoilCoordinateSystem"]
+      },
+      "then": { "required": ["HeadCoilCoordinateSystemDescription"] }
+    },
+    "if-AnatomicalLandmarkCoordinateSystem-is-Other-then-Description-is-required": {
+      "if": {
+        "type": "object",
+        "properties": {
+          "AnatomicalLandmarkCoordinateSystem": { "const": "Other" }
+        },
+        "required": ["AnatomicalLandmarkCoordinateSystem"]
+      },
+      "then": { "required": ["AnatomicalLandmarkCoordinateSystemDescription"] }
+    },
+    "if-DigitizedHeadPointsCoordinateSystem-is-Other-then-Description-is-required": {
+      "if": {
+        "type": "object",
+        "properties": {
+          "DigitizedHeadPointsCoordinateSystem": { "const": "Other" }
+        },
+        "required": ["DigitizedHeadPointsCoordinateSystem"]
+      },
+      "then": { "required": ["DigitizedHeadPointsCoordinateSystemDescription"] }
+    }
+  }
 }

--- a/bids-validator/validators/json/schemas/coordsystem_meg.json
+++ b/bids-validator/validators/json/schemas/coordsystem_meg.json
@@ -3,10 +3,10 @@
   "properties": {
     "MEGCoordinateSystem": { "type": "string", "minLength": 1 },
     "MEGCoordinateUnits": { "$ref": "common_definitions.json#/definitions/CoordUnits" },
-    "MEGCoordinateSystemDescription": { "type": "string" },
+    "MEGCoordinateSystemDescription": { "type": "string", "minLength": 1 },
     "EEGCoordinateSystem": { "type": "string", "minLength": 1 },
     "EEGCoordinateUnits": { "$ref": "common_definitions.json#/definitions/CoordUnits" },
-    "EEGCoordinateSystemDescription": { "type": "string" },
+    "EEGCoordinateSystemDescription": { "type": "string", "minLength": 1 },
     "IntendedFor": {
       "anyOf": [
         {
@@ -23,15 +23,15 @@
     "HeadCoilCoordinates": { "$ref": "common_definitions.json#/definitions/LandmarkCoordinates" },
     "HeadCoilCoordinateSystem": { "type": "string", "minLength": 1 },
     "HeadCoilCoordinateUnits": { "$ref": "common_definitions.json#/definitions/CoordUnits" },
-    "HeadCoilCoordinateSystemDescription": { "type": "string" },
+    "HeadCoilCoordinateSystemDescription": { "type": "string", "minLength": 1 },
     "AnatomicalLandmarkCoordinates": { "$ref": "common_definitions.json#/definitions/LandmarkCoordinates" },
     "AnatomicalLandmarkCoordinateSystem": { "type": "string", "minLength": 1 },
     "AnatomicalLandmarkCoordinateUnits": { "$ref": "common_definitions.json#/definitions/CoordUnits" },
-    "AnatomicalLandmarkCoordinateSystemDescription": { "type": "string" },
+    "AnatomicalLandmarkCoordinateSystemDescription": { "type": "string", "minLength": 1 },
     "DigitizedHeadPoints": { "type": "string" },
     "DigitizedHeadPointsCoordinateSystem": { "type": "string" },
     "DigitizedHeadPointsCoordinateUnits": { "$ref": "common_definitions.json#/definitions/CoordUnits" },
-    "DigitizedHeadPointsCoordinateSystemDescription": { "type": "string" }
+    "DigitizedHeadPointsCoordinateSystemDescription": { "type": "string", "minLength": 1 }
   },
   "required": ["MEGCoordinateSystem", "MEGCoordinateUnits"],
   "additionalProperties": false,


### PR DESCRIPTION
if *CoordinateSystem is 'Other', ensure that *CoordinateSystemDescription is supplied. closes #945 

This significantly enhances validation and will remind users to supply unusable data.

solved via https://stackoverflow.com/a/64299870/5201771

edit: In a follow-up PR I will add the "enum" to the schema, requiring a list of particular coordinate system to be supplied, where `"Other"` will be the wildcard --> not putting this in here for clarity.