### PR TITLE
Implement sidecar-level HED validation

### DIFF
--- a/bids-validator/package.json
+++ b/bids-validator/package.json
@@ -27,7 +27,7 @@
     "cross-fetch": "^2.2.2",
     "date-fns": "^2.7.0",
     "esm": "^3.2.25",
-    "hed-validator": "^2.0.1",
+    "hed-validator": "^3.0.0",
     "ignore": "^4.0.2",
     "is-utf8": "^0.2.1",
     "jshint": "^2.9.6",

--- a/bids-validator/tests/events.spec.js
+++ b/bids-validator/tests/events.spec.js
@@ -604,7 +604,7 @@ describe('Events', function() {
             },
           },
           myValue: {
-            HED: 'Attribute/Visual/Color/#,Item/Object/Vehicle/Bus',
+            HED: 'Attribute/Visual/Color/#,Item/Object/Vehicle/Bicycle',
           },
         },
         '/dataset_description.json': { HEDVersion: '7.1.1' },
@@ -643,7 +643,7 @@ describe('Events', function() {
             },
           },
           myCodes: {
-            HED: 'Attribute/Visual/Color/#,Item/Object/Vehicle/Bus',
+            HED: 'Attribute/Visual/Color/#,Item/Object/Vehicle/Bicycle',
           },
         },
         '/dataset_description.json': { HEDVersion: '7.1.1' },
@@ -681,7 +681,7 @@ describe('Events', function() {
             },
           },
           myValue: {
-            HED: 'Attribute/Visual/Color,Item/Object/Vehicle/Bus',
+            HED: 'Attribute/Visual/Color/Red,Item/Object/Vehicle/Bicycle',
           },
         },
         '/dataset_description.json': { HEDVersion: '7.1.1' },
@@ -907,7 +907,7 @@ describe('Events', function() {
           path: '/sub01/sub01_task-test_events.tsv',
           contents:
             'onset\tduration\tHED\n' +
-            '7\tsomething\tEvent/Label/Test,Event/Category/Miscellaneous/Test,Event/Description/Test,Item/Object/Person/Driver,Event/Something\n',
+            '7\tsomething\tEvent/Label/Test,Event/Category/Miscellaneous/Test,Event/Description/Test,Item/Object/Person/Cyclist,Event/Something\n',
         },
       ]
       const jsonDictionary = {

--- a/bids-validator/tests/events.spec.js
+++ b/bids-validator/tests/events.spec.js
@@ -927,6 +927,33 @@ describe('Events', function() {
       })
     })
 
