### PR TITLE
Add --filenames option to validate filenames from stdin

### DIFF
--- a/bids-validator/bin/bids-validator
+++ b/bids-validator/bin/bids-validator
@@ -2,7 +2,7 @@
 
 process.title = 'bids-validator'
 
-var argv = require('yargs')
+const argv = require('yargs')
   .usage('Usage: $0 <dataset_directory> [options]')
   .help('help')
   .alias('help', 'h')
@@ -50,6 +50,13 @@ var argv = require('yargs')
       'Optional configuration file. See https://github.com/bids-standard/bids-validator for more info',
     default: '.bids-validator-config.json',
   })
+  .boolean('filenames')
+  .default('filenames', false)
+  .describe(
+    'filenames',
+    'A less accurate check that reads filenames one per line from stdin.',
+  )
+  .hide('filenames')
   .epilogue(
     'This tool checks if a dataset in a given directory is \
 compatible with the Brain Imaging Data Structure specification. To learn \

--- a/bids-validator/cli.js
+++ b/bids-validator/cli.js
@@ -5,7 +5,7 @@ import validate from './index.js'
 const format = validate.consoleFormat
 import colors from 'colors/safe'
 import fs from 'fs'
-import remoteFiles from './utils/files/remoteFiles'
+import { filenamesOnly } from './utils/filenamesOnly.js'
 
 const exitProcess = issues => {
   if (
@@ -50,6 +50,10 @@ export default function(dir, options) {
     )
     process.exit(3)
   })
+
+  if (options.filenames) {
+    return filenamesOnly()
+  }
 
   if (fs.existsSync(dir)) {
     if (options.json) {

--- a/bids-validator/utils/__tests__/filenamesOnly.spec.js
+++ b/bids-validator/utils/__tests__/filenamesOnly.spec.js
@@ -1,0 +1,28 @@
+import { validateFilenames } from '../filenamesOnly.js'
+
+describe('test filenames mode', () => {
+  beforeEach(() => {
+    console.log = jest.fn()
+  })
+  it('throws an error when obviously non-BIDS input', async () => {
+    async function* badData() {
+      yield 'nope'
+      yield 'not-bids'
+      yield 'data'
+    }
+    const res = await validateFilenames(badData())
+    expect(res).toBe(false)
+  })
+  it('passes validation with a simple dataset', async () => {
+    async function* goodData() {
+      yield 'CHANGES'
+      yield 'dataset_description.json'
+      yield 'participants.tsv'
+      yield 'README'
+      yield 'sub-01/anat/sub-01_T1w.nii.gz'
+      yield 'T1w.json'
+    }
+    const res = await validateFilenames(goodData())
+    expect(res).toBe(true)
+  })
+})

--- a/bids-validator/utils/filenamesOnly.js
+++ b/bids-validator/utils/filenamesOnly.js
@@ -1,0 +1,73 @@
+/**
+ * Run validation against a list of input files from git pre-receive
+ */
+import readline from 'readline'
+import path from 'path'
+import { promisify } from 'util'
+import consoleFormat from './consoleFormat'
+import quickTest from '../validators/bids/quickTest'
+import fullTest from '../validators/bids/fullTest'
+
+// Disable most tests that might access files
+const defaultOptions = {
+  ignoreWarnings: true,
+  ignoreNiftiHeaders: true,
+  ignoreSymlinks: true,
+  ignoreSubjectConsistency: true,
+  verbose: false,
+  gitTreeMode: false,
+  remoteFiles: false,
+  gitRef: 'HEAD',
+  config: { ignore: [44], warn: [], error: [], ignoredFiles: [] },
+}
+
+async function generateFileObjects(stream) {
+  const inputFiles = {}
+  let index = 0
+  for await (const line of stream) {
+    const rootPath = `/${line}`
+    /**
+     * Simulated file object based on input
+     * File size is 1 to prevent 0 size errors but makes some checks inaccurate
+     */
+    const file = {
+      name: path.basename(line),
+      path: rootPath,
+      relativePath: rootPath,
+      size: 1,
+    }
+    inputFiles[index] = file
+    index++
+  }
+  return inputFiles
+}
+
+export async function validateFilenames(stream) {
+  const inputFiles = await generateFileObjects(stream)
+  const couldBeBIDS = quickTest(inputFiles)
+  if (couldBeBIDS) {
+    await new Promise(resolve => {
+      fullTest(inputFiles, defaultOptions, false, '/dev/null', function(
+        issues,
+        summary,
+      ) {
+        console.log(consoleFormat.issues(issues, defaultOptions) + '\n')
+        console.log(consoleFormat.summary(summary, defaultOptions))
+        resolve()
+      })
+    })
+    return true
+  } else {
+    console.log(
+      'This dataset failed a quick validation, please verify it is a BIDS dataset at the root of the git repository',
+    )
+    return false
+  }
+}
+
+export async function filenamesOnly() {
+  const rl = readline.createInterface({
+    input: process.stdin,
+  })
+  validateFilenames(rl)
+}


### PR DESCRIPTION
This adds support for passing filenames from stdin and running validation against the list, which is useful for OpenNeuro to perform some validation before a dataset is pushed. At the time this needs to run, there are only filenames available for new git tree (and file sizes for new files but not all files). Test 44 is disabled and a limitation is .bidsignore is not handled by this mode since file contents are not available when it runs.

I've hidden this option from the CLI help as it isn't that generally useful.