### PR TITLE
Include unused sidecar HED strings in event-level validation

### DIFF
--- a/bids-validator/validators/events/hed.js
+++ b/bids-validator/validators/events/hed.js
@@ -30,6 +30,7 @@ export default function checkHedStrings(events, headers, jsonContents, dir) {
       let hedStringsFound = false
       const sidecarIssueTypes = {}
       let sidecarErrorsFound = false
+      const sidecarHedStringsUsed = {}
       // loop through event data files
       events.forEach(eventFile => {
         const hedStrings = []
@@ -69,6 +70,7 @@ export default function checkHedStrings(events, headers, jsonContents, dir) {
                 true,
                 true,
               )
+              sidecarHedStringsUsed[hedString] = false
               if (!isHedStringValid) {
                 const convertedIssues = convertHedIssuesToBidsIssues(
                   hedIssues,
@@ -169,9 +171,11 @@ export default function checkHedStrings(events, headers, jsonContents, dir) {
                 continue
               }
               if (typeof sidecarHedData === 'string') {
+                sidecarHedStringsUsed[sidecarHedData] = true
                 sidecarHedString = sidecarHedData.replace('#', rowCell)
               } else {
                 sidecarHedString = sidecarHedData[rowCell]
+                sidecarHedStringsUsed[sidecarHedString] = true
               }
               if (sidecarHedString !== undefined) {
                 hedStringParts.push(sidecarHedString)
@@ -191,6 +195,13 @@ export default function checkHedStrings(events, headers, jsonContents, dir) {
             continue
           }
           hedStrings.push(hedStringParts.join(','))
+        }
+
+        // Add unused sidecar strings
+        for (const hedString in sidecarHedStringsUsed) {
+          if (!sidecarHedStringsUsed[hedString]) {
+            hedStrings.push(hedString)
+          }
         }
 
         if (hedStrings.length > 0) {


### PR DESCRIPTION
Previously, sidecar HED strings that are not referenced in the TSV file were only validated at the string level, not at the event or dataset levels. This would cause issues with definitions once support for those is implemented in hed-validator, since definitions will be included in sidecar HED strings that are not referenced in the TSV. This commit keeps a log of which sidecar strings have been referenced in the TSV and dumps the unused ones into the TSV before passing to the dataset-level validation (which includes event-level).

The tests do not currently pass, since they include invalid strings, previously skipped, that are now being validated (and failed). I need to come up with a good solution for this problem.