### PR TITLE
Make the python package callable

### DIFF
--- a/bids-validator/README.md
+++ b/bids-validator/README.md
@@ -50,7 +50,8 @@
    1. From a terminal run `pip install bids_validator` to acquire the
       [BIDS Validator PyPi package](https://pypi.org/project/bids-validator/)
    1. Open a Python terminal `python`
-   1. Import the BIDS Validator package `from bids_validator import BIDSValidator`
+   1. Run `bids-validator path/to/a/bids/file`; it will return 0 in `$?` if valid, and print an error and return 1 if not.
+   1. **or** Import the BIDS Validator package `from bids_validator import BIDSValidator`
    1. Check if a file is BIDS compatible `BIDSValidator().is_bids('path/to/a/bids/file')`
 
 ## Support

--- a/bids-validator/bids_validator/__init__.py
+++ b/bids-validator/bids_validator/__init__.py
@@ -1,4 +1,5 @@
 """BIDS validator common Python package."""
+import sys
 import argparse
 from ._version import get_versions
 from .bids_validator import BIDSValidator

--- a/bids-validator/bids_validator/__init__.py
+++ b/bids-validator/bids_validator/__init__.py
@@ -1,6 +1,21 @@
 """BIDS validator common Python package."""
+import argparse
 from ._version import get_versions
 from .bids_validator import BIDSValidator
 __version__ = get_versions()['version']
-__all__ = ['BIDSValidator']
+__all__ = ['BIDSValidator', 'main']
 del get_versions
+
+
+def main():
+    "bids-validator cli"
+    parser = argparse.ArgumentParser(description="Report whether folders follow https://bids-standard.github.io.")
+    parser.add_argument("path", nargs="+", help="Paths to validate")
+    args = parser.parse_args()
+
+    for path in args.path:
+        if BIDSValidator().is_bids(path):
+            raise SystemExit(0)
+        else:
+            print(f"Validation of {path} failed.", file=sys.stderr)
+            raise SystemExit(1)

--- a/bids-validator/setup.cfg
+++ b/bids-validator/setup.cfg
@@ -21,6 +21,10 @@ classifiers =
 [options]
 packages = find:
 
+[options.entry_points]
+console_scripts = 
+    bids-validator = bids_validator:main
+
 [options.package_data]
 bids_validator =
     rules/*.json


### PR DESCRIPTION
I did this really really quickly. It doesn't support all the options the javascript version does. Particularly, it doesn't print explanations of what fails validation. The URL in the help string is wrong. The code is probably in the wrong files. But I wanted to throw this out here to get the conversation going.