### PR TITLE
Provide issue CHANNELS_COLUMN_STATUS evidence as string

### DIFF
--- a/bids-validator/validators/tsv/checkStatusCol.js
+++ b/bids-validator/validators/tsv/checkStatusCol.js
@@ -21,7 +21,7 @@ const checkStatusCol = function(rows, file, issues) {
         issues.push(
           new Issue({
             file: file,
-            evidence: line,
+            evidence: line.toString(),
             line: i + 1,
             reason:
               'the status column values should either be good, bad, or n/a',


### PR DESCRIPTION
This fixes issue CHANNELS_COLUMN_STATUS to return the evidence field as string. OpenNeuro expects the JSON here to be consistently typed and fixing this prevents it from stumbling over any datasets with this issue.