### PR TITLE
Fix for HED validation issue file field

### DIFF
--- a/bids-validator/tests/events.spec.js
+++ b/bids-validator/tests/events.spec.js
@@ -1342,6 +1342,9 @@ describe('Events', function() {
         assert.strictEqual(issues.length, 3)
         assert.strictEqual(issues[0].code, 210)
         assert.strictEqual(issues[1].code, 208)
+        // Check for correct file properties
+        expect(issues[0].file).toHaveProperty('path')
+        expect(issues[1].file).toHaveProperty('path')
       })
     })
   })

--- a/bids-validator/utils/issues/issue.js
+++ b/bids-validator/utils/issues/issue.js
@@ -21,7 +21,7 @@ const constructHelpUrl = issue => {
  * @param {Object} options
  * @param {string} options.key The descriptive string matching the issue code
  * @param {number} options.code Issue code - see 'list.js' for definitions
- * @param {string} [options.file] The relative path of the affected file
+ * @param {File} [options.file] File object for the affected file
  * @param {string} [options.evidence] The value throwing this issue
  * @param {number} [options.line] The line of the affected file (if within a file)
  * @param {number} [options.character] The character offset in the affected line

--- a/bids-validator/validators/events/hed.js
+++ b/bids-validator/validators/events/hed.js
@@ -72,7 +72,7 @@ export default function checkHedStrings(events, headers, jsonContents, dir) {
               if (!isHedStringValid) {
                 const convertedIssues = convertHedIssuesToBidsIssues(
                   hedIssues,
-                  sidecarName,
+                  eventFile.file,
                 )
                 fileIssues = fileIssues.concat(convertedIssues)
               }
@@ -87,10 +87,22 @@ export default function checkHedStrings(events, headers, jsonContents, dir) {
                 }
               }
               if (fileErrorsFound) {
-                issues.push(new Issue({ code: 209, file: sidecarName }))
+                issues.push(
+                  new Issue({
+                    code: 209,
+                    file: eventFile.file,
+                    evidence: sidecarName,
+                  }),
+                )
                 sidecarIssueTypes[sidecarName] = 'error'
               } else {
-                issues.push(new Issue({ code: 210, file: sidecarName }))
+                issues.push(
+                  new Issue({
+                    code: 210,
+                    file: eventFile.file,
+                    evidence: sidecarName,
+                  }),
+                )
                 sidecarIssueTypes[sidecarName] = 'warning'
               }
               issues = issues.concat(fileIssues)


### PR DESCRIPTION
Few fixes related to https://github.com/OpenNeuroOrg/openneuro/issues/2118

Some of the HED issues returned a string for the file field. Almost every other Issue passes the file object with a path, not the string. OpenNeuro accepts any object here but not a string. This fix does change which file is returned in the issue, instead of the sidecar you get the event file and the sidecar name is provided as evidence.

![image](https://user-images.githubusercontent.com/11369795/117752475-ab93ce00-b1cb-11eb-873c-9543470772bb.png)

* Fixes the misleading jsdoc on Issue
* Extends a related test to check for this
* Fixes the issues to use a file object