### PR TITLE
ENH: Add GeneratedBy and SourceDatasets to dataset_description schema

### DIFF
--- a/bids-validator/tests/json.spec.js
+++ b/bids-validator/tests/json.spec.js
@@ -496,4 +496,45 @@ describe('JSON', function() {
       assert(issues.length === 0)
     })
   })
+
+  it('dataset_description.json should validate with DatasetType "derivative" and GeneratedBy defined', function() {
+    var jsonObj = {
+      Name: 'Example Name',
+      BIDSVersion: '1.4.0',
+      Authors: ['example author'],
+      DatasetType: 'derivative',
+      GeneratedBy: [{Name: 'Manual'}],
+    }
+    jsonDict[dataset_description_file.relativePath] = jsonObj
+    validate.JSON(dataset_description_file, jsonDict, function(issues) {
+      assert(issues.length === 0)
+    })
+  })
+
+  it('dataset_description.json should NOT validate with DatasetType "derivative" and GeneratedBy empty', function() {
+    var jsonObj = {
+      Name: 'Example Name',
+      BIDSVersion: '1.4.0',
+      Authors: ['example author'],
+      DatasetType: 'derivative',
+      GeneratedBy: [],
+    }
+    jsonDict[dataset_description_file.relativePath] = jsonObj
+    validate.JSON(dataset_description_file, jsonDict, function(issues) {
+      assert(issues.length === 1 && issues[0].code == 55)
+    })
+  })
+
+  it('dataset_description.json should NOT validate with DatasetType "derivative" and GeneratedBy missing', function() {
+    var jsonObj = {
+      Name: 'Example Name',
+      BIDSVersion: '1.4.0',
+      Authors: ['example author'],
+      DatasetType: 'derivative',
+    }
+    jsonDict[dataset_description_file.relativePath] = jsonObj
+    validate.JSON(dataset_description_file, jsonDict, function(issues) {
+      assert(issues.length === 1 && issues[0].code == 55)
+    })
+  })
 })

--- a/bids-validator/tests/json.spec.js
+++ b/bids-validator/tests/json.spec.js
@@ -521,7 +521,10 @@ describe('JSON', function() {
     }
     jsonDict[dataset_description_file.relativePath] = jsonObj
     validate.JSON(dataset_description_file, jsonDict, function(issues) {
-      assert(issues.length === 1 && issues[0].code == 55)
+      assert(issues.length === 1)
+      assert(issues[0].code == 55 &&
+             issues[0].evidence ==
+             ".GeneratedBy should NOT have fewer than 1 items")
     })
   })
 
@@ -534,7 +537,10 @@ describe('JSON', function() {
     }
     jsonDict[dataset_description_file.relativePath] = jsonObj
     validate.JSON(dataset_description_file, jsonDict, function(issues) {
-      assert(issues.length === 1 && issues[0].code == 55)
+      assert(issues.length === 2)
+      assert(issues[0].code == 55 &&
+             issues[0].evidence ==
+             " should have required property 'GeneratedBy'")
     })
   })
 })

