### PR TITLE
CI: Add rust to package build environment (for cryptography >= 3.4)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,9 +85,9 @@ jobs:
           path: ~/web_version
   pypi_precheck:
     docker:
-      - image: alpine:3.8
+      - image: alpine:3.13
     steps:
-      - run: apk --no-cache add ca-certificates git openssh-client
+      - run: apk --no-cache add ca-certificates git openssh-client rust cargo
       - checkout
       - run:
           name: Set up environment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,9 @@ jobs:
           command: apk --no-cache add python3 python3-dev
       - run:
           name: Update Python install tools
-          command: python3 -m pip install --upgrade pip setuptools wheel
+          command: |
+            python3 -m ensurepip
+            python3 -m pip install --upgrade pip setuptools wheel
       - run:
           name: Install twine, readme renderer
           command: python3 -m pip install twine readme_renderer[md]


### PR DESCRIPTION
Following https://github.com/pyca/cryptography/issues/5753#issuecomment-774775479.