### PR TITLE
pixels is a valid unit for iEEG coordsystem

### DIFF
--- a/bids-validator/tests/json.spec.js
+++ b/bids-validator/tests/json.spec.js
@@ -291,7 +291,7 @@ describe('JSON', function() {
   it('iEEG *_coordsystem.json schema should require *Description if *Coordsystem is "Other"', function() {
     var jsonObj = {
       iEEGCoordinateSystem: 'Other',
-      iEEGCoordinateUnits: 'mm',
+      iEEGCoordinateUnits: 'pixels',
     }
     jsonDict[ieeg_coordsystem_file.relativePath] = jsonObj
     validate.JSON(ieeg_coordsystem_file, jsonDict, function(issues) {

--- a/bids-validator/validators/json/schemas/coordsystem_ieeg.json
+++ b/bids-validator/validators/json/schemas/coordsystem_ieeg.json
@@ -3,7 +3,7 @@
   "properties": {
     "IntendedFor": { "type": "string", "minLength": 1 },
     "iEEGCoordinateSystem": { "type": "string", "enum": ["Pixels", "ACPC", "Other"] },
-    "iEEGCoordinateUnits":  { "$ref": "common_definitions.json#/definitions/CoordUnits" },
+    "iEEGCoordinateUnits":  { "type": "string", "enum": ["m", "mm", "cm", "pixels", "n/a"] },
     "iEEGCoordinateSystemDescription": { "type": "string", "minLength": 1 },
     "iEEGCoordinateProcessingDescription": { "type": "string", "minLength": 1 },
     "iEEGCoordinateProcessingReference": { "type": "string", "minLength": 1 }


### PR DESCRIPTION
see table in https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/04-intracranial-electroencephalography.html#coordinate-system-json-_coordsystemjson

I wasn't sure how to make this work with the "common definitions":

https://github.com/bids-standard/bids-validator/blob/a110f684ac96921d7ac582c1ce81eda3ecb78925/bids-validator/validators/json/schemas/common_definitions.json#L6

... that is - whether it's possible to say something like `accept all keywords you find in $common-definitions, and additionally this one: pixels`.

So I just added the keywords on their own, which is less elegant, but achieves what we need.

needed for https://github.com/bids-standard/bids-examples/pull/221 to pass.