### PR TITLE
Refactor filename only mode to avoid fullTest and read file calls

### DIFF
--- a/bids-validator/validators/tsv/validate.js
+++ b/bids-validator/validators/tsv/validate.js
@@ -16,56 +16,47 @@ const validate = (
   let participantsTsvContent = ''
   // validate tsv
   const tsvPromises = files.map(function(file) {
-    return utils.limit(
-      () =>
-        new Promise((resolve, reject) => {
-          utils.files
-            .readFile(file, annexed, dir)
-            .then(contents => {
-              // Push TSV to list for custom column verification after all data dictionaries have been read
-              tsvs.push({
+    return utils.limit(() =>
+      utils.files.readFile(file, annexed, dir).then(contents => {
+        // Push TSV to list for custom column verification after all data dictionaries have been read
+        tsvs.push({
+          file: file,
+          contents: contents,
+        })
+        if (file.name.endsWith('_events.tsv')) {
+          events.push({
+            file: file,
+            path: file.relativePath,
+            contents: contents,
+          })
+        }
+        tsv(file, contents, fileList, function(
+          tsvIssues,
+          participantList,
+          stimFiles,
+        ) {
+          if (participantList) {
+            if (file.name.endsWith('participants.tsv')) {
+              participants = {
+                list: participantList,
                 file: file,
-                contents: contents,
-              })
-              if (file.name.endsWith('_events.tsv')) {
-                events.push({
-                  file: file,
-                  path: file.relativePath,
-                  contents: contents,
-                })
               }
-              tsv(file, contents, fileList, function(
-                tsvIssues,
-                participantList,
-                stimFiles,
-              ) {
-                if (participantList) {
-                  if (file.name.endsWith('participants.tsv')) {
-                    participants = {
-                      list: participantList,
-                      file: file,
-                    }
-                    // save content for metadata extraction
-                    participantsTsvContent = contents
-                  } else if (file.relativePath.includes('phenotype/')) {
-                    phenotypeParticipants.push({
-                      list: participantList,
-                      file: file,
-                    })
-                  }
-                }
-                if (stimFiles && stimFiles.length) {
-                  // add unique new events to the stimuli.events array
-                  stimuli.events = [
-                    ...new Set([...stimuli.events, ...stimFiles]),
-                  ]
-                }
-                issues = issues.concat(tsvIssues)
-                return resolve()
+              // save content for metadata extraction
+              participantsTsvContent = contents
+            } else if (file.relativePath.includes('phenotype/')) {
+              phenotypeParticipants.push({
+                list: participantList,
+                file: file,
               })
-            })
-            .catch(reject)
-        }),
+            }
+          }
+          if (stimFiles && stimFiles.length) {
+            // add unique new events to the stimuli.events array
+            stimuli.events = [...new Set([...stimuli.events, ...stimFiles])]
+          }
+          issues = issues.concat(tsvIssues)
+        })
+      }),
     )
   })
   return Promise.all(tsvPromises).then(() => ({


### PR DESCRIPTION
This is a fix for OpenNeuro to succeed on when receiving pushes for more existing datasets by limiting validation to only filenames. This disables a few rules that worked in full test but attempting to use the entire full test pass as is was rejecting many valid datasets.