### PR TITLE
Enh: Raise warning if recommended README file is too small

### DIFF
--- a/bids-validator/tests/utils/files-web.spec.js
+++ b/bids-validator/tests/utils/files-web.spec.js
@@ -52,6 +52,19 @@ describe('files in browser', () => {
       const issues = checkReadme(fileList)
       assert(issues[0].key === 'README_FILE_MISSING')
     })
+
+    it('throws warning if it is too small', () => {
+      const fileList = {
+        1: {
+          name: 'README',
+          path: 'tests/data/bids-examples/ds001/README',
+          relativePath: '/README',
+          size: 20,
+        },
+      }
+      const issues = checkReadme(fileList)
+      assert(issues[0].key === 'README_FILE_SMALL')
+    })
   })
 
   describe('validateMisc', () => {
@@ -77,7 +90,10 @@ describe('files in browser', () => {
         // *.meg4 and BadChannels files are empty. But only *.meg4 is an issue
         assert.ok(issues.length == 1)
         assert.ok(issues.every(issue => issue instanceof utils.issues.Issue))
-        assert.notStrictEqual(issues.findIndex(issue => issue.code === 99), -1)
+        assert.notStrictEqual(
+          issues.findIndex(issue => issue.code === 99),
+          -1,
+        )
         assert.ok(issues[0].file.name == 'sub-0001_task-AEF_run-01_meg.meg4')
         done()
       })

--- a/bids-validator/tests/utils/files.spec.js
+++ b/bids-validator/tests/utils/files.spec.js
@@ -97,7 +97,6 @@ describe('README', () => {
       },
     }
     const issues = checkReadme(fileList)
-    console.log(issues)
     assert(issues[0].key === 'README_FILE_SMALL')
   })
 })

--- a/bids-validator/tests/utils/files.spec.js
+++ b/bids-validator/tests/utils/files.spec.js
@@ -86,6 +86,20 @@ describe('README', () => {
     const issues = checkReadme(fileList)
     assert(issues[0].key === 'README_FILE_MISSING')
   })
