### PR TITLE
FIX: Replace TotalAcquiredVolumes with TotalAcquiredPairs

### DIFF
--- a/bids-validator/validators/json/schemas/asl.json
+++ b/bids-validator/validators/json/schemas/asl.json
@@ -197,9 +197,9 @@
       "type": "number",
       "exclusiveMinimum": 0
     },
-    "TotalAcquiredVolumes" :{
-          "type": "array",
-          "items": { "type": "number" }
+    "TotalAcquiredPairs" :{
+      "type": "number",
+      "exclusiveMinimum": 0
     },
     "PulseSequenceDetails" : {
       "type" : "string"


### PR DESCRIPTION
This is a number, presumably positive.

Follow-up to https://github.com/bids-standard/bids-specification/pull/742