### PR TITLE
Skip session checks

### DIFF
--- a/bids-validator-web/components/App.jsx
+++ b/bids-validator-web/components/App.jsx
@@ -23,6 +23,7 @@ const initState = () => ({
   options: {
     ignoreWarnings: false,
     ignoreNiftiHeaders: false,
+    ignoreSubjectConsistency: false
   },
 })
 

--- a/bids-validator-web/components/Options.jsx
+++ b/bids-validator-web/components/Options.jsx
@@ -8,6 +8,10 @@ const Options = ({ setOption, options }) => (
       <label htmlFor="ignoreWarnings">Ignore Warnings</label>
       <input name="ignoreNiftiHeaders" type="checkbox" checked={options.ignoreNiftiHeaders} readOnly />
       <label htmlFor="ignoreNiftiHeaders">Ignore NIfTI Headers</label>
+      <input name="ignoreSubjectConsistency" type="checkbox" checked={options.ignoreSubjectConsistency} readOnly />
+      <label htmlFor="ignoreSubjectConsistency">
+        Skip Subject Filename Consistency Check
+      </label>
     </form>
     <hr />
   </>

--- a/bids-validator/bin/bids-validator
+++ b/bids-validator/bin/bids-validator
@@ -18,7 +18,7 @@ var argv = require('yargs')
   )
   .boolean('ignoreSessionConsistency')
   .describe(
-    'ignoreSymlinks',
+    'ignoreSessionConsistency',
     'Skip checking that any given session file is present for all subjects.',
   )
   .boolean('verbose')

--- a/bids-validator/bin/bids-validator
+++ b/bids-validator/bin/bids-validator
@@ -16,10 +16,10 @@ var argv = require('yargs')
     'ignoreNiftiHeaders',
     'Disregard NIfTI header content during validation',
   )
-  .boolean('ignoreSessionConsistency')
+  .boolean('ignoreSubjectConsistency')
   .describe(
-    'ignoreSessionConsistency',
-    'Skip checking that any given session file is present for all subjects.',
+    'ignoreSubjectConsistency',
+    'Skip checking that any given file for one subject is present for all other subjects.',
   )
   .boolean('verbose')
   .describe('verbose', 'Log more extensive information about issues')

--- a/bids-validator/bin/bids-validator
+++ b/bids-validator/bin/bids-validator
@@ -16,6 +16,11 @@ var argv = require('yargs')
     'ignoreNiftiHeaders',
     'Disregard NIfTI header content during validation',
   )
+  .boolean('ignoreSessionConsistency')
+  .describe(
+    'ignoreSymlinks',
+    'Skip checking that any given session file is present for all subjects.',
+  )
   .boolean('verbose')
   .describe('verbose', 'Log more extensive information about issues')
   .boolean('json')

--- a/bids-validator/utils/options.js
+++ b/bids-validator/utils/options.js
@@ -15,6 +15,7 @@ export default {
       ignoreWarnings: Boolean(options.ignoreWarnings),
       ignoreNiftiHeaders: Boolean(options.ignoreNiftiHeaders),
       ignoreSymlinks: Boolean(options.ignoreSymlinks),
+      ignoreSessionConsistency: Boolean(options.ignoreSessionConsistency),
       verbose: Boolean(options.verbose),
       gitTreeMode: Boolean(options.gitTreeMode),
       remoteFiles: Boolean(options.remoteFiles),

--- a/bids-validator/utils/options.js
+++ b/bids-validator/utils/options.js
@@ -15,7 +15,7 @@ export default {
       ignoreWarnings: Boolean(options.ignoreWarnings),
       ignoreNiftiHeaders: Boolean(options.ignoreNiftiHeaders),
       ignoreSymlinks: Boolean(options.ignoreSymlinks),
-      ignoreSessionConsistency: Boolean(options.ignoreSessionConsistency),
+      ignoreSubjectConsistency: Boolean(options.ignoreSubjectConsistency),
       verbose: Boolean(options.verbose),
       gitTreeMode: Boolean(options.gitTreeMode),
       remoteFiles: Boolean(options.remoteFiles),

--- a/bids-validator/validators/bids/fullTest.js
+++ b/bids-validator/validators/bids/fullTest.js
@@ -194,7 +194,7 @@ const fullTest = (fileList, options, annexed, dir, callback) => {
       // Validate continous recording files
       self.issues = self.issues.concat(tsv.validateContRec(files.contRecord, jsonContentsDict))
 
-      if (!options.ignoreSessionConsistency) {
+      if (!options.ignoreSubjectConsistency) {
         // Validate session files
         self.issues = self.issues.concat(session(fileList))
       }

--- a/bids-validator/validators/bids/fullTest.js
+++ b/bids-validator/validators/bids/fullTest.js
@@ -194,8 +194,10 @@ const fullTest = (fileList, options, annexed, dir, callback) => {
       // Validate continous recording files
       self.issues = self.issues.concat(tsv.validateContRec(files.contRecord, jsonContentsDict))
 
-      // Validate session files
-      self.issues = self.issues.concat(session(fileList))
+      if (!options.ignoreSessionConsistency) {
+        // Validate session files
+        self.issues = self.issues.concat(session(fileList))
+      }
 
       // Determine if each subject has data present
       self.issues = self.issues.concat(


### PR DESCRIPTION
On datasets with large numbers of subjects/sessions performing this check can cause the stack limit to be hit. Adding a flag to skip the checks can allow validation to complete for some datasets: #1083