+
+  it('throws warning if it is too small', () => {
+    const fileList = {
+      1: {
+        name: 'README',
+        path: 'tests/data/bids-examples/ds001/README',
+        relativePath: '/README',
+        stats: { size: 20 },
+      },
+    }
+    const issues = checkReadme(fileList)
+    console.log(issues)
+    assert(issues[0].key === 'README_FILE_SMALL')
+  })
 })
 
 describe('validateMisc', () => {
@@ -111,7 +125,10 @@ describe('validateMisc', () => {
       // *.meg4 and BadChannels files are empty. But only *.meg4 is an issue
       assert.ok(issues.length == 1)
       assert.ok(issues.every(issue => issue instanceof utils.issues.Issue))
-      assert.notStrictEqual(issues.findIndex(issue => issue.code === 99), -1)
+      assert.notStrictEqual(
+        issues.findIndex(issue => issue.code === 99),
+        -1,
+      )
       assert.ok(issues[0].file.name == 'sub-0001_task-AEF_run-01_meg.meg4')
       done()
     })

--- a/bids-validator/utils/issues/list.js
+++ b/bids-validator/utils/issues/list.js
@@ -1148,4 +1148,10 @@ export default {
     reason:
       'Participant_id column labels must consist of the pattern "sub-<subject_id>".',
   },
+  213: {
+    key: 'README_FILE_SMALL',
+    severity: 'warning',
+    reason:
+      'The recommended file /README is very small. Please consider expanding it with additional information about the dataset.',
+  },
 }

--- a/bids-validator/validators/bids/checkReadme.js
+++ b/bids-validator/validators/bids/checkReadme.js
@@ -14,7 +14,7 @@ const checkReadme = fileList => {
   } else {
     // Get the README file object
     for (var key in fileList) {
-      if (fileList[key].name == '/README') {
+      if (fileList[key].relativePath == '/README') {
         var readmeFile = fileList[key]
         break
       }

--- a/bids-validator/validators/bids/checkReadme.js
+++ b/bids-validator/validators/bids/checkReadme.js
@@ -22,9 +22,9 @@ const checkReadme = fileList => {
 
     // Check size and raise warning if too small
     const size = !isNode ? readmeFile.size : readmeFile.stats.size
-    var failsSizeRequirement = size <= 5000
+    var failsSizeRequirement = size <= 150
     if (failsSizeRequirement) {
-      issues.push(new Issue({ code: 101 }))
+      issues.push(new Issue({ code: 213 }))
     }
   }
   return issues

--- a/bids-validator/validators/bids/checkReadme.js
+++ b/bids-validator/validators/bids/checkReadme.js
@@ -5,27 +5,17 @@ const Issue = require('../../utils').issues.Issue
 const checkReadme = fileList => {
   const issues = []
   const fileKeys = Object.keys(fileList)
-  const hasReadme = fileKeys.some(key => {
-    const file = fileList[key]
-    return file.relativePath && file.relativePath == '/README'
-  })
-  if (!hasReadme) {
-    issues.push(new Issue({ code: 101 }))
-  } else {
-    // Get the README file object
-    for (var key in fileList) {
-      if (fileList[key].relativePath == '/README') {
-        var readmeFile = fileList[key]
-        break
-      }
-    }
-
-    // Check size and raise warning if too small
+  const readmeFile = Array.from(Object.values(fileList)).find(
+    file => file.relativePath && file.relativePath == '/README',
+  )
+  if (readmeFile) {
     const size = !isNode ? readmeFile.size : readmeFile.stats.size
     const failsSizeRequirement = size <= 150
     if (failsSizeRequirement) {
       issues.push(new Issue({ code: 213 }))
     }
+  } else {
+    issues.push(new Issue({ code: 101 }))
   }
   return issues
 }

--- a/bids-validator/validators/bids/checkReadme.js
+++ b/bids-validator/validators/bids/checkReadme.js
@@ -14,7 +14,7 @@ const checkReadme = fileList => {
   } else {
     // Get the README file object
     for (var key in fileList) {
-      if (fileList[key].name == 'README') {
+      if (fileList[key].name == '/README') {
         var readmeFile = fileList[key]
         break
       }

--- a/bids-validator/validators/bids/checkReadme.js
+++ b/bids-validator/validators/bids/checkReadme.js
@@ -1,3 +1,5 @@
+import isNode from '../../utils/isNode'
+
 const Issue = require('../../utils').issues.Issue
 
 const checkReadme = fileList => {
@@ -9,6 +11,21 @@ const checkReadme = fileList => {
   })
   if (!hasReadme) {
     issues.push(new Issue({ code: 101 }))
+  } else {
+    // Get the README file object
+    for (var key in fileList) {
+      if (fileList[key].name == 'README') {
+        var readmeFile = fileList[key]
+        break
+      }
+    }
+
+    // Check size and raise warning if too small
+    const size = !isNode ? readmeFile.size : readmeFile.stats.size
+    var failsSizeRequirement = size <= 5000
+    if (failsSizeRequirement) {
+      issues.push(new Issue({ code: 101 }))
+    }
   }
   return issues
 }

--- a/bids-validator/validators/bids/checkReadme.js
+++ b/bids-validator/validators/bids/checkReadme.js
@@ -22,7 +22,7 @@ const checkReadme = fileList => {
 
     // Check size and raise warning if too small
     const size = !isNode ? readmeFile.size : readmeFile.stats.size
-    var failsSizeRequirement = size <= 150
+    const failsSizeRequirement = size <= 150
     if (failsSizeRequirement) {
       issues.push(new Issue({ code: 213 }))
     }


### PR DESCRIPTION
closes #1279 

as discussed in https://github.com/bids-standard/bids-specification/issues/662, the README is a very important file for making sense of a dataset. Next to providing a template for a README (see also https://github.com/bids-standard/bids-specification/pull/793), one thing we wanted to add was a simple check that raises a warning for suspiciously small README files.

That's what I do here. I have a very threshold for size right now: "150"

Practically that means this [README](https://github.com/bids-standard/bids-examples/blob/3f503bf19823284754a53796551a05946d49e4e8/pet001/README#L1) would just barely pass (size: 176):

> This dataset consists of a single PET measurement of a pig using [11C]CIMBI-36 to measure serotonin 2A availability. There are arterial measurements available for this tracer.

Whereas this [README](https://github.com/bids-standard/bids-examples/blob/3f503bf19823284754a53796551a05946d49e4e8/7t_trt/README#L1) would fail (size: 12):

> 7t_trt data


To get an impression on how best to tune this "size" param, you can use `find . -name 'README' -exec stat --printf="%n %s\n" {} +;` from the root of bids-examples.


My threshold currently is a bit too low, but it's hard to determine what would be a good thing to encourage best practice without annoying everybody.

cc @Remi-Gau 


