### PR TITLE
FIX JSON schema: inclusiveMaximum -> maximum, and letter casing

### DIFF
--- a/bids-validator/validators/json/schemas/M0Scan.json
+++ b/bids-validator/validators/json/schemas/M0Scan.json
@@ -3,7 +3,7 @@
   "properties": {
     "EchoTime": {
       "type": "number",
-      "exclusiveMinimum": 0 
+      "exclusiveMinimum": 0
     },
     "EffectiveEchoSpacing": {
       "type": "number",
@@ -15,16 +15,14 @@
     },
     "RepetitionTimePreparation": {
       "anyOf": [
-        { "type": "number",
-          "Minimum": 0 
-        },
+        { "type": "number", "minimum": 0 },
         {
           "type": "array",
           "items": { "type": "number" },
-          "Minimum": 0
+          "minimum": 0
         }
-      ]  
-    }, 
+      ]
+    },
     "SliceEncodingDirection": {
       "type": "string",
       "enum": ["i", "j", "k", "i-", "j-", "k-"]
@@ -36,11 +34,11 @@
         "minimum": 0
       }
     },
-    "AcquisitionVoxelSize" :{
+    "AcquisitionVoxelSize": {
       "type": "array",
       "items": {
-          "type": "number",
-          "exclusiveMinimum": 0
+        "type": "number",
+        "exclusiveMinimum": 0
       }
     }
   }

--- a/bids-validator/validators/json/schemas/asl.json
+++ b/bids-validator/validators/json/schemas/asl.json
@@ -20,11 +20,11 @@
     },
     "RepetitionTimePreparation": {
       "anyOf": [
-        { "type": "number", "Minimum": 0 },
+        { "type": "number", "minimum": 0 },
         {
           "type": "array",
           "items": { "type": "number" },
-          "Minimum": 0
+          "minimum": 0
         }
       ]
     },
@@ -54,21 +54,21 @@
     },
     "LabelingDuration": {
       "anyOf": [
-        { "type": "number", "Minimum": 0 },
+        { "type": "number", "minimum": 0 },
         {
           "type": "array",
           "items": { "type": "number" },
-          "Minimum": 0
+          "minimum": 0
         }
       ]
     },
     "PostLabelingDelay": {
       "anyOf": [
-        { "type": "number", "Minimum": 0 },
+        { "type": "number", "minimum": 0 },
         {
           "type": "array",
           "items": { "type": "number" },
-          "Minimum": 0
+          "minimum": 0
         }
       ]
     },
@@ -95,7 +95,7 @@
     "LabelingPulseFlipAngle": {
       "type": "number",
       "exclusiveMinimum": 0,
-      "Maximum": 360
+      "maximum": 360
     },
     "LabelingSlabThickness": {
       "type": "number",
@@ -167,11 +167,11 @@
     },
     "BolusCutOffDelayTime": {
       "anyOf": [
-        { "type": "number", "Minimum": 0 },
+        { "type": "number", "minimum": 0 },
         {
           "type": "array",
           "items": { "type": "number" },
-          "Minimum": 0
+          "minimum": 0
         }
       ]
     },

--- a/bids-validator/validators/json/schemas/asl.json
+++ b/bids-validator/validators/json/schemas/asl.json
@@ -95,8 +95,7 @@
     "LabelingPulseFlipAngle": {
       "type": "number",
       "exclusiveMinimum": 0,
-      "inclusiveMaximum": 360,
-      "_inclusiveMaximum_comment": "to be checked"
+      "Maximum": 360
     },
     "LabelingSlabThickness": {
       "type": "number",


### PR DESCRIPTION
there is no keyword `inclusiveMaximum` in the JSON schema (see [spec](https://json-schema.org/understanding-json-schema/reference/numeric.html?highlight=minimum#range)). Conceptually, this is `maximum`.

Furthermore, there are no `Minimum` and `Maximum` keys in the JSON schema. Only `minimum` and `maximum` --> letter casing is important (I think).

