### PR TITLE
Fix a missing callback for some nifti header checks

### DIFF
--- a/bids-validator/validators/nifti/nii.js
+++ b/bids-validator/validators/nifti/nii.js
@@ -1260,8 +1260,8 @@ export default function NIFTI(
         checkIfValidFiletype(intendedForFile, issues, file)
       }
     }
-    callback(issues)
   }
+  callback(issues)
 }
 
 function missingEvents(path, potentialEvents, events) {


### PR DESCRIPTION
Looks like the scope for this callback was wrong, leading to an early exit if the `mergedDictionary.invalid` was true while checking nifti headers. An example affected dataset is [OpenNeuro ds003459:1.0.1](https://openneuro.org/datasets/ds003459/versions/1.0.1). Without this change this dataset does not return any validator output.