### PR TITLE
add preregistration to dataset_description schema

### DIFF
--- a/bids-validator/validators/json/schemas/dataset_description.json
+++ b/bids-validator/validators/json/schemas/dataset_description.json
@@ -52,6 +52,9 @@
     "DatasetDOI": {
       "type": "string"
     },
+    "Preregistration": {
+      "type": "string"
+    },
     "GeneratedBy": {
       "type": "array",
       "minItems": 1,

--- a/bids-validator/validators/json/schemas/dataset_description.json
+++ b/bids-validator/validators/json/schemas/dataset_description.json
@@ -53,7 +53,8 @@
       "type": "string"
     },
     "Preregistration": {
-      "type": "string"
+      "type": "string",
+      "format": "uri"
     },
     "GeneratedBy": {
       "type": "array",


### PR DESCRIPTION
Related to its [counterpart PR on specs repo](https://github.com/bids-standard/bids-specification/pull/572)

#### For reviewers

I added this by working from the examples provided by the other fields: let me know if I missed something. :wink: #Newbie

