### PR TITLE
allow events.json and scans.json to be defined at the top level + tests

### DIFF
--- a/bids-validator/bids_validator/rules/top_level_rules.json
+++ b/bids-validator/bids_validator/rules/top_level_rules.json
@@ -13,7 +13,9 @@
         "phasediff.json",
         "phase1.json",
         "phase2.json",
-        "fieldmap.json"
+        "fieldmap.json",
+        "events.json",
+        "scans.json"
       ]
     }
   },

--- a/bids-validator/tests/type.spec.js
+++ b/bids-validator/tests/type.spec.js
@@ -110,6 +110,8 @@ describe('utils.type.file.isTopLevel', function() {
     '/task-testing_eeg.json',
     '/task-testing_ieeg.json',
     '/task-testing_meg.json',
+    'events.json',
+    'scans.json',
   ]
 
   goodFilenames.forEach(function(path) {

--- a/bids-validator/tests/type.spec.js
+++ b/bids-validator/tests/type.spec.js
@@ -110,8 +110,8 @@ describe('utils.type.file.isTopLevel', function() {
     '/task-testing_eeg.json',
     '/task-testing_ieeg.json',
     '/task-testing_meg.json',
-    'events.json',
-    'scans.json',
+    '/events.json',
+    '/scans.json',
   ]
 
   goodFilenames.forEach(function(path) {


### PR DESCRIPTION
closes #742 
closes #1119 

if all events.tsv (or scans.tsv) files can be explained using a single accompanying JSON, then it would be valid BIDS to place this JSON at the root (top level), and let inheritance take care of the rest.