### PR TITLE
[FIX] Validate TermURL is formatted as a URI

### DIFF
--- a/bids-validator/validators/json/schemas/data_dictionary.json
+++ b/bids-validator/validators/json/schemas/data_dictionary.json
@@ -34,7 +34,8 @@
         "TermURL": {
           "title": "TermURL",
           "description": "URL pointing to a formal definition in an ontology available on the web.",
-          "type": "string"
+          "type": "string",
+          "format": "uri"
         }
       }
     }

--- a/bids-validator/validators/json/schemas/dataset_description.json
+++ b/bids-validator/validators/json/schemas/dataset_description.json
@@ -50,8 +50,7 @@
       "type": "array"
     },
     "DatasetDOI": {
-      "type": "string",
-      "format": "uri"
+      "type": "string"
     },
     "Preregistration": {
       "type": "string",
@@ -84,7 +83,7 @@
         "type": "object",
         "properties": {
           "URL": {"type": "string", "format": "uri"},
-          "DOI": {"type": "string", "format": "uri"},
+          "DOI": {"type": "string"},
           "Version": {"type": "string"}
         }
       }

--- a/bids-validator/validators/json/schemas/dataset_description.json
+++ b/bids-validator/validators/json/schemas/dataset_description.json
@@ -50,7 +50,8 @@
       "type": "array"
     },
     "DatasetDOI": {
-      "type": "string"
+      "type": "string",
+      "format": "uri"
     },
     "Preregistration": {
       "type": "string",
@@ -83,7 +84,7 @@
         "type": "object",
         "properties": {
           "URL": {"type": "string", "format": "uri"},
-          "DOI": {"type": "string"},
+          "DOI": {"type": "string", "format": "uri"},
           "Version": {"type": "string"}
         }
       }


### PR DESCRIPTION
related to #1121 

A couple of instances of DOI and URL are just of the `type string` but should also include `format URI` according to the specs.

One thing I am not clear about the validator yet is how it tells apart things that `required` from the `recommended` ones: in more concrete fashion "are the changes that I am introducing here going to start breaking people's dataset or just throw warnings?"