+    it('should throw an issue if the HED column in a single row contains invalid HED data in the form of a tag extension', () => {
+      const events = [
+        {
+          file: { path: '/sub01/sub01_task-test_events.tsv' },
+          path: '/sub01/sub01_task-test_events.tsv',
+          contents:
+            'onset\tduration\tHED\n' +
+            '7\tsomething\tEvent/Label/Test,Event/Category/Miscellaneous/Test,Event/Description/Test,Item/Object/Person/Driver\n',
+        },
+      ]
+      const jsonDictionary = {
+        '/sub01/sub01_task-test_events.json': {},
+        '/dataset_description.json': { HEDVersion: '7.1.1' },
+      }
+
+      return validate.Events.validateEvents(
+        events,
+        [],
+        headers,
+        jsonDictionary,
+        '',
+      ).then(issues => {
+        assert.strictEqual(issues.length, 1)
+        assert.strictEqual(issues[0].code, 140)
+      })
+    })
+
     it('should throw an issue if the HED column in a single row contains invalid HED data in the form of a duplicate unique tag', () => {
       const events = [
         {
@@ -1166,7 +1193,7 @@ describe('Events', function() {
       })
     })
 
-    it('should throw an issue if the HED string contains non-existent path', () => {
+    it('should throw an issue if the HED string contains a non-existent path', () => {
       const events = [
         {
           file: { path: '/sub01/sub01_task-test_events.tsv' },

--- a/bids-validator/tests/events.spec.js
+++ b/bids-validator/tests/events.spec.js
@@ -1171,9 +1171,7 @@ describe('Events', function() {
         {
           file: { path: '/sub01/sub01_task-test_events.tsv' },
           path: '/sub01/sub01_task-test_events.tsv',
-          contents:
-            'onset\tduration\tmyCodes\n' +
-            '7\tsomething\tone\n',
+          contents: 'onset\tduration\tmyCodes\n' + '7\tsomething\tone\n',
         },
       ]
       const jsonDictionary = {
@@ -1230,9 +1228,7 @@ describe('Events', function() {
         {
           file: { path: '/sub01/sub01_task-test_events.tsv' },
           path: '/sub01/sub01_task-test_events.tsv',
-          contents:
-            'onset\tduration\tmyCodes\n' +
-            '7\tsomething\tone\n',
+          contents: 'onset\tduration\tmyCodes\n' + '7\tsomething\tone\n',
         },
       ]
       const jsonDictionary = {
@@ -1289,9 +1285,7 @@ describe('Events', function() {
         {
           file: { path: '/sub01/sub01_task-test_events.tsv' },
           path: '/sub01/sub01_task-test_events.tsv',
-          contents:
-            'onset\tduration\tmyCodes\n' +
-            '7\tsomething\tone\n',
+          contents: 'onset\tduration\tmyCodes\n' + '7\tsomething\tone\n',
         },
       ]
       const jsonDictionary = {

--- a/bids-validator/tests/events.spec.js
+++ b/bids-validator/tests/events.spec.js
@@ -1166,6 +1166,38 @@ describe('Events', function() {
       })
     })
 
+    it('should not throw an issue if a sidecar HED string is a valid short-form tag', () => {
+      const events = [
+        {
+          file: { path: '/sub01/sub01_task-test_events.tsv' },
+          path: '/sub01/sub01_task-test_events.tsv',
+          contents:
+            'onset\tduration\tmyCodes\n' +
+            '7\tsomething\tone\n',
+        },
+      ]
+      const jsonDictionary = {
+        '/sub01/sub01_task-test_events.json': {
+          myCodes: {
+            HED: {
+              one: 'Duration/3 ms',
+            },
+          },
+        },
+        '/dataset_description.json': { HEDVersion: '8.0.0-alpha.1' },
+      }
+
+      return validate.Events.validateEvents(
+        events,
+        [],
+        headers,
+        jsonDictionary,
+        '',
+      ).then(issues => {
+        assert.deepStrictEqual(issues, [])
+      })
+    })
+
     it('should throw an issue if the HED string contains a nested valid short-form tag', () => {
       const events = [
         {
@@ -1193,6 +1225,40 @@ describe('Events', function() {
       })
     })
 
+    it('should throw an issue if a sidecar HED string contains a nested valid short-form tag', () => {
+      const events = [
+        {
+          file: { path: '/sub01/sub01_task-test_events.tsv' },
+          path: '/sub01/sub01_task-test_events.tsv',
+          contents:
+            'onset\tduration\tmyCodes\n' +
+            '7\tsomething\tone\n',
+        },
+      ]
+      const jsonDictionary = {
+        '/sub01/sub01_task-test_events.json': {
+          myCodes: {
+            HED: {
+              one: 'Experiment-control/Geometric',
+            },
+          },
+        },
+        '/dataset_description.json': { HEDVersion: '8.0.0-alpha.1' },
+      }
+
+      return validate.Events.validateEvents(
+        events,
+        [],
+        headers,
+        jsonDictionary,
+        '',
+      ).then(issues => {
+        assert.strictEqual(issues.length, 2)
+        assert.strictEqual(issues[0].code, 139)
+        assert.strictEqual(issues[1].code, 135)
+      })
+    })
+
     it('should throw an issue if the HED string contains a non-existent path', () => {
       const events = [
         {
@@ -1215,6 +1281,40 @@ describe('Events', function() {
       ).then(issues => {
         assert.strictEqual(issues.length, 1)
         assert.strictEqual(issues[0].code, 136)
+      })
+    })
+
+    it('should throw an issue if a sidecar HED string contains a non-existent path', () => {
+      const events = [
+        {
+          file: { path: '/sub01/sub01_task-test_events.tsv' },
+          path: '/sub01/sub01_task-test_events.tsv',
+          contents:
+            'onset\tduration\tmyCodes\n' +
+            '7\tsomething\tone\n',
+        },
+      ]
+      const jsonDictionary = {
+        '/sub01/sub01_task-test_events.json': {
+          myCodes: {
+            HED: {
+              one: 'InvalidEvent',
+            },
+          },
+        },
+        '/dataset_description.json': { HEDVersion: '8.0.0-alpha.1' },
+      }
+
+      return validate.Events.validateEvents(
+        events,
+        [],
+        headers,
+        jsonDictionary,
+        '',
+      ).then(issues => {
+        assert.strictEqual(issues.length, 2)
+        assert.strictEqual(issues[0].code, 139)
+        assert.strictEqual(issues[1].code, 136)
       })
     })
   })

--- a/bids-validator/utils/issues/list.js
+++ b/bids-validator/utils/issues/list.js
@@ -765,4 +765,9 @@ export default {
     severity: 'error',
     reason: 'The source HED schema is invalid as it contains duplicate tags.',
   },
+  139: {
+    key: 'HED_INVALID_SIDECAR',
+    severity: 'error',
+    reason: 'A HED error was found in the JSON sidecar.',
+  },
 }

--- a/bids-validator/utils/issues/list.js
+++ b/bids-validator/utils/issues/list.js
@@ -770,4 +770,9 @@ export default {
     severity: 'error',
     reason: 'A HED error was found in the JSON sidecar.',
   },
+  140: {
+    key: 'HED_TAG_EXTENSION',
+    severity: 'warning',
+    reason: 'A HED tag extension was found.',
+  },
 }

--- a/bids-validator/validators/events/hed.js
+++ b/bids-validator/validators/events/hed.js
@@ -185,22 +185,20 @@ export default function checkHedStrings(events, headers, jsonContents, dir) {
           hedStringsFound = true
         }
 
-        for (const hedString of hedStrings) {
-          const [
-            isHedStringValid,
+        const [
+          isHedDatasetValid,
+          hedIssues,
+        ] = hedValidator.validator.validateHedDataset(
+          hedStrings,
+          hedSchema,
+          true,
+        )
+        if (!isHedDatasetValid) {
+          const convertedIssues = convertHedIssuesToBidsIssues(
             hedIssues,
-          ] = hedValidator.validator.validateHedEvent(
-            hedString,
-            hedSchema,
-            true,
+            eventFile.file,
           )
-          if (!isHedStringValid) {
-            const convertedIssues = convertHedIssuesToBidsIssues(
-              hedIssues,
-              eventFile.file,
-            )
-            issues = issues.concat(convertedIssues)
-          }
+          issues = issues.concat(convertedIssues)
         }
       })
       if (hedStringsFound && Object.entries(schemaDefinition).length === 0) {

--- a/bids-validator/validators/events/hed.js
+++ b/bids-validator/validators/events/hed.js
@@ -67,6 +67,7 @@ export default function checkHedStrings(events, headers, jsonContents, dir) {
                 hedString,
                 hedSchema,
                 true,
+                true,
               )
               if (!isHedStringValid) {
                 const convertedIssues = convertHedIssuesToBidsIssues(
@@ -188,7 +189,7 @@ export default function checkHedStrings(events, headers, jsonContents, dir) {
           const [
             isHedStringValid,
             hedIssues,
-          ] = hedValidator.validator.validateHedString(
+          ] = hedValidator.validator.validateHedEvent(
             hedString,
             hedSchema,
             true,

--- a/bids-validator/validators/events/hed.js
+++ b/bids-validator/validators/events/hed.js
@@ -41,7 +41,7 @@ export default function checkHedStrings(events, headers, jsonContents, dir) {
         for (const sidecarName of potentialSidecars) {
           if (!(sidecarName in sidecarIssues)) {
             const sidecarDictionary = jsonContents[sidecarName]
-            const sidecarHedStrings = []
+            let sidecarHedStrings = []
             for (const sidecarKey in sidecarDictionary) {
               const sidecarValue = sidecarDictionary[sidecarKey]
               if (
@@ -49,7 +49,13 @@ export default function checkHedStrings(events, headers, jsonContents, dir) {
                 typeof sidecarValue === 'object' &&
                 sidecarValue.HED !== undefined
               ) {
-                sidecarHedStrings.push(sidecarValue.HED)
+                if (typeof sidecarValue.HED === 'string') {
+                  sidecarHedStrings.push(sidecarValue.HED)
+                } else {
+                  sidecarHedStrings = sidecarHedStrings.concat(
+                    Object.values(sidecarValue.HED),
+                  )
+                }
               }
             }
             let fileIssues = []

--- a/bids-validator/validators/events/hed.js
+++ b/bids-validator/validators/events/hed.js
@@ -230,6 +230,7 @@ function convertHedIssuesToBidsIssues(hedIssues, file) {
     noValidTagFound: 136,
     emptyTagFound: 137,
     duplicateTagsInSchema: 138,
+    extension: 140,
   }
 
   const convertedIssues = []


### PR DESCRIPTION
This branch continues the work from #1116 by actually implementing sidecar-level validation. This includes bumping the dependency requirement to the just-released version 3.0.0 of hed-validator, along with supporting a new warning code from that package for tag extensions.