### PR TITLE
Fix Sbref Regexps

### DIFF
--- a/bids-validator/bids_validator/rules/file_level_rules.json
+++ b/bids-validator/bids_validator/rules/file_level_rules.json
@@ -74,10 +74,18 @@
   },
 
   "dwi": {
-    "regexp": "^[\\/\\\\](sub-[a-zA-Z0-9]+)[\\/\\\\](?:(ses-[a-zA-Z0-9]+)[\\/\\\\])?dwi[\\/\\\\]\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_dir-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?((?:_@@@_dwi_type_@@@)\\.(@@@_dwi_ext_@@@)|(?:_recording-[a-zA-Z0-9]+)?(?:@@@_cont_ext_@@@))$",
+    "regexp": "^[\\/\\\\](sub-[a-zA-Z0-9]+)[\\/\\\\](?:(ses-[a-zA-Z0-9]+)[\\/\\\\])?dwi[\\/\\\\]\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_dir-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?((?:@@@_dwi_ext_@@@)|(?:_recording-[a-zA-Z0-9]+)?(?:@@@_cont_ext_@@@))$",
     "tokens": {
-      "@@@_dwi_ext_@@@": ["nii\\.gz", "nii", "json", "bvec", "bval"],
-      "@@@_dwi_type_@@@": ["dwi", "sbref"],
+      "@@@_dwi_ext_@@@": [
+        "_dwi\\.nii\\.gz",
+        "_dwi\\.nii",
+        "_dwi\\.json",
+        "_dwi\\.bvec",
+        "_dwi\\.bval",
+        "_sbref\\.nii\\.gz",
+        "_sbref\\.nii",
+        "_sbref\\.json"
+      ],
       "@@@_cont_ext_@@@": [
         "_physio\\.tsv\\.gz",
         "_stim\\.tsv\\.gz",

--- a/bids-validator/tests/type.spec.js
+++ b/bids-validator/tests/type.spec.js
@@ -188,9 +188,15 @@ describe('utils.type.file.isSessionLevel', function() {
 describe('utils.type.file.isDWI', function() {
   const goodFilenames = [
     '/sub-12/dwi/sub-12_dwi.nii.gz',
+    '/sub-12/dwi/sub-12_dwi.json',
     '/sub-12/ses-pre/dwi/sub-12_ses-pre_dwi.nii.gz',
     '/sub-12/ses-pre/dwi/sub-12_ses-pre_dwi.bvec',
     '/sub-12/ses-pre/dwi/sub-12_ses-pre_dwi.bval',
+    '/sub-12/ses-pre/dwi/sub-12_ses-pre_dwi.json',
+    '/sub-12/dwi/sub-12_sbref.nii.gz',
+    '/sub-12/dwi/sub-12_sbref.json',
+    '/sub-12/ses-pre/dwi/sub-12_ses-pre_sbref.nii.gz',
+    '/sub-12/ses-pre/dwi/sub-12_ses-pre_sbref.json',
   ]
 
   goodFilenames.forEach(function(path) {

--- a/bids-validator/tests/type.spec.js
+++ b/bids-validator/tests/type.spec.js
@@ -211,6 +211,10 @@ describe('utils.type.file.isDWI', function() {
     '/sub-12/ses-pre/sub-12_ses-pre_scan.tsv',
     '/sub-12/ses-pre/dwi/sub-12_ses-pre_dwi.bvecs',
     '/sub-12/ses-pre/dwi/sub-12_ses-pre_dwi.bvals',
+    '/sub-12/dwi/sub-12_sbref.bval',
+    '/sub-12/dwi/sub-12_sbref.bvec',
+    '/sub-12/ses-pre/dwi/sub-12_ses-pre_sbref.bval',
+    '/sub-12/ses-pre/dwi/sub-12_ses-pre_sbref.bvec',
   ]
 
   badFilenames.forEach(function(path) {


### PR DESCRIPTION
closes #1145 

According to https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/01-magnetic-resonance-imaging-data.html#diffusion-imaging-data there is no such thing as a DWI `*sbref.bvec` or `*sbref.bval`.

Prior to this PR however, this was permitted due to the `@@@_dwi_ext_@@@` and `@@@_dwi_type_@@@` being freely combined.

Other than that there was also an error in #1145 which is fixed with this PR (according to the test cases I added) ... but I don't know exactly what is fixed or what the issue was.

cc @rwblair @effigies  

EDIT: I also synced the bids-examples submodule with master  using `git pull` from the submodule directory -> `Submodule bids-examples updated 2831 files` 