### PR TITLE
Add support for passing .bidsignore to --filename only validation

### DIFF
--- a/bids-validator/utils/__tests__/filenamesOnly.spec.js
+++ b/bids-validator/utils/__tests__/filenamesOnly.spec.js
@@ -6,6 +6,7 @@ describe('test filenames mode', () => {
   })
   it('throws an error when obviously non-BIDS input', async () => {
     async function* badData() {
+      yield '0001'
       yield 'nope'
       yield 'not-bids'
       yield 'data'
@@ -15,12 +16,28 @@ describe('test filenames mode', () => {
   })
   it('passes validation with a simple dataset', async () => {
     async function* goodData() {
+      yield '0001'
       yield 'CHANGES'
       yield 'dataset_description.json'
       yield 'participants.tsv'
       yield 'README'
       yield 'sub-01/anat/sub-01_T1w.nii.gz'
       yield 'T1w.json'
+    }
+    const res = await validateFilenames(goodData())
+    expect(res).toBe(true)
+  })
+  it('passes validation with .bidsignore', async () => {
+    async function* goodData() {
+      yield 'sub-02/*'
+      yield '0001'
+      yield 'CHANGES'
+      yield 'dataset_description.json'
+      yield 'participants.tsv'
+      yield 'README'
+      yield 'sub-01/anat/sub-01_T1w.nii.gz'
+      yield 'T1w.json'
+      yield 'sub-02/not-bids-file.txt'
     }
     const res = await validateFilenames(goodData())
     expect(res).toBe(true)

--- a/bids-validator/utils/files/readDir.js
+++ b/bids-validator/utils/files/readDir.js
@@ -314,13 +314,17 @@ async function getFilesFromFs(dir, rootPath, ig, options) {
   return filesAccumulator
 }
 
-async function getBIDSIgnore(dir) {
-  const ig = ignore()
+export function defaultIgnore() {
+  return ignore()
     .add('.*')
     .add('!*.icloud')
     .add('/derivatives')
     .add('/sourcedata')
     .add('/code')
+}
+
+async function getBIDSIgnore(dir) {
+  const ig = defaultIgnore()
 
   const bidsIgnoreFileObj = getBIDSIgnoreFileObj(dir)
   if (bidsIgnoreFileObj) {


### PR DESCRIPTION
To support accurate pre-receive validation on OpenNeuro during git pushes, this allows the hook to pass .bidsignore contents ahead of the filenames.