### PR TITLE
allow json sidecars for tsv in top and session for MEG EEG iEEG channels and EEG iEEG electrodes

### DIFF
--- a/bids-validator/bids_validator/rules/session_level_rules.json
+++ b/bids-validator/bids_validator/rules/session_level_rules.json
@@ -54,6 +54,7 @@
       "@@@_meg_ses_type_@@@": [
         "_events.tsv",
         "_channels.tsv",
+        "_channels.json",
         "_meg.json",
         "_coordsystem.json",
         "_photo.jpg",
@@ -68,7 +69,9 @@
       "@@@_eeg_ses_type_@@@": [
         "_events.tsv",
         "_channels.tsv",
+        "_channels.json",
         "_electrodes.tsv",
+        "_electrodes.json",
         "_eeg.json",
         "_coordsystem.json",
         "_photo.jpg"
@@ -82,7 +85,9 @@
       "@@@_ieeg_ses_type_@@@": [
         "_events.tsv",
         "_channels.tsv",
+        "_channels.json",
         "_electrodes.tsv",
+        "_electrodes.json",
         "_ieeg.json",
         "_coordsystem.json",
         "_photo.jpg"

--- a/bids-validator/bids_validator/rules/top_level_rules.json
+++ b/bids-validator/bids_validator/rules/top_level_rules.json
@@ -71,7 +71,9 @@
       "@@@_eeg_top_ext_@@@": [
         "_eeg\\.json",
         "_channels\\.tsv",
+        "_channels\\.json",
         "_electrodes\\.tsv",
+        "_electrodes\\.json",
         "_photo\\.jpg",
         "_coordsystem\\.json"
       ]
@@ -83,7 +85,9 @@
       "@@@_ieeg_top_ext_@@@": [
         "_ieeg\\.json",
         "_channels\\.tsv",
+        "_channels\\.json",
         "_electrodes\\.tsv",
+        "_electrodes\\.json",
         "_photo\\.jpg",
         "_coordsystem\\.json"
       ]
@@ -95,6 +99,7 @@
       "@@@_meg_top_ext_@@@": [
         "_meg\\.json",
         "_channels\\.tsv",
+        "_channels\\.json",
         "_photo\\.jpg",
         "_coordsystem\\.json"
       ]


### PR DESCRIPTION
closes #1118 

If we allow the TSV file, we should allow an accompanying JSON (for electrodes and channels).

related: https://github.com/bids-standard/bids-starter-kit/pull/140