### PR TITLE
FIX: Stop purging summary.subjects when doing phenotype checks

### DIFF
--- a/bids-validator/validators/tsv/checkPhenotype.js
+++ b/bids-validator/validators/tsv/checkPhenotype.js
@@ -25,7 +25,8 @@ const checkPhenotype = (phenotypeParticipants, summary) => {
 }
 
 const constructMissingPhenotypeEvidence = (fileParticipants, subjects) => {
-  const diffs = utils.array.diff(fileParticipants, subjects)
+  const subjectsClone = subjects.slice()
+  const diffs = utils.array.diff(fileParticipants, subjectsClone)
   const subjectsNotInSummarySubjects = diffs[0]
   const subjectsNotInFileParticipants = diffs[1]
   const evidenceOfMissingParticipants = subjectsNotInFileParticipants.length


### PR DESCRIPTION
closes #1226 

This func https://github.com/bids-standard/bids-validator/blob/1f50c70526877321d3a51afc311ddf854c9def1a/bids-validator/validators/tsv/checkPhenotype.js#L27-L30

used to swallow up potential participants when checking `phenotype`  specific data. As a result, a later check may say "oups you have data but no corresponding subject" ... which is a false positive warning.

I don't really get **why**working on the `subjects` input directly modifies the `summary.subjects` list, but it *does* happen.

This is a simple fix.