### PR TITLE
Exit with correct code when --filenames validation fails.

### DIFF
--- a/bids-validator/utils/filenamesOnly.js
+++ b/bids-validator/utils/filenamesOnly.js
@@ -96,5 +96,9 @@ export async function filenamesOnly() {
   const rl = readline.createInterface({
     input: process.stdin,
   })
-  validateFilenames(rl)
+  if (await validateFilenames(rl)) {
+    process.exit(0)
+  } else {
+    process.exit(1)
+  }
 }


### PR DESCRIPTION
This fixes an issue where quick validation doesn't return a non-zero exit code with the --filenames mode used by OpenNeuro's git pre-receive hook. https://github.com/OpenNeuroOrg/openneuro/issues/1960