### PR TITLE
Fix HED placeholder tests

### DIFF
--- a/bids-validator/tests/events.spec.js
+++ b/bids-validator/tests/events.spec.js
@@ -590,7 +590,7 @@ describe('Events', function() {
           path: '/sub01/sub01_task-test_events.tsv',
           contents:
             'onset\tduration\ttestingCodes\tmyValue\n' +
-            '7\tsomething\tfirst\tRed\n',
+            '7\tsomething\tfirst\t0.5\n',
         },
       ]
       const jsonDictionary = {
@@ -604,7 +604,7 @@ describe('Events', function() {
             },
           },
           myValue: {
-            HED: 'Attribute/Visual/Color/#,Item/Object/Vehicle/Bicycle',
+            HED: 'Attribute/Visual/Color/Red/#,Item/Object/Vehicle/Bicycle',
           },
         },
         '/dataset_description.json': { HEDVersion: '7.1.1' },
@@ -628,8 +628,8 @@ describe('Events', function() {
           path: '/sub01/sub01_task-test_events.tsv',
           contents:
             'onset\tduration\ttestingCodes\tmyValue\n' +
-            '7\tsomething\tfirst\tRed\n' +
-            '8\tsomething\tsecond\tBlue\n',
+            '7\tsomething\tfirst\t0.5\n' +
+            '8\tsomething\tsecond\t0.6\n',
         },
       ]
       const jsonDictionary = {
@@ -643,7 +643,7 @@ describe('Events', function() {
             },
           },
           myCodes: {
-            HED: 'Attribute/Visual/Color/#,Item/Object/Vehicle/Bicycle',
+            HED: 'Attribute/Visual/Color/Red/#,Item/Object/Vehicle/Bicycle',
           },
         },
         '/dataset_description.json': { HEDVersion: '7.1.1' },
@@ -706,7 +706,7 @@ describe('Events', function() {
           path: '/sub01/sub01_task-test_events.tsv',
           contents:
             'onset\tduration\ttestingCodes\tmyValue\n' +
-            '7\tsomething\tfirst\tRed\n',
+            '7\tsomething\tfirst\t0.5\n',
         },
       ]
       const jsonDictionary = {
@@ -720,7 +720,7 @@ describe('Events', function() {
             },
           },
           myValue: {
-            HED: 'Attribute/Visual/Color/#,Item/Object/Vehicle/#',
+            HED: 'Attribute/Visual/Color/Red/#,Attribute/Visual/Color/Blue/#',
           },
         },
         '/dataset_description.json': { HEDVersion: '7.1.1' },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@babel/preset-env": "^7.7.1",
     "jest": "^24.9.0",
     "jest-environment-node": "^24.9.0",
-    "lerna": "^3.15.0"
+    "lerna": "^3.22.0"
   },
   "dependencies": {
     "next-transpile-modules": "^4.0.2"


### PR DESCRIPTION
This fixes the HED placeholder tests to comply with hed-validator
version 3.0.3, as described in #1187. The old tests were invalid
because they used non-value tags, which should not use placeholders
per the HED 3 standard.