### PR TITLE
[FIX] Update regexp for scandate in PET schema

### DIFF
--- a/bids-validator/validators/json/schemas/pet.json
+++ b/bids-validator/validators/json/schemas/pet.json
@@ -70,7 +70,7 @@
     "FrameDuration": { "type": "array", "items": { "type": "number" } },
     "ScanDate": {
       "type": "string",
-      "pattern": "date"
+      "pattern": "^(19|20)[0-9][0-9]-(0[0-9]|1[0-2])-(0[1-9]|([12][0-9]|3[01]))T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$"
     },
     "InjectionEnd": { "type": "number" },
 


### PR DESCRIPTION
closes #1282 

This PR updates the regexp for scandate in the PET schema so it follows the ~ISO8601 format~ BIDS specific subset of the rfc3339 format. 

