### PR TITLE
[FIX] remove preregistration from dataset_description schema

### DIFF
--- a/bids-validator/validators/json/schemas/dataset_description.json
+++ b/bids-validator/validators/json/schemas/dataset_description.json
@@ -52,10 +52,6 @@
     "DatasetDOI": {
       "type": "string"
     },
-    "Preregistration": {
-      "type": "string",
-      "format": "uri"
-    },
     "GeneratedBy": {
       "type": "array",
       "minItems": 1,


### PR DESCRIPTION
The PR in the spec to add pre-reg was not merged in the end so the schema needs to be reverted for this.

See: https://github.com/bids-standard/bids-specification/pull/572