### PR TITLE
Remove unused reference to node 'crypto' module

### DIFF
--- a/bids-validator/utils/files/readDir.js
+++ b/bids-validator/utils/files/readDir.js
@@ -1,7 +1,6 @@
 import ignore from 'ignore'
 import readFile from './readFile'
 import path from 'path'
-import crypto from 'crypto'
 import fs from 'fs'
 import { spawn } from 'child_process'
 import isNode from '../isNode'
@@ -131,12 +130,6 @@ const getGitLsTree = (cwd, gitRef) =>
       resolve(output.trim().split('\n'))
     })
   })
-
-const computeFileHash = (gitHash, path) => {
-  const hash = crypto.createHash('sha1')
-  hash.update(`${gitHash}:${path}`)
-  return hash.digest('hex')
-}
 
 const readLsTreeLines = gitTreeLines =>
   gitTreeLines


### PR DESCRIPTION
One more small fix to smooth out embedding bids-validator in bundlers other than webpack.