### PR TITLE
Reorganize HED validation

### DIFF
--- a/bids-validator/tests/events.spec.js
+++ b/bids-validator/tests/events.spec.js
@@ -1190,30 +1190,5 @@ describe('Events', function() {
         assert.strictEqual(issues[0].code, 136)
       })
     })
-
-    it('should throw an issue if the HED string is empty after removing extra slashes and whitespace', () => {
-      const events = [
-        {
-          file: { path: '/sub01/sub01_task-test_events.tsv' },
-          path: '/sub01/sub01_task-test_events.tsv',
-          contents: 'onset\tduration\tHED\n' + '7\tsomething\t/ / / / \n',
-        },
-      ]
-      const jsonDictionary = {
-        '/sub01/sub01_task-test_events.json': {},
-        '/dataset_description.json': { HEDVersion: '8.0.0-alpha.1' },
-      }
-
-      return validate.Events.validateEvents(
-        events,
-        [],
-        headers,
-        jsonDictionary,
-        '',
-      ).then(issues => {
-        assert.strictEqual(issues.length, 1)
-        assert.strictEqual(issues[0].code, 137)
-      })
-    })
   })
 })

--- a/bids-validator/validators/events/hed.js
+++ b/bids-validator/validators/events/hed.js
@@ -89,14 +89,14 @@ export default function checkHedStrings(events, headers, jsonContents, dir) {
           // get the 'HED' field
           const rowCells = row.trim().split('\t')
           const hedStringParts = []
-          if (rowCells[hedColumnIndex]) {
+          if (rowCells[hedColumnIndex] && rowCells[hedColumnIndex] !== 'n/a') {
             hedStringParts.push(rowCells[hedColumnIndex])
           }
           for (const sidecarHedColumn in sidecarHedColumnIndices) {
             const sidecarHedIndex = sidecarHedColumnIndices[sidecarHedColumn]
             const sidecarHedData = sidecarHedTags[sidecarHedColumn]
             const rowCell = rowCells[sidecarHedIndex]
-            if (rowCell) {
+            if (rowCell && rowCell !== 'n/a') {
               let sidecarHedString
               if (!sidecarHedData) {
                 continue

--- a/bids-validator/validators/events/hed.js
+++ b/bids-validator/validators/events/hed.js
@@ -21,14 +21,13 @@ export default function checkHedStrings(events, headers, jsonContents, dir) {
         datasetDescription.HEDVersion,
       )
     }
-  } else {
-    issues.push(new Issue({ code: 132 }))
   }
 
   // run HED validator
   return hedValidator.validator
     .buildSchema(schemaDefinition)
     .then(hedSchema => {
+      let hedStringsFound = false
       // loop through event data files
       events.forEach(eventFile => {
         const hedStrings = []
@@ -127,6 +126,10 @@ export default function checkHedStrings(events, headers, jsonContents, dir) {
           hedStrings.push(hedStringParts.join(','))
         }
 
+        if (hedStrings.length > 0) {
+          hedStringsFound = true
+        }
+
         for (const hedString of hedStrings) {
           const [
             isHedStringValid,
@@ -145,6 +148,9 @@ export default function checkHedStrings(events, headers, jsonContents, dir) {
           }
         }
       })
+      if (hedStringsFound && Object.entries(schemaDefinition).length === 0) {
+        issues.push(new Issue({ code: 132 }))
+      }
       return issues
     })
 }

--- a/bids-validator/validators/events/hed.js
+++ b/bids-validator/validators/events/hed.js
@@ -7,132 +7,127 @@ const Issue = utils.issues.Issue
 export default function checkHedStrings(events, headers, jsonContents, dir) {
   let issues = []
 
-  const hedStrings = []
+  // find specified version in sidecar
+  const schemaDefinition = {}
+  const datasetDescription = jsonContents['/dataset_description.json']
 
-  // loop through event data files
-  events.forEach(eventFile => {
-    // get the json sidecar dictionary associated with the event data
-    const potentialSidecars = utils.files.potentialLocations(
-      eventFile.path.replace('.tsv', '.json'),
-    )
-    const mergedDictionary = utils.files.generateMergedSidecarDict(
-      potentialSidecars,
-      jsonContents,
-    )
+  if (datasetDescription && datasetDescription.HEDVersion) {
+    if (semver.valid(datasetDescription.HEDVersion)) {
+      schemaDefinition.version = datasetDescription.HEDVersion
+    } else {
+      schemaDefinition.path = path.join(
+        path.resolve(dir),
+        'sourcedata',
+        datasetDescription.HEDVersion,
+      )
+    }
+  } else {
+    issues.push(new Issue({ code: 132 }))
+  }
 
-    const sidecarHedTags = {}
-    for (const sidecarKey in mergedDictionary) {
-      const sidecarValue = mergedDictionary[sidecarKey]
-      if (
-        sidecarValue !== null &&
-        typeof sidecarValue === 'object' &&
-        sidecarValue.HED !== undefined
-      ) {
-        const sidecarHedData = sidecarValue.HED
-        if (
-          typeof sidecarHedData === 'string' &&
-          sidecarHedData.split('#').length !== 2
-        ) {
-          issues.push(
-            new Issue({
-              code: 134,
-              file: eventFile.file,
-              evidence: sidecarHedData,
-            }),
-          )
-          sidecarHedTags[sidecarKey] = false
-        } else {
-          sidecarHedTags[sidecarKey] = sidecarHedData
+  // run HED validator
+  return hedValidator.validator
+    .buildSchema(schemaDefinition)
+    .then(hedSchema => {
+      // loop through event data files
+      events.forEach(eventFile => {
+        const hedStrings = []
+        // get the json sidecar dictionary associated with the event data
+        const potentialSidecars = utils.files.potentialLocations(
+          eventFile.path.replace('.tsv', '.json'),
+        )
+        const mergedDictionary = utils.files.generateMergedSidecarDict(
+          potentialSidecars,
+          jsonContents,
+        )
+
+        const sidecarHedTags = {}
+        for (const sidecarKey in mergedDictionary) {
+          const sidecarValue = mergedDictionary[sidecarKey]
+          if (
+            sidecarValue !== null &&
+            typeof sidecarValue === 'object' &&
+            sidecarValue.HED !== undefined
+          ) {
+            const sidecarHedData = sidecarValue.HED
+            if (
+              typeof sidecarHedData === 'string' &&
+              sidecarHedData.split('#').length !== 2
+            ) {
+              issues.push(
+                new Issue({
+                  code: 134,
+                  file: eventFile.file,
+                  evidence: sidecarHedData,
+                }),
+              )
+              sidecarHedTags[sidecarKey] = false
+            } else {
+              sidecarHedTags[sidecarKey] = sidecarHedData
+            }
+          }
         }
-      }
-    }
 
-    // get all non-empty rows
-    const rows = eventFile.contents
-      .split('\n')
-      .filter(row => !(!row || /^\s*$/.test(row)))
+        // get all non-empty rows
+        const rows = eventFile.contents
+          .split('\n')
+          .filter(row => !(!row || /^\s*$/.test(row)))
 
-    const columnHeaders = rows[0].trim().split('\t')
-    const hedColumnIndex = columnHeaders.indexOf('HED')
-    const sidecarHedColumnIndices = {}
-    for (const sidecarHedColumn in sidecarHedTags) {
-      const sidecarHedColumnHeader = columnHeaders.indexOf(sidecarHedColumn)
-      if (sidecarHedColumnHeader > -1) {
-        sidecarHedColumnIndices[sidecarHedColumn] = sidecarHedColumnHeader
-      }
-    }
-    if (hedColumnIndex === -1 && sidecarHedColumnIndices.length === 0) {
-      return
-    }
+        const columnHeaders = rows[0].trim().split('\t')
+        const hedColumnIndex = columnHeaders.indexOf('HED')
+        const sidecarHedColumnIndices = {}
+        for (const sidecarHedColumn in sidecarHedTags) {
+          const sidecarHedColumnHeader = columnHeaders.indexOf(sidecarHedColumn)
+          if (sidecarHedColumnHeader > -1) {
+            sidecarHedColumnIndices[sidecarHedColumn] = sidecarHedColumnHeader
+          }
+        }
+        if (hedColumnIndex === -1 && sidecarHedColumnIndices.length === 0) {
+          return
+        }
 
-    for (const row of rows.slice(1)) {
-      // get the 'HED' field
-      const rowCells = row.trim().split('\t')
-      const hedStringParts = []
-      if (rowCells[hedColumnIndex]) {
-        hedStringParts.push(rowCells[hedColumnIndex])
-      }
-      for (const sidecarHedColumn in sidecarHedColumnIndices) {
-        const sidecarHedIndex = sidecarHedColumnIndices[sidecarHedColumn]
-        const sidecarHedData = sidecarHedTags[sidecarHedColumn]
-        const rowCell = rowCells[sidecarHedIndex]
-        if (rowCell) {
-          let sidecarHedString
-          if (!sidecarHedData) {
+        for (const row of rows.slice(1)) {
+          // get the 'HED' field
+          const rowCells = row.trim().split('\t')
+          const hedStringParts = []
+          if (rowCells[hedColumnIndex]) {
+            hedStringParts.push(rowCells[hedColumnIndex])
+          }
+          for (const sidecarHedColumn in sidecarHedColumnIndices) {
+            const sidecarHedIndex = sidecarHedColumnIndices[sidecarHedColumn]
+            const sidecarHedData = sidecarHedTags[sidecarHedColumn]
+            const rowCell = rowCells[sidecarHedIndex]
+            if (rowCell) {
+              let sidecarHedString
+              if (!sidecarHedData) {
+                continue
+              }
+              if (typeof sidecarHedData === 'string') {
+                sidecarHedString = sidecarHedData.replace('#', rowCell)
+              } else {
+                sidecarHedString = sidecarHedData[rowCell]
+              }
+              if (sidecarHedString !== undefined) {
+                hedStringParts.push(sidecarHedString)
+              } else {
+                issues.push(
+                  new Issue({
+                    code: 112,
+                    file: eventFile.file,
+                    evidence: rowCell,
+                  }),
+                )
+              }
+            }
+          }
+
+          if (hedStringParts.length === 0) {
             continue
           }
-          if (typeof sidecarHedData === 'string') {
-            sidecarHedString = sidecarHedData.replace('#', rowCell)
-          } else {
-            sidecarHedString = sidecarHedData[rowCell]
-          }
-          if (sidecarHedString !== undefined) {
-            hedStringParts.push(sidecarHedString)
-          } else {
-            issues.push(
-              new Issue({
-                code: 112,
-                file: eventFile.file,
-                evidence: rowCell,
-              }),
-            )
-          }
+          hedStrings.push(hedStringParts.join(','))
         }
-      }
 
-      if (hedStringParts.length === 0) {
-        continue
-      }
-      hedStrings.push([eventFile.file, hedStringParts.join(',')])
-    }
-  })
-
-  if (hedStrings.length === 0) {
-    return Promise.resolve(issues)
-  } else {
-    // find specified version in sidecar
-    const schemaDefinition = {}
-    const datasetDescription = jsonContents['/dataset_description.json']
-
-    if (datasetDescription && datasetDescription.HEDVersion) {
-      if (semver.valid(datasetDescription.HEDVersion)) {
-        schemaDefinition.version = datasetDescription.HEDVersion
-      } else {
-        schemaDefinition.path = path.join(
-          path.resolve(dir),
-          'sourcedata',
-          datasetDescription.HEDVersion,
-        )
-      }
-    } else {
-      issues.push(new Issue({ code: 132 }))
-    }
-
-    // run HED validator
-    return hedValidator.validator
-      .buildSchema(schemaDefinition)
-      .then(hedSchema => {
-        for (const [file, hedString] of hedStrings) {
+        for (const hedString of hedStrings) {
           const [
             isHedStringValid,
             hedIssues,
@@ -144,14 +139,14 @@ export default function checkHedStrings(events, headers, jsonContents, dir) {
           if (!isHedStringValid) {
             const convertedIssues = convertHedIssuesToBidsIssues(
               hedIssues,
-              file,
+              eventFile.file,
             )
             issues = issues.concat(convertedIssues)
           }
         }
-        return issues
       })
-  }
+      return issues
+    })
 }
 
 function convertHedIssuesToBidsIssues(hedIssues, file) {


### PR DESCRIPTION
This pull request reorganizes the HED validation code in preparation for future support of dataset-level HED validation, which will come with version 3 of hed-validator. It also properly ignores "n/a" cells during validation, properly complying with the spec. The missing tests from #1101 have been added, thus fixing #1115.

Actual support for dataset-level validation will be deferred to a future PR. Sidecar-level validation, also required by HED 3, will also be added at that time.

Fixes #1115