### PR TITLE
remove isCorrectModality function and its call in quicktest

### DIFF
--- a/bids-validator/utils/modalities.js
+++ b/bids-validator/utils/modalities.js
@@ -39,37 +39,4 @@ export default {
 
     return modalities
   },
-
-  isCorrectModality: path => {
-    let isCorrectModality = false
-    // MRI
-    if (
-      path[0].includes('.nii') &&
-      ['anat', 'func', 'dwi'].indexOf(path[1]) != -1
-    ) {
-      isCorrectModality = true
-    } else if (['.json', '.tsv'].some(v => path[0].includes(v))) {
-      const testPath = path[1]
-      switch (testPath) {
-        case 'meg':
-          // MEG
-          isCorrectModality = true
-          break
-        case 'eeg':
-          // EEG
-          isCorrectModality = true
-          break
-        case 'ieeg':
-          // iEEG
-          isCorrectModality = true
-          break
-        case 'beh':
-          isCorrectModality = true
-          break
-        default:
-          break
-      }
-    }
-    return isCorrectModality
-  },
 }

--- a/bids-validator/validators/bids/quickTest.js
+++ b/bids-validator/validators/bids/quickTest.js
@@ -1,4 +1,3 @@
-import utils from '../../utils'
 /**
  * Quick Test
  *
@@ -17,12 +16,11 @@ const quickTest = fileList => {
       path = path.split('/')
       path = path.reverse()
 
-      const isCorrectModality = utils.modalities.isCorrectModality(path)
       let pathIsSesOrSub =
-      path[2] &&
+        path[2] &&
         (path[2].indexOf('ses-') == 0 || path[2].indexOf('sub-') == 0)
 
-      return pathIsSesOrSub && isCorrectModality
+      return pathIsSesOrSub
     }
   })
   return couldBeBIDS


### PR DESCRIPTION
Quicktest looks to see if there was at least one file that either:
1. had a .nii extension and was in a either a func, anat, or dwi directory
2. had a json or tsv extension and was in any other accepted modality directory.

This is causing more problems that it solves:
https://neurostars.org/t/quick-validation-failed-on-physiological-files/17611

We now have regex to let users know what is a correctly or incorrectly formed filename. This PR makes quicktest just test that at least one subject session directory exists.