--- a/bids-validator/tests/json.spec.js
+++ b/bids-validator/tests/json.spec.js
@@ -503,7 +503,7 @@ describe('JSON', function() {
       BIDSVersion: '1.4.0',
       Authors: ['example author'],
       DatasetType: 'derivative',
-      GeneratedBy: [{Name: 'Manual'}],
+      GeneratedBy: [{ Name: 'Manual' }],
     }
     jsonDict[dataset_description_file.relativePath] = jsonObj
     validate.JSON(dataset_description_file, jsonDict, function(issues) {

--- a/bids-validator/tests/json.spec.js
+++ b/bids-validator/tests/json.spec.js
@@ -522,9 +522,11 @@ describe('JSON', function() {
     jsonDict[dataset_description_file.relativePath] = jsonObj
     validate.JSON(dataset_description_file, jsonDict, function(issues) {
       assert(issues.length === 1)
-      assert(issues[0].code == 55 &&
-             issues[0].evidence ==
-             ".GeneratedBy should NOT have fewer than 1 items")
+      assert(
+        issues[0].code == 55 &&
+          issues[0].evidence ==
+            '.GeneratedBy should NOT have fewer than 1 items',
+      )
     })
   })
 
@@ -538,9 +540,10 @@ describe('JSON', function() {
     jsonDict[dataset_description_file.relativePath] = jsonObj
     validate.JSON(dataset_description_file, jsonDict, function(issues) {
       assert(issues.length === 2)
-      assert(issues[0].code == 55 &&
-             issues[0].evidence ==
-             " should have required property 'GeneratedBy'")
+      assert(
+        issues[0].code == 55 &&
+          issues[0].evidence == " should have required property 'GeneratedBy'",
+      )
     })
   })
 })

--- a/bids-validator/validators/json/schemas/dataset_description.json
+++ b/bids-validator/validators/json/schemas/dataset_description.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-06/schema#",
   "$id": "http://example.com/example.json",
+  "type": "object",
   "properties": {
     "Name": {
       "type": "string"
@@ -53,6 +54,7 @@
     },
     "GeneratedBy": {
       "type": "array",
+      "minLength": 1,
       "items": {
         "type": "object",
         "properties": {
@@ -101,5 +103,15 @@
     }
   },
   "required": ["Name", "BIDSVersion"],
-  "type": "object"
+  "allOf": [
+    {
+      "if": {
+	"type": "object",
+	"properties": {"DatasetType": {"const": "derivative"}}
+      },
+      "then": {
+	"required": ["GeneratedBy"]
+      }
+    }
+  ]
 }

--- a/bids-validator/validators/json/schemas/dataset_description.json
+++ b/bids-validator/validators/json/schemas/dataset_description.json
@@ -51,6 +51,37 @@
     "DatasetDOI": {
       "type": "string"
     },
+    "GeneratedBy": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "Name": {"type": "string"},
+          "Version": {"type": "string"},
+          "Description": {"type": "string"},
+          "CodeURL": {"type": "string", "format": "uri"},
+          "Container": {
+            "type": "object",
+            "properties": {
+              "Type": {"type": "string"},
+              "Tag": {"type": "string"},
+              "URI": {"type": "string", "format": "uri"}
+            }
+          }
+        }
+      }
+    },
+    "SourceDatasets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "URL": {"type": "string", "format": "uri"},
+          "DOI": {"type": "string"},
+          "Version": {"type": "string"}
+        }
+      }
+    },
     "Genetics": {
       "type": "object",
       "properties": {

--- a/bids-validator/validators/json/schemas/dataset_description.json
+++ b/bids-validator/validators/json/schemas/dataset_description.json
@@ -104,10 +104,10 @@
   },
   "required": ["Name", "BIDSVersion"],
   "allOf": [
-    { "$ref": "#/dependency-definitions/if-DatasetTpe-is-derivative-then-GeneratedBy-is-required" }
+    { "$ref": "#/dependency-definitions/if-DatasetType-is-derivative-then-GeneratedBy-is-required" }
   ],
   "dependency-definitions": {
-    "if-DatasetTpe-is-derivative-then-GeneratedBy-is-required": {
+    "if-DatasetType-is-derivative-then-GeneratedBy-is-required": {
       "if": {
 	"type": "object",
 	"properties": {"DatasetType": {"const": "derivative"}},

--- a/bids-validator/validators/json/schemas/dataset_description.json
+++ b/bids-validator/validators/json/schemas/dataset_description.json
@@ -104,14 +104,18 @@
   },
   "required": ["Name", "BIDSVersion"],
   "allOf": [
-    {
+    { "$ref": "#/dependency-definitions/if-DatasetTpe-is-derivative-then-GeneratedBy-is-required" }
+  ],
+  "dependency-definitions": {
+    "if-DatasetTpe-is-derivative-then-GeneratedBy-is-required": {
       "if": {
 	"type": "object",
-	"properties": {"DatasetType": {"const": "derivative"}}
+	"properties": {"DatasetType": {"const": "derivative"}},
+	"required": ["DatasetType"]
       },
       "then": {
 	"required": ["GeneratedBy"]
       }
     }
-  ]
+  }
 }

--- a/bids-validator/validators/json/schemas/dataset_description.json
+++ b/bids-validator/validators/json/schemas/dataset_description.json
@@ -54,7 +54,7 @@
     },
     "GeneratedBy": {
       "type": "array",
-      "minLength": 1,
+      "minItems": 1,
       "items": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
Need to make `GeneratedBy` mandatory if `DatasetType` is `"derivative"`. Not sure where yet. And should warn if `SourceDatasets` is missing.