### PR TITLE
run: npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
       }
     },
     "bids-validator": {
-      "version": "1.7.1",
+      "version": "1.7.3-dev.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.9.0",
@@ -46,6 +46,8 @@
         "bids-validator": "bin/bids-validator"
       },
       "devDependencies": {
+        "adm-zip": "",
+        "chai": "",
         "codecov": "^3.1.0",
         "eslint": "^5.2.0",
         "eslint-config-prettier": "^2.9.0",
@@ -54,16 +56,14 @@
         "lockfile": "^1.0.4",
         "prettier": "^1.14.2",
         "pretty-quick": "^1.6.0",
-        "sync-request": "6.0.0",
-        "adm-zip": "",
-        "chai": ""
+        "sync-request": "6.0.0"
       },
       "engines": {
         "node": ">=10.11.0"
       }
     },
     "bids-validator-web": {
-      "version": "1.7.0",
+      "version": "1.7.3-dev.0",
       "license": "MIT",
       "dependencies": {
         "bootstrap": "^4.3.0",
@@ -8370,16 +8370,19 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "10.0.7",
-      "license": "MIT"
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-10.2.0.tgz",
+      "integrity": "sha512-tsWBsn1Rb6hXRaHc/pWMCpZ4Ipkf3OCbZ54ef5ukgIyEvzzGdGFXQshPP2AF7yb+8yMpunWs7vOMZW3e8oPF6A=="
     },
     "node_modules/@next/polyfill-module": {
-      "version": "10.0.7",
-      "license": "MIT"
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@next/polyfill-module/-/polyfill-module-10.2.0.tgz",
+      "integrity": "sha512-Nl3GexIUXsmuggkUqrRFyE/2k7UI44JaVzSywtXEyHzxpZm2a5bdMaWuC89pgLiFDDOqmbqyLAbtwm5lNxa7Eg=="
     },
     "node_modules/@next/react-dev-overlay": {
-      "version": "10.0.7",
-      "license": "MIT",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@next/react-dev-overlay/-/react-dev-overlay-10.2.0.tgz",
+      "integrity": "sha512-PRIAoWog41hLN4iJ8dChKp4ysOX0Q8yiNQ/cwzyqEd3EjugkDV5OiKl3mumGKaApJaIra1MX6j1wgQRuLhuWMA==",
       "dependencies": {
         "@babel/code-frame": "7.12.11",
         "anser": "1.4.9",
@@ -8400,21 +8403,24 @@
     },
     "node_modules/@next/react-dev-overlay/node_modules/@babel/code-frame": {
       "version": "7.12.11",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+      "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
       "dependencies": {
         "@babel/highlight": "^7.10.4"
       }
     },
     "node_modules/@next/react-dev-overlay/node_modules/ansi-regex": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@next/react-dev-overlay/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -8427,7 +8433,8 @@
     },
     "node_modules/@next/react-dev-overlay/node_modules/chalk": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
+      "integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -8441,7 +8448,8 @@
     },
     "node_modules/@next/react-dev-overlay/node_modules/color-convert": {
       "version": "2.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -8451,18 +8459,21 @@
     },
     "node_modules/@next/react-dev-overlay/node_modules/color-name": {
       "version": "1.1.4",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/@next/react-dev-overlay/node_modules/has-flag": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@next/react-dev-overlay/node_modules/source-map": {
       "version": "0.8.0-beta.0",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
+      "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
       "dependencies": {
         "whatwg-url": "^7.0.0"
       },
@@ -8472,7 +8483,8 @@
     },
     "node_modules/@next/react-dev-overlay/node_modules/strip-ansi": {
       "version": "6.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
       "dependencies": {
         "ansi-regex": "^5.0.0"
       },
@@ -8482,7 +8494,8 @@
     },
     "node_modules/@next/react-dev-overlay/node_modules/supports-color": {
       "version": "7.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -8492,7 +8505,8 @@
     },
     "node_modules/@next/react-dev-overlay/node_modules/whatwg-url": {
       "version": "7.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
       "dependencies": {
         "lodash.sortby": "^4.7.0",
         "tr46": "^1.0.1",
@@ -8500,8 +8514,9 @@
       }
     },
     "node_modules/@next/react-refresh-utils": {
-      "version": "10.0.7",
-      "license": "MIT",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-10.2.0.tgz",
+      "integrity": "sha512-3I31K9B4hEQRl7yQ44Umyz+szHtuMJrNdwsgJGhoEnUCXSBRHp5wv5Zv8eDa2NewSbe53b2C0oOpivrzmdBakw==",
       "peerDependencies": {
         "react-refresh": "0.8.3",
         "webpack": "^4 || ^5"
@@ -9322,193 +9337,6 @@
       "version": "20.2.0",
       "license": "MIT"
     },
-    "node_modules/@webassemblyjs/ast": {
-      "version": "1.9.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/helper-module-context": "1.9.0",
-        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-        "@webassemblyjs/wast-parser": "1.9.0"
-      }
-    },
-    "node_modules/@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.9.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@webassemblyjs/helper-api-error": {
-      "version": "1.9.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@webassemblyjs/helper-buffer": {
-      "version": "1.9.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@webassemblyjs/helper-code-frame": {
-      "version": "1.9.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/wast-printer": "1.9.0"
-      }
-    },
-    "node_modules/@webassemblyjs/helper-fsm": {
-      "version": "1.9.0",
-      "license": "ISC",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@webassemblyjs/helper-module-context": {
-      "version": "1.9.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.9.0"
-      }
-    },
-    "node_modules/@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.9.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@webassemblyjs/helper-wasm-section": {
-      "version": "1.9.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/helper-buffer": "1.9.0",
-        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-        "@webassemblyjs/wasm-gen": "1.9.0"
-      }
-    },
-    "node_modules/@webassemblyjs/ieee754": {
-      "version": "1.9.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@xtuc/ieee754": "^1.2.0"
-      }
-    },
-    "node_modules/@webassemblyjs/leb128": {
-      "version": "1.9.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@webassemblyjs/utf8": {
-      "version": "1.9.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@webassemblyjs/wasm-edit": {
-      "version": "1.9.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/helper-buffer": "1.9.0",
-        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-        "@webassemblyjs/helper-wasm-section": "1.9.0",
-        "@webassemblyjs/wasm-gen": "1.9.0",
-        "@webassemblyjs/wasm-opt": "1.9.0",
-        "@webassemblyjs/wasm-parser": "1.9.0",
-        "@webassemblyjs/wast-printer": "1.9.0"
-      }
-    },
-    "node_modules/@webassemblyjs/wasm-gen": {
-      "version": "1.9.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-        "@webassemblyjs/ieee754": "1.9.0",
-        "@webassemblyjs/leb128": "1.9.0",
-        "@webassemblyjs/utf8": "1.9.0"
-      }
-    },
-    "node_modules/@webassemblyjs/wasm-opt": {
-      "version": "1.9.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/helper-buffer": "1.9.0",
-        "@webassemblyjs/wasm-gen": "1.9.0",
-        "@webassemblyjs/wasm-parser": "1.9.0"
-      }
-    },
-    "node_modules/@webassemblyjs/wasm-parser": {
-      "version": "1.9.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/helper-api-error": "1.9.0",
-        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-        "@webassemblyjs/ieee754": "1.9.0",
-        "@webassemblyjs/leb128": "1.9.0",
-        "@webassemblyjs/utf8": "1.9.0"
-      }
-    },
-    "node_modules/@webassemblyjs/wast-parser": {
-      "version": "1.9.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/floating-point-hex-parser": "1.9.0",
-        "@webassemblyjs/helper-api-error": "1.9.0",
-        "@webassemblyjs/helper-code-frame": "1.9.0",
-        "@webassemblyjs/helper-fsm": "1.9.0",
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@webassemblyjs/wast-printer": {
-      "version": "1.9.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/wast-parser": "1.9.0",
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@xtuc/ieee754": {
-      "version": "1.2.0",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@xtuc/long": {
-      "version": "4.2.2",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@zkochan/cmd-shim": {
       "version": "3.1.0",
       "dev": true,
@@ -9639,24 +9467,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-errors": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "ajv": ">=5.0.0"
-      }
-    },
-    "node_modules/ajv-keywords": {
-      "version": "3.5.2",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "ajv": "^6.9.1"
       }
     },
     "node_modules/amdefine": {
@@ -9817,11 +9627,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/array-flatten": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/array-ify": {
       "version": "1.0.0",
       "dev": true,
@@ -9885,7 +9690,8 @@
     },
     "node_modules/asn1.js": {
       "version": "5.4.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
       "dependencies": {
         "bn.js": "^4.0.0",
         "inherits": "^2.0.1",
@@ -9895,13 +9701,18 @@
     },
     "node_modules/asn1.js/node_modules/bn.js": {
       "version": "4.12.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "node_modules/assert": {
-      "version": "1.4.1",
-      "license": "MIT",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
+      "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
       "dependencies": {
-        "util": "0.10.3"
+        "es6-object-assign": "^1.1.0",
+        "is-nan": "^1.2.1",
+        "object-is": "^1.0.1",
+        "util": "^0.12.0"
       }
     },
     "node_modules/assert-plus": {
@@ -9910,17 +9721,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
-      }
-    },
-    "node_modules/assert/node_modules/inherits": {
-      "version": "2.0.1",
-      "license": "ISC"
-    },
-    "node_modules/assert/node_modules/util": {
-      "version": "0.10.3",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "2.0.1"
       }
     },
     "node_modules/assign-symbols": {
@@ -9985,6 +9785,25 @@
       "version": "2.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
+      "integrity": "sha512-XWX3OX8Onv97LMk/ftVyBibpGwY5a8SmuxZPzeOxqmuEqUCOM9ZE+uIaD1VNJ5QnvU2UQusvmKbuM1FR8QWGfQ==",
+      "dependencies": {
+        "array-filter": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/available-typed-arrays/node_modules/array-filter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
+      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM="
     },
     "node_modules/aws-sign2": {
       "version": "0.7.0",
@@ -10648,39 +10467,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/bl/node_modules/buffer": {
-      "version": "5.7.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
     "node_modules/block-stream": {
       "version": "0.0.9",
       "license": "ISC",
@@ -10695,12 +10481,13 @@
     },
     "node_modules/bluebird": {
       "version": "3.7.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/bn.js": {
       "version": "5.2.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+      "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
     },
     "node_modules/bootstrap": {
       "version": "4.6.0",
@@ -10783,7 +10570,8 @@
     },
     "node_modules/brorand": {
       "version": "1.1.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
     "node_modules/browser-process-hrtime": {
       "version": "1.0.0",
@@ -10793,7 +10581,8 @@
     },
     "node_modules/browserify-aes": {
       "version": "1.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dependencies": {
         "buffer-xor": "^1.0.3",
         "cipher-base": "^1.0.0",
@@ -10805,7 +10594,8 @@
     },
     "node_modules/browserify-cipher": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "dependencies": {
         "browserify-aes": "^1.0.4",
         "browserify-des": "^1.0.0",
@@ -10814,7 +10604,8 @@
     },
     "node_modules/browserify-des": {
       "version": "1.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "dependencies": {
         "cipher-base": "^1.0.1",
         "des.js": "^1.0.0",
@@ -10824,7 +10615,8 @@
     },
     "node_modules/browserify-rsa": {
       "version": "4.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.0.tgz",
+      "integrity": "sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==",
       "dependencies": {
         "bn.js": "^5.0.0",
         "randombytes": "^2.0.1"
@@ -10832,7 +10624,8 @@
     },
     "node_modules/browserify-sign": {
       "version": "4.2.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
+      "integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
       "dependencies": {
         "bn.js": "^5.1.1",
         "browserify-rsa": "^4.0.1",
@@ -10847,6 +10640,8 @@
     },
     "node_modules/browserify-sign/node_modules/safe-buffer": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "funding": [
         {
           "type": "github",
@@ -10860,12 +10655,12 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "license": "MIT"
+      ]
     },
     "node_modules/browserify-zlib": {
       "version": "0.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "dependencies": {
         "pako": "~1.0.5"
       }
@@ -10905,7 +10700,8 @@
     },
     "node_modules/buffer": {
       "version": "4.9.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
       "dependencies": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",
@@ -10918,11 +10714,13 @@
     },
     "node_modules/buffer-xor": {
       "version": "1.0.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
     },
     "node_modules/builtin-status-codes": {
       "version": "3.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
     },
     "node_modules/builtins": {
       "version": "1.0.3",
@@ -10954,7 +10752,7 @@
     },
     "node_modules/cacache": {
       "version": "12.0.4",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "bluebird": "^3.5.5",
@@ -11067,8 +10865,13 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001192",
-      "license": "CC-BY-4.0"
+      "version": "1.0.30001228",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz",
+      "integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -11187,20 +10990,8 @@
     },
     "node_modules/chownr": {
       "version": "1.1.4",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
-    },
-    "node_modules/chrome-trace-event": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=6.0"
-      }
     },
     "node_modules/ci-info": {
       "version": "2.0.0",
@@ -11208,7 +10999,8 @@
     },
     "node_modules/cipher-base": {
       "version": "1.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dependencies": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -11451,15 +11243,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/color": {
-      "version": "3.1.3",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "color-convert": "^1.9.1",
-        "color-string": "^1.5.4"
-      }
-    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "license": "MIT",
@@ -11470,15 +11253,6 @@
     "node_modules/color-name": {
       "version": "1.1.3",
       "license": "MIT"
-    },
-    "node_modules/color-string": {
-      "version": "1.5.4",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
     },
     "node_modules/colorette": {
       "version": "1.2.2",
@@ -11680,10 +11454,9 @@
       "peer": true
     },
     "node_modules/console-browserify": {
-      "version": "1.1.0",
-      "dependencies": {
-        "date-now": "^0.1.4"
-      }
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
+      "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA=="
     },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
@@ -11692,7 +11465,8 @@
     },
     "node_modules/constants-browserify": {
       "version": "1.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
     },
     "node_modules/conventional-changelog-angular": {
       "version": "5.0.12",
@@ -11942,7 +11716,7 @@
     },
     "node_modules/copy-concurrently": {
       "version": "1.0.5",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "aproba": "^1.1.1",
@@ -11955,7 +11729,7 @@
     },
     "node_modules/copy-concurrently/node_modules/aproba": {
       "version": "1.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/copy-descriptor": {
@@ -12003,7 +11777,8 @@
     },
     "node_modules/create-ecdh": {
       "version": "4.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+      "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
       "dependencies": {
         "bn.js": "^4.1.0",
         "elliptic": "^6.5.3"
@@ -12011,11 +11786,13 @@
     },
     "node_modules/create-ecdh/node_modules/bn.js": {
       "version": "4.12.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "node_modules/create-hash": {
       "version": "1.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dependencies": {
         "cipher-base": "^1.0.1",
         "inherits": "^2.0.1",
@@ -12026,7 +11803,8 @@
     },
     "node_modules/create-hmac": {
       "version": "1.1.7",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dependencies": {
         "cipher-base": "^1.0.3",
         "create-hash": "^1.1.0",
@@ -12059,7 +11837,8 @@
     },
     "node_modules/crypto-browserify": {
       "version": "3.12.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "dependencies": {
         "browserify-cipher": "^1.0.0",
         "browserify-sign": "^4.0.0",
@@ -12079,88 +11858,29 @@
     },
     "node_modules/css.escape": {
       "version": "1.5.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s="
     },
     "node_modules/cssnano-preset-simple": {
-      "version": "1.2.2",
-      "license": "MIT",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-simple/-/cssnano-preset-simple-2.0.0.tgz",
+      "integrity": "sha512-HkufSLkaBJbKBFx/7aj5HmCK9Ni/JedRQm0mT2qBzMG/dEuJOLnMt2lK6K1rwOOyV4j9aSY+knbW9WoS7BYpzg==",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001179",
-        "postcss": "^7.0.32"
-      }
-    },
-    "node_modules/cssnano-preset-simple/node_modules/postcss": {
-      "version": "7.0.35",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^2.4.2",
-        "source-map": "^0.6.1",
-        "supports-color": "^6.1.0"
+        "caniuse-lite": "^1.0.30001202"
       },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      }
-    },
-    "node_modules/cssnano-preset-simple/node_modules/source-map": {
-      "version": "0.6.1",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/cssnano-preset-simple/node_modules/supports-color": {
-      "version": "6.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
+      "peerDependencies": {
+        "postcss": "^8.2.1"
       }
     },
     "node_modules/cssnano-simple": {
-      "version": "1.2.2",
-      "license": "MIT",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cssnano-simple/-/cssnano-simple-2.0.0.tgz",
+      "integrity": "sha512-0G3TXaFxlh/szPEG/o3VcmCwl0N3E60XNb9YZZijew5eIs6fLjJuOPxQd9yEBaX2p/YfJtt49i4vYi38iH6/6w==",
       "dependencies": {
-        "cssnano-preset-simple": "1.2.2",
-        "postcss": "^7.0.32"
-      }
-    },
-    "node_modules/cssnano-simple/node_modules/postcss": {
-      "version": "7.0.35",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^2.4.2",
-        "source-map": "^0.6.1",
-        "supports-color": "^6.1.0"
+        "cssnano-preset-simple": "^2.0.0"
       },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      }
-    },
-    "node_modules/cssnano-simple/node_modules/source-map": {
-      "version": "0.6.1",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/cssnano-simple/node_modules/supports-color": {
-      "version": "6.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
+      "peerDependencies": {
+        "postcss": "^8.2.2"
       }
     },
     "node_modules/cssom": {
@@ -12204,7 +11924,7 @@
     },
     "node_modules/cyclist": {
       "version": "1.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/dargs": {
@@ -12231,7 +11951,8 @@
     },
     "node_modules/data-uri-to-buffer": {
       "version": "3.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
+      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==",
       "engines": {
         "node": ">= 6"
       }
@@ -12249,9 +11970,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/date-now": {
-      "version": "0.1.4"
     },
     "node_modules/dateformat": {
       "version": "3.0.3",
@@ -12329,32 +12047,10 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/dedent": {
       "version": "0.7.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=4.0.0"
-      }
     },
     "node_modules/deep-is": {
       "version": "0.1.3",
@@ -12430,7 +12126,8 @@
     },
     "node_modules/des.js": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
+      "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
       "dependencies": {
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
@@ -12447,17 +12144,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/detect-libc": {
-      "version": "1.0.3",
-      "license": "Apache-2.0",
-      "optional": true,
-      "bin": {
-        "detect-libc": "bin/detect-libc.js"
-      },
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/detect-newline": {
@@ -12489,7 +12175,8 @@
     },
     "node_modules/diffie-hellman": {
       "version": "5.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dependencies": {
         "bn.js": "^4.1.0",
         "miller-rabin": "^4.0.0",
@@ -12498,7 +12185,8 @@
     },
     "node_modules/diffie-hellman/node_modules/bn.js": {
       "version": "4.12.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "node_modules/dir-glob": {
       "version": "2.2.2",
@@ -12520,11 +12208,14 @@
       }
     },
     "node_modules/domain-browser": {
-      "version": "1.2.0",
-      "license": "MIT",
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.19.0.tgz",
+      "integrity": "sha512-fRA+BaAWOR/yr/t7T9E9GJztHPeFjj8U35ajyAjCDtAAnTn1Rc1f6W6VGPJrO1tkQv9zWu+JRof7z6oQtiYVFQ==",
       "engines": {
-        "node": ">=0.4",
-        "npm": ">=1.2"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
       }
     },
     "node_modules/domexception": {
@@ -12566,7 +12257,7 @@
     },
     "node_modules/duplexify": {
       "version": "3.7.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.0.0",
@@ -12577,7 +12268,7 @@
     },
     "node_modules/duplexify/node_modules/readable-stream": {
       "version": "2.3.7",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -12591,7 +12282,7 @@
     },
     "node_modules/duplexify/node_modules/string_decoder": {
       "version": "1.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -12617,7 +12308,8 @@
     },
     "node_modules/elliptic": {
       "version": "6.5.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -12630,7 +12322,8 @@
     },
     "node_modules/elliptic/node_modules/bn.js": {
       "version": "4.12.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "node_modules/emittery": {
       "version": "0.7.2",
@@ -12649,15 +12342,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/emojis-list": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/encodeurl": {
       "version": "1.0.2",
       "license": "MIT",
@@ -12668,7 +12352,6 @@
     },
     "node_modules/encoding": {
       "version": "0.1.13",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "^0.6.2"
@@ -12676,7 +12359,6 @@
     },
     "node_modules/encoding/node_modules/iconv-lite": {
       "version": "0.6.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -12690,56 +12372,6 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
-      }
-    },
-    "node_modules/enhanced-resolve": {
-      "version": "4.5.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "memory-fs": "^0.5.0",
-        "tapable": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/enhanced-resolve/node_modules/memory-fs": {
-      "version": "0.5.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "errno": "^0.1.3",
-        "readable-stream": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4.3.0 <5.0.0 || >=5.10"
-      }
-    },
-    "node_modules/enhanced-resolve/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/enhanced-resolve/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/env-paths": {
@@ -12764,18 +12396,6 @@
       "version": "1.1.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/errno": {
-      "version": "0.1.8",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "prr": "~1.0.1"
-      },
-      "bin": {
-        "errno": "cli.js"
-      }
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -12806,7 +12426,6 @@
     },
     "node_modules/es-abstract": {
       "version": "1.18.0-next.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -12833,7 +12452,6 @@
     },
     "node_modules/es-to-primitive": {
       "version": "1.2.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.1.4",
@@ -12846,6 +12464,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es6-object-assign": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
+      "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw="
     },
     "node_modules/es6-promise": {
       "version": "4.2.8",
@@ -12920,19 +12543,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/eslint-scope": {
-      "version": "4.0.3",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "license": "BSD-2-Clause",
@@ -12942,36 +12552,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/esrecurse": {
-      "version": "4.3.0",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/esrecurse/node_modules/estraverse": {
-      "version": "5.2.0",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/estraverse": {
-      "version": "4.3.0",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=4.0"
       }
     },
     "node_modules/esutils": {
@@ -13001,9 +12581,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/evp_bytestokey": {
       "version": "1.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dependencies": {
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
@@ -13150,14 +12739,6 @@
     "node_modules/expand-brackets/node_modules/ms": {
       "version": "2.0.0",
       "license": "MIT"
-    },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "license": "(MIT OR WTFPL)",
-      "optional": true,
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/expect": {
       "version": "26.6.2",
@@ -13561,7 +13142,7 @@
     },
     "node_modules/figgy-pudding": {
       "version": "3.5.2",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/figures": {
@@ -13739,7 +13320,7 @@
     },
     "node_modules/flush-write-stream": {
       "version": "1.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -13748,7 +13329,7 @@
     },
     "node_modules/flush-write-stream/node_modules/readable-stream": {
       "version": "2.3.7",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -13762,7 +13343,7 @@
     },
     "node_modules/flush-write-stream/node_modules/string_decoder": {
       "version": "1.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -13782,6 +13363,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
     },
     "node_modules/forever-agent": {
       "version": "0.6.1",
@@ -13824,7 +13410,7 @@
     },
     "node_modules/from2": {
       "version": "2.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.1",
@@ -13833,7 +13419,7 @@
     },
     "node_modules/from2/node_modules/readable-stream": {
       "version": "2.3.7",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -13847,16 +13433,11 @@
     },
     "node_modules/from2/node_modules/string_decoder": {
       "version": "1.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
-    },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/fs-extra": {
       "version": "8.1.0",
@@ -13880,7 +13461,7 @@
     },
     "node_modules/fs-write-stream-atomic": {
       "version": "1.0.10",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "graceful-fs": "^4.1.2",
@@ -13891,7 +13472,7 @@
     },
     "node_modules/fs-write-stream-atomic/node_modules/readable-stream": {
       "version": "2.3.7",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -13905,7 +13486,7 @@
     },
     "node_modules/fs-write-stream-atomic/node_modules/string_decoder": {
       "version": "1.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -14051,6 +13632,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-orientation": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/get-orientation/-/get-orientation-1.1.2.tgz",
+      "integrity": "sha512-/pViTfifW+gBbh/RnlFYHINvELT9Znt+SYyDKAUL6uV6By019AK/s+i9XP4jSwq7lwP38Fd8HVeTxym3+hkwmQ==",
+      "dependencies": {
+        "stream-parser": "^0.3.1"
       }
     },
     "node_modules/get-package-type": {
@@ -14673,11 +14262,6 @@
         "ini": "^1.3.2"
       }
     },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/glob": {
       "version": "7.1.6",
       "license": "ISC",
@@ -14905,7 +14489,8 @@
     },
     "node_modules/hash-base": {
       "version": "3.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+      "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
       "dependencies": {
         "inherits": "^2.0.4",
         "readable-stream": "^3.6.0",
@@ -14917,6 +14502,8 @@
     },
     "node_modules/hash-base/node_modules/safe-buffer": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "funding": [
         {
           "type": "github",
@@ -14930,12 +14517,12 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "license": "MIT"
+      ]
     },
     "node_modules/hash.js": {
       "version": "1.1.7",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
       "dependencies": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
@@ -14974,7 +14561,8 @@
     },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dependencies": {
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
@@ -14982,9 +14570,10 @@
       }
     },
     "node_modules/hosted-git-info": {
-      "version": "2.8.8",
-      "devOptional": true,
-      "license": "ISC"
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "devOptional": true
     },
     "node_modules/html-encoding-sniffer": {
       "version": "2.0.1",
@@ -15064,7 +14653,8 @@
     },
     "node_modules/https-browserify": {
       "version": "1.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+      "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
     },
     "node_modules/https-proxy-agent": {
       "version": "2.2.4",
@@ -15119,7 +14709,7 @@
     },
     "node_modules/iferr": {
       "version": "0.1.5",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ignore": {
@@ -15211,7 +14801,7 @@
     },
     "node_modules/infer-owner": {
       "version": "1.0.4",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/inflight": {
@@ -15228,7 +14818,7 @@
     },
     "node_modules/ini": {
       "version": "1.3.8",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/init-package-json": {
@@ -15315,6 +14905,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.0.tgz",
+      "integrity": "sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==",
+      "dependencies": {
+        "call-bind": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "license": "MIT"
@@ -15335,7 +14939,6 @@
     },
     "node_modules/is-callable": {
       "version": "1.2.3",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -15376,7 +14979,6 @@
     },
     "node_modules/is-date-object": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -15474,6 +15076,17 @@
         "node": ">=6"
       }
     },
+    "node_modules/is-generator-function": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.9.tgz",
+      "integrity": "sha512-ZJ34p1uvIfptHCN7sFTjGibB9/oBg17sHqzDLfuwhvmN/qLVvIQXRQ8licZQ35WJ8KuEQt/etnnzQFI9C9Ue/A==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.1",
       "license": "MIT",
@@ -15484,9 +15097,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-negative-zero": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -15547,7 +15174,6 @@
     },
     "node_modules/is-regex": {
       "version": "1.1.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -15577,7 +15203,6 @@
     },
     "node_modules/is-symbol": {
       "version": "1.0.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.1"
@@ -15598,6 +15223,24 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.5.tgz",
+      "integrity": "sha512-S+GRDgJlR3PyEbsX/Fobd9cqpZBuvUS+8asRqYDMLCb2qMzt1oz5m5oxQCxOgUDxiWsOVNi4yaF+/uvdlHlYug==",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.2",
+        "call-bind": "^1.0.2",
+        "es-abstract": "^1.18.0-next.2",
+        "foreach": "^2.0.5",
+        "has-symbols": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-typedarray": {
@@ -20237,6 +19880,7 @@
     },
     "node_modules/jest-worker": {
       "version": "24.9.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "merge-stream": "^2.0.0",
@@ -20248,6 +19892,7 @@
     },
     "node_modules/jest-worker/node_modules/supports-color": {
       "version": "6.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
@@ -20688,24 +20333,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/line-column": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "isarray": "^1.0.0",
-        "isobject": "^2.0.0"
-      }
-    },
-    "node_modules/line-column/node_modules/isobject": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "isarray": "1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/lines-and-columns": {
       "version": "1.1.6",
       "dev": true,
@@ -20724,41 +20351,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/loader-runner": {
-      "version": "2.4.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=4.3.0 <5.0.0 || >=5.10"
-      }
-    },
-    "node_modules/loader-utils": {
-      "version": "1.4.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/loader-utils/node_modules/json5": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
       }
     },
     "node_modules/locate-path": {
@@ -20888,7 +20480,7 @@
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -20975,45 +20567,12 @@
     },
     "node_modules/md5.js": {
       "version": "1.3.5",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
       "dependencies": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
-      }
-    },
-    "node_modules/memory-fs": {
-      "version": "0.4.1",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "errno": "^0.1.3",
-        "readable-stream": "^2.0.1"
-      }
-    },
-    "node_modules/memory-fs/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/memory-fs/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/meow": {
@@ -21174,9 +20733,10 @@
       }
     },
     "node_modules/meow/node_modules/read-pkg/node_modules/hosted-git-info": {
-      "version": "2.8.8",
-      "dev": true,
-      "license": "ISC"
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true
     },
     "node_modules/meow/node_modules/read-pkg/node_modules/normalize-package-data": {
       "version": "2.5.0",
@@ -22192,7 +21752,8 @@
     },
     "node_modules/miller-rabin": {
       "version": "4.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dependencies": {
         "bn.js": "^4.0.0",
         "brorand": "^1.0.1"
@@ -22203,7 +21764,8 @@
     },
     "node_modules/miller-rabin/node_modules/bn.js": {
       "version": "4.12.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "node_modules/mime": {
       "version": "2.5.2",
@@ -22240,17 +21802,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "dev": true,
@@ -22261,11 +21812,13 @@
     },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "node_modules/minimalistic-crypto-utils": {
       "version": "1.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
     },
     "node_modules/minimatch": {
       "version": "3.0.4",
@@ -22313,7 +21866,7 @@
     },
     "node_modules/mississippi": {
       "version": "3.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "concat-stream": "^1.5.0",
@@ -22333,7 +21886,7 @@
     },
     "node_modules/mississippi/node_modules/concat-stream": {
       "version": "1.6.2",
-      "devOptional": true,
+      "dev": true,
       "engines": [
         "node >= 0.8"
       ],
@@ -22347,7 +21900,7 @@
     },
     "node_modules/mississippi/node_modules/readable-stream": {
       "version": "2.3.7",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -22361,7 +21914,7 @@
     },
     "node_modules/mississippi/node_modules/string_decoder": {
       "version": "1.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -22369,7 +21922,7 @@
     },
     "node_modules/mississippi/node_modules/through2": {
       "version": "2.0.5",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readable-stream": "~2.3.6",
@@ -22397,11 +21950,6 @@
         "mkdirp": "bin/cmd.js"
       }
     },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/mkdirp-promise": {
       "version": "5.0.1",
       "dev": true,
@@ -22423,7 +21971,7 @@
     },
     "node_modules/move-concurrently": {
       "version": "1.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "aproba": "^1.1.1",
@@ -22436,7 +21984,7 @@
     },
     "node_modules/move-concurrently/node_modules/aproba": {
       "version": "1.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ms": {
@@ -22479,8 +22027,9 @@
       "peer": true
     },
     "node_modules/nanoid": {
-      "version": "3.1.20",
-      "license": "MIT",
+      "version": "3.1.23",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
+      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -22508,11 +22057,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/napi-build-utils": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/native-url": {
       "version": "0.3.4",
       "license": "Apache-2.0",
@@ -22539,54 +22083,66 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "10.0.7",
-      "license": "MIT",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/next/-/next-10.2.0.tgz",
+      "integrity": "sha512-PKDKCSF7s82xudu3kQhOEaokxggpbLEWouEUtzP6OqV0YqKYHF+Ff+BFLycEem8ixtTM2M6ElN0VRJcskJfxPQ==",
       "dependencies": {
         "@babel/runtime": "7.12.5",
         "@hapi/accept": "5.0.1",
-        "@next/env": "10.0.7",
-        "@next/polyfill-module": "10.0.7",
-        "@next/react-dev-overlay": "10.0.7",
-        "@next/react-refresh-utils": "10.0.7",
+        "@next/env": "10.2.0",
+        "@next/polyfill-module": "10.2.0",
+        "@next/react-dev-overlay": "10.2.0",
+        "@next/react-refresh-utils": "10.2.0",
         "@opentelemetry/api": "0.14.0",
+        "assert": "2.0.0",
         "ast-types": "0.13.2",
+        "browserify-zlib": "0.2.0",
         "browserslist": "4.16.1",
         "buffer": "5.6.0",
         "caniuse-lite": "^1.0.30001179",
         "chalk": "2.4.2",
         "chokidar": "3.5.1",
+        "constants-browserify": "1.0.0",
         "crypto-browserify": "3.12.0",
-        "cssnano-simple": "1.2.2",
+        "cssnano-simple": "2.0.0",
+        "domain-browser": "4.19.0",
+        "encoding": "0.1.13",
         "etag": "1.8.1",
         "find-cache-dir": "3.3.1",
-        "jest-worker": "24.9.0",
+        "get-orientation": "1.1.2",
+        "https-browserify": "1.0.0",
+        "jest-worker": "27.0.0-next.5",
         "native-url": "0.3.4",
         "node-fetch": "2.6.1",
         "node-html-parser": "1.4.9",
         "node-libs-browser": "^2.2.1",
+        "os-browserify": "0.3.0",
         "p-limit": "3.1.0",
         "path-browserify": "1.0.1",
         "pnp-webpack-plugin": "1.6.4",
-        "postcss": "8.1.7",
+        "postcss": "8.2.13",
         "process": "0.11.10",
         "prop-types": "15.7.2",
+        "querystring-es3": "0.2.1",
         "raw-body": "2.4.1",
         "react-is": "16.13.1",
         "react-refresh": "0.8.3",
         "stream-browserify": "3.0.0",
+        "stream-http": "3.1.1",
+        "string_decoder": "1.3.0",
         "styled-jsx": "3.3.2",
+        "timers-browserify": "2.0.12",
+        "tty-browserify": "0.0.1",
         "use-subscription": "1.5.1",
+        "util": "0.12.3",
         "vm-browserify": "1.1.2",
-        "watchpack": "2.0.0-beta.13"
+        "watchpack": "2.1.1"
       },
       "bin": {
         "next": "dist/bin/next"
       },
       "engines": {
         "node": ">=10.13.0"
-      },
-      "optionalDependencies": {
-        "sharp": "0.26.3"
       },
       "peerDependencies": {
         "fibers": ">= 3.1.0",
@@ -22643,6 +22199,27 @@
         "ieee754": "^1.1.4"
       }
     },
+    "node_modules/next/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/next/node_modules/jest-worker": {
+      "version": "27.0.0-next.5",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.0-next.5.tgz",
+      "integrity": "sha512-mk0umAQ5lT+CaOJ+Qp01N6kz48sJG2kr2n1rX0koqKf6FIygQV0qLOdN9SCYID4IVeSigDOcPeGLozdMLYfb5g==",
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
     "node_modules/next/node_modules/p-limit": {
       "version": "3.1.0",
       "license": "MIT",
@@ -22656,28 +22233,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.1.7",
-      "license": "MIT",
+    "node_modules/next/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dependencies": {
-        "colorette": "^1.2.1",
-        "line-column": "^1.0.2",
-        "nanoid": "^3.1.16",
-        "source-map": "^0.6.1"
+        "has-flag": "^4.0.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14"
+        "node": ">=10"
       },
       "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      }
-    },
-    "node_modules/next/node_modules/source-map": {
-      "version": "0.6.1",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/nice-try": {
@@ -22691,27 +22258,6 @@
       "engines": {
         "node": ">=4.0.0"
       }
-    },
-    "node_modules/node-abi": {
-      "version": "2.20.0",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "semver": "^5.4.1"
-      }
-    },
-    "node_modules/node-abi/node_modules/semver": {
-      "version": "5.7.1",
-      "license": "ISC",
-      "optional": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/node-addon-api": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/node-dir": {
       "version": "0.1.17",
@@ -22789,7 +22335,8 @@
     },
     "node_modules/node-libs-browser": {
       "version": "2.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
+      "integrity": "sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==",
       "dependencies": {
         "assert": "^1.1.1",
         "browserify-zlib": "^0.2.0",
@@ -22816,28 +22363,56 @@
         "vm-browserify": "^1.0.1"
       }
     },
-    "node_modules/node-libs-browser/node_modules/events": {
-      "version": "3.3.0",
-      "license": "MIT",
+    "node_modules/node-libs-browser/node_modules/assert": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
+      "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "util": "0.10.3"
+      }
+    },
+    "node_modules/node-libs-browser/node_modules/assert/node_modules/inherits": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+    },
+    "node_modules/node-libs-browser/node_modules/assert/node_modules/util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+      "dependencies": {
+        "inherits": "2.0.1"
+      }
+    },
+    "node_modules/node-libs-browser/node_modules/domain-browser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
+      "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
       "engines": {
-        "node": ">=0.8.x"
+        "node": ">=0.4",
+        "npm": ">=1.2"
       }
     },
     "node_modules/node-libs-browser/node_modules/inherits": {
       "version": "2.0.3",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "node_modules/node-libs-browser/node_modules/path-browserify": {
       "version": "0.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
+      "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ=="
     },
     "node_modules/node-libs-browser/node_modules/punycode": {
       "version": "1.4.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "node_modules/node-libs-browser/node_modules/readable-stream": {
       "version": "2.3.7",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -22850,22 +22425,42 @@
     },
     "node_modules/node-libs-browser/node_modules/stream-browserify": {
       "version": "2.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
+      "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
       "dependencies": {
         "inherits": "~2.0.1",
         "readable-stream": "^2.0.2"
       }
     },
+    "node_modules/node-libs-browser/node_modules/stream-http": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
+      "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.3.6",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
     "node_modules/node-libs-browser/node_modules/string_decoder": {
       "version": "1.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/node-libs-browser/node_modules/tty-browserify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
+    },
     "node_modules/node-libs-browser/node_modules/util": {
       "version": "0.11.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
+      "integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
       "dependencies": {
         "inherits": "2.0.3"
       }
@@ -23366,11 +22961,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/noop-logger": {
-      "version": "0.1.1",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/nopt": {
       "version": "4.0.3",
       "dev": true,
@@ -23628,8 +23218,22 @@
     },
     "node_modules/object-inspect": {
       "version": "1.9.0",
-      "dev": true,
       "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-is": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -23787,7 +23391,8 @@
     },
     "node_modules/os-browserify": {
       "version": "0.3.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+      "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
     },
     "node_modules/os-homedir": {
       "version": "1.0.2",
@@ -23945,11 +23550,12 @@
     },
     "node_modules/pako": {
       "version": "1.0.11",
-      "license": "(MIT AND Zlib)"
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "node_modules/parallel-transform": {
       "version": "1.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cyclist": "^1.0.1",
@@ -23959,7 +23565,7 @@
     },
     "node_modules/parallel-transform/node_modules/readable-stream": {
       "version": "2.3.7",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -23973,7 +23579,7 @@
     },
     "node_modules/parallel-transform/node_modules/string_decoder": {
       "version": "1.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -23981,7 +23587,8 @@
     },
     "node_modules/parse-asn1": {
       "version": "5.1.6",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
+      "integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
       "dependencies": {
         "asn1.js": "^5.2.0",
         "browserify-aes": "^1.0.0",
@@ -24103,8 +23710,9 @@
       }
     },
     "node_modules/pbkdf2": {
-      "version": "3.1.1",
-      "license": "MIT",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
+      "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
       "dependencies": {
         "create-hash": "^1.1.2",
         "create-hmac": "^1.1.4",
@@ -24180,16 +23788,18 @@
     },
     "node_modules/platform": {
       "version": "1.3.6",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
     },
     "node_modules/plist": {
-      "version": "3.0.1",
-      "license": "MIT",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.2.tgz",
+      "integrity": "sha512-MSrkwZBdQ6YapHy87/8hDU8MnIcyxBKjeF+McXnr5A9MtffPewTs7G3hlpodT5TacyfIyFTaJEhh3GGcmasTgQ==",
       "peer": true,
       "dependencies": {
-        "base64-js": "^1.2.3",
+        "base64-js": "^1.5.1",
         "xmlbuilder": "^9.0.7",
-        "xmldom": "0.1.x"
+        "xmldom": "^0.5.0"
       },
       "engines": {
         "node": ">=6"
@@ -24228,64 +23838,29 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/prebuild-install": {
-      "version": "6.0.1",
-      "license": "MIT",
-      "optional": true,
+    "node_modules/postcss": {
+      "version": "8.2.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.13.tgz",
+      "integrity": "sha512-FCE5xLH+hjbzRdpbRb1IMCvPv9yZx2QnDarBEYSN0N0HYk+TcXsEhwdFcFb+SRWOKzKGErhIEbBK2ogyLdTtfQ==",
       "dependencies": {
-        "detect-libc": "^1.0.3",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^1.0.1",
-        "node-abi": "^2.7.0",
-        "noop-logger": "^0.1.1",
-        "npmlog": "^4.0.1",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^3.0.3",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0",
-        "which-pm-runs": "^1.0.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
+        "colorette": "^1.2.2",
+        "nanoid": "^3.1.22",
+        "source-map": "^0.6.1"
       },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/prebuild-install/node_modules/decompress-response": {
-      "version": "4.2.1",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "mimic-response": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/prebuild-install/node_modules/mimic-response": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
+        "node": "^10 || ^12 || >=14"
       },
       "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
-    "node_modules/prebuild-install/node_modules/simple-get": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "decompress-response": "^4.2.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
+    "node_modules/postcss/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prelude-ls": {
@@ -24421,7 +23996,8 @@
     },
     "node_modules/process": {
       "version": "0.11.10",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -24440,7 +24016,7 @@
     },
     "node_modules/promise-inflight": {
       "version": "1.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/promise-retry": {
@@ -24512,12 +24088,6 @@
         "genfun": "^5.0.0"
       }
     },
-    "node_modules/prr": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/pseudomap": {
       "version": "1.0.2",
       "license": "ISC",
@@ -24531,7 +24101,8 @@
     },
     "node_modules/public-encrypt": {
       "version": "4.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
       "dependencies": {
         "bn.js": "^4.1.0",
         "browserify-rsa": "^4.0.0",
@@ -24543,7 +24114,8 @@
     },
     "node_modules/public-encrypt/node_modules/bn.js": {
       "version": "4.12.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "node_modules/pump": {
       "version": "3.0.0",
@@ -24555,7 +24127,7 @@
     },
     "node_modules/pumpify": {
       "version": "1.5.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "duplexify": "^3.6.0",
@@ -24565,7 +24137,7 @@
     },
     "node_modules/pumpify/node_modules/pump": {
       "version": "2.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -24624,6 +24196,8 @@
     },
     "node_modules/querystring-es3": {
       "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "engines": {
         "node": ">=0.4.x"
       }
@@ -24638,14 +24212,16 @@
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
     },
     "node_modules/randomfill": {
       "version": "1.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "dependencies": {
         "randombytes": "^2.0.5",
         "safe-buffer": "^5.1.0"
@@ -24670,28 +24246,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "optional": true,
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/rc/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/react": {
@@ -24794,7 +24348,8 @@
     },
     "node_modules/react-refresh": {
       "version": "0.8.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",
+      "integrity": "sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -25319,7 +24874,8 @@
     },
     "node_modules/ripemd160": {
       "version": "2.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "dependencies": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
@@ -25342,7 +24898,7 @@
     },
     "node_modules/run-queue": {
       "version": "1.0.3",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "aproba": "^1.1.1"
@@ -25350,7 +24906,7 @@
     },
     "node_modules/run-queue/node_modules/aproba": {
       "version": "1.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/rxjs": {
@@ -25700,20 +25256,6 @@
         "object-assign": "^4.1.1"
       }
     },
-    "node_modules/schema-utils": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "ajv": "^6.1.0",
-        "ajv-errors": "^1.0.0",
-        "ajv-keywords": "^3.1.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/scss-tokenizer": {
       "version": "0.2.3",
       "license": "MIT",
@@ -25803,15 +25345,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/serialize-javascript": {
-      "version": "4.0.0",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "randombytes": "^2.1.0"
-      }
-    },
     "node_modules/serve-static": {
       "version": "1.14.1",
       "license": "MIT",
@@ -25872,7 +25405,8 @@
     },
     "node_modules/setimmediate": {
       "version": "1.0.5",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
     "node_modules/setprototypeof": {
       "version": "1.1.1",
@@ -25880,7 +25414,8 @@
     },
     "node_modules/sha.js": {
       "version": "2.4.11",
-      "license": "(MIT AND BSD-3-Clause)",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dependencies": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -25899,60 +25434,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/sharp": {
-      "version": "0.26.3",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "array-flatten": "^3.0.0",
-        "color": "^3.1.3",
-        "detect-libc": "^1.0.3",
-        "node-addon-api": "^3.0.2",
-        "npmlog": "^4.1.2",
-        "prebuild-install": "^6.0.0",
-        "semver": "^7.3.2",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.1.1",
-        "tunnel-agent": "^0.6.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/sharp/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/sharp/node_modules/semver": {
-      "version": "7.3.4",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/sharp/node_modules/yallist": {
-      "version": "4.0.0",
-      "license": "ISC",
-      "optional": true
     },
     "node_modules/shebang-command": {
       "version": "1.2.0",
@@ -26002,49 +25483,6 @@
       "version": "3.0.3",
       "license": "ISC"
     },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
     "node_modules/simple-plist": {
       "version": "1.1.1",
       "license": "MIT",
@@ -26054,19 +25492,6 @@
         "bplist-parser": "0.2.0",
         "plist": "^3.0.1"
       }
-    },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.2",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
-      }
-    },
-    "node_modules/simple-swizzle/node_modules/is-arrayish": {
-      "version": "0.3.2",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -26313,12 +25738,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/source-list-map": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/source-map": {
       "version": "0.5.7",
       "license": "BSD-3-Clause",
@@ -26445,9 +25864,10 @@
       }
     },
     "node_modules/ssri": {
-      "version": "6.0.1",
-      "devOptional": true,
-      "license": "ISC",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+      "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
+      "dev": true,
       "dependencies": {
         "figgy-pudding": "^3.5.1"
       }
@@ -26640,7 +26060,7 @@
     },
     "node_modules/stream-each": {
       "version": "1.2.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -26656,39 +26076,40 @@
       }
     },
     "node_modules/stream-http": {
-      "version": "2.8.3",
-      "license": "MIT",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.1.1.tgz",
+      "integrity": "sha512-S7OqaYu0EkFpgeGFb/NPOoPLxFko7TPqtEeFg5DXPB4v/KETHG0Ln6fRFrNezoelpaDKmycEmmZ81cC9DAwgYg==",
       "dependencies": {
         "builtin-status-codes": "^3.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.3.6",
-        "to-arraybuffer": "^1.0.0",
-        "xtend": "^4.0.0"
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "xtend": "^4.0.2"
       }
     },
-    "node_modules/stream-http/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "license": "MIT",
+    "node_modules/stream-parser": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/stream-parser/-/stream-parser-0.3.1.tgz",
+      "integrity": "sha1-FhhUhpRCACGhGC/wrxkRwSl2F3M=",
       "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "debug": "2"
       }
     },
-    "node_modules/stream-http/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "license": "MIT",
+    "node_modules/stream-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dependencies": {
-        "safe-buffer": "~5.1.0"
+        "ms": "2.0.0"
       }
+    },
+    "node_modules/stream-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "node_modules/stream-shift": {
       "version": "1.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/strict-uri-encode": {
@@ -26795,7 +26216,6 @@
     },
     "node_modules/string.prototype.trimend": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -26807,7 +26227,6 @@
     },
     "node_modules/string.prototype.trimstart": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -27011,15 +26430,6 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
-    "node_modules/tapable": {
-      "version": "1.1.3",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/tar": {
       "version": "4.4.13",
       "dev": true,
@@ -27035,32 +26445,6 @@
       },
       "engines": {
         "node": ">=4.5"
-      }
-    },
-    "node_modules/tar-fs": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/teeny-request": {
@@ -27227,78 +26611,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/terser": {
-      "version": "4.8.0",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "commander": "^2.20.0",
-        "source-map": "~0.6.1",
-        "source-map-support": "~0.5.12"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/terser-webpack-plugin": {
-      "version": "1.4.5",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "cacache": "^12.0.2",
-        "find-cache-dir": "^2.1.0",
-        "is-wsl": "^1.1.0",
-        "schema-utils": "^1.0.0",
-        "serialize-javascript": "^4.0.0",
-        "source-map": "^0.6.1",
-        "terser": "^4.1.2",
-        "webpack-sources": "^1.4.0",
-        "worker-farm": "^1.7.0"
-      },
-      "engines": {
-        "node": ">= 6.9.0"
-      },
-      "peerDependencies": {
-        "webpack": "^4.0.0"
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/find-cache-dir": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "commondir": "^1.0.1",
-        "make-dir": "^2.0.0",
-        "pkg-dir": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/source-map": {
-      "version": "0.6.1",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/terser/node_modules/source-map": {
-      "version": "0.6.1",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/test-exclude": {
       "version": "5.2.3",
       "dev": true,
@@ -27373,7 +26685,8 @@
     },
     "node_modules/timers-browserify": {
       "version": "2.0.12",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
+      "integrity": "sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==",
       "dependencies": {
         "setimmediate": "^1.0.4"
       },
@@ -27398,7 +26711,8 @@
     },
     "node_modules/to-arraybuffer": {
       "version": "1.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+      "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
@@ -27519,8 +26833,9 @@
       "license": "0BSD"
     },
     "node_modules/tty-browserify": {
-      "version": "0.0.0",
-      "license": "MIT"
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
+      "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw=="
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -27569,7 +26884,7 @@
     },
     "node_modules/typedarray": {
       "version": "0.0.6",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/typedarray-to-buffer": {
@@ -27706,7 +27021,7 @@
     },
     "node_modules/unique-filename": {
       "version": "1.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "unique-slug": "^2.0.0"
@@ -27714,7 +27029,7 @@
     },
     "node_modules/unique-slug": {
       "version": "2.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4"
@@ -27837,6 +27152,19 @@
         "react": "^16.8.0 || ^17.0.0"
       }
     },
+    "node_modules/util": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.3.tgz",
+      "integrity": "sha512-I8XkoQwE+fPQEhy9v012V+TSdH2kp9ts29i20TaaDUXsg7x/onePbhFJUExBfv/2ay1ZOp/Vsm3nDlmnFGSAog==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "safe-buffer": "^5.1.2",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "license": "MIT"
@@ -27947,7 +27275,8 @@
     },
     "node_modules/vm-browserify": {
       "version": "1.1.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
+      "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
     },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
@@ -27985,8 +27314,9 @@
       }
     },
     "node_modules/watchpack": {
-      "version": "2.0.0-beta.13",
-      "license": "MIT",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.1.1.tgz",
+      "integrity": "sha512-Oo7LXCmc1eE1AjyuSBmtC3+Wy4HcV8PxWh2kP6fOl8yTlNS7r0K9l1ao2lrrUza7V39Y3D/BbJgY8VeSlc5JKw==",
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -27997,7 +27327,8 @@
     },
     "node_modules/watchpack/node_modules/glob-to-regexp": {
       "version": "0.4.1",
-      "license": "BSD-2-Clause"
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
     },
     "node_modules/wcwidth": {
       "version": "1.0.1",
@@ -28009,100 +27340,6 @@
     "node_modules/webidl-conversions": {
       "version": "4.0.2",
       "license": "BSD-2-Clause"
-    },
-    "node_modules/webpack": {
-      "version": "4.46.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/helper-module-context": "1.9.0",
-        "@webassemblyjs/wasm-edit": "1.9.0",
-        "@webassemblyjs/wasm-parser": "1.9.0",
-        "acorn": "^6.4.1",
-        "ajv": "^6.10.2",
-        "ajv-keywords": "^3.4.1",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^4.5.0",
-        "eslint-scope": "^4.0.3",
-        "json-parse-better-errors": "^1.0.2",
-        "loader-runner": "^2.4.0",
-        "loader-utils": "^1.2.3",
-        "memory-fs": "^0.4.1",
-        "micromatch": "^3.1.10",
-        "mkdirp": "^0.5.3",
-        "neo-async": "^2.6.1",
-        "node-libs-browser": "^2.2.1",
-        "schema-utils": "^1.0.0",
-        "tapable": "^1.1.3",
-        "terser-webpack-plugin": "^1.4.3",
-        "watchpack": "^1.7.4",
-        "webpack-sources": "^1.4.1"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=6.11.5"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        },
-        "webpack-command": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/webpack-sources": {
-      "version": "1.4.3",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "source-list-map": "^2.0.0",
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/webpack-sources/node_modules/source-map": {
-      "version": "0.6.1",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/webpack/node_modules/acorn": {
-      "version": "6.4.2",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/webpack/node_modules/watchpack": {
-      "version": "1.7.5",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0"
-      },
-      "optionalDependencies": {
-        "chokidar": "^3.4.1",
-        "watchpack-chokidar2": "^2.0.1"
-      }
     },
     "node_modules/whatwg-encoding": {
       "version": "1.0.5",
@@ -28173,10 +27410,25 @@
       "version": "2.0.0",
       "license": "ISC"
     },
-    "node_modules/which-pm-runs": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "optional": true
+    "node_modules/which-typed-array": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.4.tgz",
+      "integrity": "sha512-49E0SpUe90cjpoc7BOJwyPHRqSAd12c10Qm2amdEZrJPCY2NDxaW01zHITrem+rnETY3dwrbH3UUrUwagfCYDA==",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.2",
+        "call-bind": "^1.0.0",
+        "es-abstract": "^1.18.0-next.1",
+        "foreach": "^2.0.5",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.1",
+        "is-typed-array": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/wide-align": {
       "version": "1.1.3",
@@ -28213,15 +27465,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/worker-farm": {
-      "version": "1.7.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "errno": "~0.1.7"
-      }
     },
     "node_modules/wrap-ansi": {
       "version": "5.1.0",
@@ -28396,11 +27639,12 @@
       }
     },
     "node_modules/xmldom": {
-      "version": "0.1.31",
-      "license": "(LGPL-2.0 or MIT)",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
+      "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==",
       "peer": true,
       "engines": {
-        "node": ">=0.1"
+        "node": ">=10.0.0"
       }
     },
     "node_modules/xtend": {
@@ -28416,7 +27660,7 @@
     },
     "node_modules/yallist": {
       "version": "3.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/yargs": {
@@ -32752,13 +31996,19 @@
       }
     },
     "@next/env": {
-      "version": "10.0.7"
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-10.2.0.tgz",
+      "integrity": "sha512-tsWBsn1Rb6hXRaHc/pWMCpZ4Ipkf3OCbZ54ef5ukgIyEvzzGdGFXQshPP2AF7yb+8yMpunWs7vOMZW3e8oPF6A=="
     },
     "@next/polyfill-module": {
-      "version": "10.0.7"
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@next/polyfill-module/-/polyfill-module-10.2.0.tgz",
+      "integrity": "sha512-Nl3GexIUXsmuggkUqrRFyE/2k7UI44JaVzSywtXEyHzxpZm2a5bdMaWuC89pgLiFDDOqmbqyLAbtwm5lNxa7Eg=="
     },
     "@next/react-dev-overlay": {
-      "version": "10.0.7",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@next/react-dev-overlay/-/react-dev-overlay-10.2.0.tgz",
+      "integrity": "sha512-PRIAoWog41hLN4iJ8dChKp4ysOX0Q8yiNQ/cwzyqEd3EjugkDV5OiKl3mumGKaApJaIra1MX6j1wgQRuLhuWMA==",
       "requires": {
         "@babel/code-frame": "7.12.11",
         "anser": "1.4.9",
@@ -32775,21 +32025,29 @@
       "dependencies": {
         "@babel/code-frame": {
           "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+          "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
           "requires": {
             "@babel/highlight": "^7.10.4"
           }
         },
         "ansi-regex": {
-          "version": "5.0.0"
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
         },
         "ansi-styles": {
           "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "requires": {
             "color-convert": "^2.0.1"
           }
         },
         "chalk": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
+          "integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -32797,36 +32055,50 @@
         },
         "color-convert": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "requires": {
             "color-name": "~1.1.4"
           }
         },
         "color-name": {
-          "version": "1.1.4"
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "has-flag": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "source-map": {
           "version": "0.8.0-beta.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
+          "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
           "requires": {
             "whatwg-url": "^7.0.0"
           }
         },
         "strip-ansi": {
           "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "requires": {
             "ansi-regex": "^5.0.0"
           }
         },
         "supports-color": {
           "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "requires": {
             "has-flag": "^4.0.0"
           }
         },
         "whatwg-url": {
           "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+          "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
           "requires": {
             "lodash.sortby": "^4.7.0",
             "tr46": "^1.0.1",
@@ -32836,7 +32108,9 @@
       }
     },
     "@next/react-refresh-utils": {
-      "version": "10.0.7",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-10.2.0.tgz",
+      "integrity": "sha512-3I31K9B4hEQRl7yQ44Umyz+szHtuMJrNdwsgJGhoEnUCXSBRHp5wv5Zv8eDa2NewSbe53b2C0oOpivrzmdBakw==",
       "requires": {}
     },
     "@nodelib/fs.stat": {
@@ -33489,173 +32763,6 @@
     "@types/yargs-parser": {
       "version": "20.2.0"
     },
-    "@webassemblyjs/ast": {
-      "version": "1.9.0",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@webassemblyjs/helper-module-context": "1.9.0",
-        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-        "@webassemblyjs/wast-parser": "1.9.0"
-      }
-    },
-    "@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.9.0",
-      "optional": true,
-      "peer": true
-    },
-    "@webassemblyjs/helper-api-error": {
-      "version": "1.9.0",
-      "optional": true,
-      "peer": true
-    },
-    "@webassemblyjs/helper-buffer": {
-      "version": "1.9.0",
-      "optional": true,
-      "peer": true
-    },
-    "@webassemblyjs/helper-code-frame": {
-      "version": "1.9.0",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@webassemblyjs/wast-printer": "1.9.0"
-      }
-    },
-    "@webassemblyjs/helper-fsm": {
-      "version": "1.9.0",
-      "optional": true,
-      "peer": true
-    },
-    "@webassemblyjs/helper-module-context": {
-      "version": "1.9.0",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@webassemblyjs/ast": "1.9.0"
-      }
-    },
-    "@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.9.0",
-      "optional": true,
-      "peer": true
-    },
-    "@webassemblyjs/helper-wasm-section": {
-      "version": "1.9.0",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/helper-buffer": "1.9.0",
-        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-        "@webassemblyjs/wasm-gen": "1.9.0"
-      }
-    },
-    "@webassemblyjs/ieee754": {
-      "version": "1.9.0",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@xtuc/ieee754": "^1.2.0"
-      }
-    },
-    "@webassemblyjs/leb128": {
-      "version": "1.9.0",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "@webassemblyjs/utf8": {
-      "version": "1.9.0",
-      "optional": true,
-      "peer": true
-    },
-    "@webassemblyjs/wasm-edit": {
-      "version": "1.9.0",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/helper-buffer": "1.9.0",
-        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-        "@webassemblyjs/helper-wasm-section": "1.9.0",
-        "@webassemblyjs/wasm-gen": "1.9.0",
-        "@webassemblyjs/wasm-opt": "1.9.0",
-        "@webassemblyjs/wasm-parser": "1.9.0",
-        "@webassemblyjs/wast-printer": "1.9.0"
-      }
-    },
-    "@webassemblyjs/wasm-gen": {
-      "version": "1.9.0",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-        "@webassemblyjs/ieee754": "1.9.0",
-        "@webassemblyjs/leb128": "1.9.0",
-        "@webassemblyjs/utf8": "1.9.0"
-      }
-    },
-    "@webassemblyjs/wasm-opt": {
-      "version": "1.9.0",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/helper-buffer": "1.9.0",
-        "@webassemblyjs/wasm-gen": "1.9.0",
-        "@webassemblyjs/wasm-parser": "1.9.0"
-      }
-    },
-    "@webassemblyjs/wasm-parser": {
-      "version": "1.9.0",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/helper-api-error": "1.9.0",
-        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-        "@webassemblyjs/ieee754": "1.9.0",
-        "@webassemblyjs/leb128": "1.9.0",
-        "@webassemblyjs/utf8": "1.9.0"
-      }
-    },
-    "@webassemblyjs/wast-parser": {
-      "version": "1.9.0",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/floating-point-hex-parser": "1.9.0",
-        "@webassemblyjs/helper-api-error": "1.9.0",
-        "@webassemblyjs/helper-code-frame": "1.9.0",
-        "@webassemblyjs/helper-fsm": "1.9.0",
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "@webassemblyjs/wast-printer": {
-      "version": "1.9.0",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/wast-parser": "1.9.0",
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "@xtuc/ieee754": {
-      "version": "1.2.0",
-      "optional": true,
-      "peer": true
-    },
-    "@xtuc/long": {
-      "version": "4.2.2",
-      "optional": true,
-      "peer": true
-    },
     "@zkochan/cmd-shim": {
       "version": "3.1.0",
       "dev": true,
@@ -33747,18 +32854,6 @@
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       }
-    },
-    "ajv-errors": {
-      "version": "1.0.1",
-      "optional": true,
-      "peer": true,
-      "requires": {}
-    },
-    "ajv-keywords": {
-      "version": "3.5.2",
-      "optional": true,
-      "peer": true,
-      "requires": {}
     },
     "amdefine": {
       "version": "1.0.1",
@@ -33870,10 +32965,6 @@
       "version": "1.0.2",
       "devOptional": true
     },
-    "array-flatten": {
-      "version": "3.0.0",
-      "optional": true
-    },
     "array-ify": {
       "version": "1.0.0",
       "dev": true
@@ -33916,6 +33007,8 @@
     },
     "asn1.js": {
       "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
       "requires": {
         "bn.js": "^4.0.0",
         "inherits": "^2.0.1",
@@ -33924,25 +33017,21 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.12.0"
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         }
       }
     },
     "assert": {
-      "version": "1.4.1",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
+      "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
       "requires": {
-        "util": "0.10.3"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.1"
-        },
-        "util": {
-          "version": "0.10.3",
-          "requires": {
-            "inherits": "2.0.1"
-          }
-        }
+        "es6-object-assign": "^1.1.0",
+        "is-nan": "^1.2.1",
+        "object-is": "^1.0.1",
+        "util": "^0.12.0"
       }
     },
     "assert-plus": {
@@ -33985,6 +33074,21 @@
     "atob-lite": {
       "version": "2.0.0",
       "dev": true
+    },
+    "available-typed-arrays": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
+      "integrity": "sha512-XWX3OX8Onv97LMk/ftVyBibpGwY5a8SmuxZPzeOxqmuEqUCOM9ZE+uIaD1VNJ5QnvU2UQusvmKbuM1FR8QWGfQ==",
+      "requires": {
+        "array-filter": "^1.0.0"
+      },
+      "dependencies": {
+        "array-filter": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
+          "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM="
+        }
+      }
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -34468,8 +33572,10 @@
       "version": "file:bids-validator",
       "requires": {
         "@aws-sdk/client-s3": "^3.9.0",
+        "adm-zip": "",
         "ajv": "^6.5.2",
         "bytes": "^3.0.0",
+        "chai": "",
         "codecov": "^3.1.0",
         "colors": "^1.3.1",
         "cross-fetch": "^3.0.6",
@@ -34495,9 +33601,7 @@
         "semver": "^7.3.2",
         "sync-request": "6.0.0",
         "table": "^5.2.3",
-        "yargs": "^16.2.0",
-        "adm-zip": "",
-        "chai": ""
+        "yargs": "^16.2.0"
       },
       "dependencies": {
         "@babel/code-frame": {
@@ -36350,25 +35454,6 @@
     "binary-extensions": {
       "version": "2.2.0"
     },
-    "bl": {
-      "version": "4.1.0",
-      "optional": true,
-      "requires": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "5.7.1",
-          "optional": true,
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.1.13"
-          }
-        }
-      }
-    },
     "block-stream": {
       "version": "0.0.9",
       "optional": true,
@@ -36379,10 +35464,12 @@
     },
     "bluebird": {
       "version": "3.7.2",
-      "devOptional": true
+      "dev": true
     },
     "bn.js": {
-      "version": "5.2.0"
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+      "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
     },
     "bootstrap": {
       "version": "4.6.0",
@@ -36439,7 +35526,9 @@
       }
     },
     "brorand": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
     "browser-process-hrtime": {
       "version": "1.0.0",
@@ -36449,6 +35538,8 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "requires": {
         "buffer-xor": "^1.0.3",
         "cipher-base": "^1.0.0",
@@ -36460,6 +35551,8 @@
     },
     "browserify-cipher": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "requires": {
         "browserify-aes": "^1.0.4",
         "browserify-des": "^1.0.0",
@@ -36468,6 +35561,8 @@
     },
     "browserify-des": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "requires": {
         "cipher-base": "^1.0.1",
         "des.js": "^1.0.0",
@@ -36477,6 +35572,8 @@
     },
     "browserify-rsa": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.0.tgz",
+      "integrity": "sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==",
       "requires": {
         "bn.js": "^5.0.0",
         "randombytes": "^2.0.1"
@@ -36484,6 +35581,8 @@
     },
     "browserify-sign": {
       "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
+      "integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
       "requires": {
         "bn.js": "^5.1.1",
         "browserify-rsa": "^4.0.1",
@@ -36497,12 +35596,16 @@
       },
       "dependencies": {
         "safe-buffer": {
-          "version": "5.2.1"
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         }
       }
     },
     "browserify-zlib": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "requires": {
         "pako": "~1.0.5"
       }
@@ -36529,6 +35632,8 @@
     },
     "buffer": {
       "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",
@@ -36539,10 +35644,14 @@
       "version": "1.1.1"
     },
     "buffer-xor": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
     },
     "builtin-status-codes": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
     },
     "builtins": {
       "version": "1.0.3",
@@ -36561,7 +35670,7 @@
     },
     "cacache": {
       "version": "12.0.4",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "bluebird": "^3.5.5",
         "chownr": "^1.1.1",
@@ -36639,7 +35748,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001192"
+      "version": "1.0.30001228",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz",
+      "integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -36717,21 +35828,15 @@
     },
     "chownr": {
       "version": "1.1.4",
-      "devOptional": true
-    },
-    "chrome-trace-event": {
-      "version": "1.0.2",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "tslib": "^1.9.0"
-      }
+      "dev": true
     },
     "ci-info": {
       "version": "2.0.0"
     },
     "cipher-base": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -36901,14 +36006,6 @@
         "object-visit": "^1.0.0"
       }
     },
-    "color": {
-      "version": "3.1.3",
-      "optional": true,
-      "requires": {
-        "color-convert": "^1.9.1",
-        "color-string": "^1.5.4"
-      }
-    },
     "color-convert": {
       "version": "1.9.3",
       "requires": {
@@ -36917,14 +36014,6 @@
     },
     "color-name": {
       "version": "1.1.3"
-    },
-    "color-string": {
-      "version": "1.5.4",
-      "optional": true,
-      "requires": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
     },
     "colorette": {
       "version": "1.2.2"
@@ -37078,17 +36167,18 @@
       }
     },
     "console-browserify": {
-      "version": "1.1.0",
-      "requires": {
-        "date-now": "^0.1.4"
-      }
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
+      "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA=="
     },
     "console-control-strings": {
       "version": "1.1.0",
       "devOptional": true
     },
     "constants-browserify": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
     },
     "conventional-changelog-angular": {
       "version": "5.0.12",
@@ -37264,7 +36354,7 @@
     },
     "copy-concurrently": {
       "version": "1.0.5",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "aproba": "^1.1.1",
         "fs-write-stream-atomic": "^1.0.8",
@@ -37276,7 +36366,7 @@
       "dependencies": {
         "aproba": {
           "version": "1.2.0",
-          "devOptional": true
+          "dev": true
         }
       }
     },
@@ -37309,18 +36399,24 @@
     },
     "create-ecdh": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+      "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
       "requires": {
         "bn.js": "^4.1.0",
         "elliptic": "^6.5.3"
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.12.0"
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         }
       }
     },
     "create-hash": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "requires": {
         "cipher-base": "^1.0.1",
         "inherits": "^2.0.1",
@@ -37331,6 +36427,8 @@
     },
     "create-hmac": {
       "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "requires": {
         "cipher-base": "^1.0.3",
         "create-hash": "^1.1.0",
@@ -37357,6 +36455,8 @@
     },
     "crypto-browserify": {
       "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "requires": {
         "browserify-cipher": "^1.0.0",
         "browserify-sign": "^4.0.0",
@@ -37372,58 +36472,24 @@
       }
     },
     "css.escape": {
-      "version": "1.5.1"
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s="
     },
     "cssnano-preset-simple": {
-      "version": "1.2.2",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-simple/-/cssnano-preset-simple-2.0.0.tgz",
+      "integrity": "sha512-HkufSLkaBJbKBFx/7aj5HmCK9Ni/JedRQm0mT2qBzMG/dEuJOLnMt2lK6K1rwOOyV4j9aSY+knbW9WoS7BYpzg==",
       "requires": {
-        "caniuse-lite": "^1.0.30001179",
-        "postcss": "^7.0.32"
-      },
-      "dependencies": {
-        "postcss": {
-          "version": "7.0.35",
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1"
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
+        "caniuse-lite": "^1.0.30001202"
       }
     },
     "cssnano-simple": {
-      "version": "1.2.2",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cssnano-simple/-/cssnano-simple-2.0.0.tgz",
+      "integrity": "sha512-0G3TXaFxlh/szPEG/o3VcmCwl0N3E60XNb9YZZijew5eIs6fLjJuOPxQd9yEBaX2p/YfJtt49i4vYi38iH6/6w==",
       "requires": {
-        "cssnano-preset-simple": "1.2.2",
-        "postcss": "^7.0.32"
-      },
-      "dependencies": {
-        "postcss": {
-          "version": "7.0.35",
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1"
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
+        "cssnano-preset-simple": "^2.0.0"
       }
     },
     "cssom": {
@@ -37461,7 +36527,7 @@
     },
     "cyclist": {
       "version": "1.0.1",
-      "devOptional": true
+      "dev": true
     },
     "dargs": {
       "version": "4.1.0",
@@ -37478,7 +36544,9 @@
       }
     },
     "data-uri-to-buffer": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
+      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
     },
     "data-urls": {
       "version": "2.0.0",
@@ -37490,9 +36558,6 @@
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
       }
-    },
-    "date-now": {
-      "version": "0.1.4"
     },
     "dateformat": {
       "version": "3.0.3",
@@ -37538,20 +36603,9 @@
     "decode-uri-component": {
       "version": "0.2.0"
     },
-    "decompress-response": {
-      "version": "6.0.0",
-      "optional": true,
-      "requires": {
-        "mimic-response": "^3.1.0"
-      }
-    },
     "dedent": {
       "version": "0.7.0",
       "dev": true
-    },
-    "deep-extend": {
-      "version": "0.6.0",
-      "optional": true
     },
     "deep-is": {
       "version": "0.1.3",
@@ -37603,6 +36657,8 @@
     },
     "des.js": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
+      "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
       "requires": {
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
@@ -37615,10 +36671,6 @@
     "detect-indent": {
       "version": "5.0.0",
       "dev": true
-    },
-    "detect-libc": {
-      "version": "1.0.3",
-      "optional": true
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -37642,6 +36694,8 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "requires": {
         "bn.js": "^4.1.0",
         "miller-rabin": "^4.0.0",
@@ -37649,7 +36703,9 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.12.0"
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         }
       }
     },
@@ -37668,7 +36724,9 @@
       }
     },
     "domain-browser": {
-      "version": "1.2.0"
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.19.0.tgz",
+      "integrity": "sha512-fRA+BaAWOR/yr/t7T9E9GJztHPeFjj8U35ajyAjCDtAAnTn1Rc1f6W6VGPJrO1tkQv9zWu+JRof7z6oQtiYVFQ=="
     },
     "domexception": {
       "version": "2.0.1",
@@ -37700,7 +36758,7 @@
     },
     "duplexify": {
       "version": "3.7.1",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "end-of-stream": "^1.0.0",
         "inherits": "^2.0.1",
@@ -37710,7 +36768,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "2.3.7",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -37723,7 +36781,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -37747,6 +36805,8 @@
     },
     "elliptic": {
       "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
       "requires": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -37758,7 +36818,9 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.12.0"
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         }
       }
     },
@@ -37772,25 +36834,18 @@
       "version": "7.0.3",
       "dev": true
     },
-    "emojis-list": {
-      "version": "3.0.0",
-      "optional": true,
-      "peer": true
-    },
     "encodeurl": {
       "version": "1.0.2",
       "peer": true
     },
     "encoding": {
       "version": "0.1.13",
-      "dev": true,
       "requires": {
         "iconv-lite": "^0.6.2"
       },
       "dependencies": {
         "iconv-lite": {
           "version": "0.6.2",
-          "dev": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
@@ -37803,49 +36858,6 @@
         "once": "^1.4.0"
       }
     },
-    "enhanced-resolve": {
-      "version": "4.5.0",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "memory-fs": "^0.5.0",
-        "tapable": "^1.0.0"
-      },
-      "dependencies": {
-        "memory-fs": {
-          "version": "0.5.0",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "errno": "^0.1.3",
-            "readable-stream": "^2.0.1"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
     "env-paths": {
       "version": "2.2.0",
       "dev": true
@@ -37856,14 +36868,6 @@
     "err-code": {
       "version": "1.1.2",
       "dev": true
-    },
-    "errno": {
-      "version": "0.1.8",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "prr": "~1.0.1"
-      }
     },
     "error-ex": {
       "version": "1.3.2",
@@ -37888,7 +36892,6 @@
     },
     "es-abstract": {
       "version": "1.18.0-next.2",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
@@ -37908,12 +36911,16 @@
     },
     "es-to-primitive": {
       "version": "1.2.1",
-      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "es6-object-assign": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
+      "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw="
     },
     "es6-promise": {
       "version": "4.2.8",
@@ -37964,37 +36971,8 @@
         }
       }
     },
-    "eslint-scope": {
-      "version": "4.0.3",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
-      }
-    },
     "esprima": {
       "version": "4.0.1"
-    },
-    "esrecurse": {
-      "version": "4.3.0",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "estraverse": "^5.2.0"
-      },
-      "dependencies": {
-        "estraverse": {
-          "version": "5.2.0",
-          "optional": true,
-          "peer": true
-        }
-      }
-    },
-    "estraverse": {
-      "version": "4.3.0",
-      "optional": true,
-      "peer": true
     },
     "esutils": {
       "version": "2.0.3"
@@ -38010,8 +36988,15 @@
       "version": "3.1.2",
       "dev": true
     },
+    "events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
+    },
     "evp_bytestokey": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "requires": {
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
@@ -38114,10 +37099,6 @@
           "version": "2.0.0"
         }
       }
-    },
-    "expand-template": {
-      "version": "2.0.3",
-      "optional": true
     },
     "expect": {
       "version": "26.6.2",
@@ -38421,7 +37402,7 @@
     },
     "figgy-pudding": {
       "version": "3.5.2",
-      "devOptional": true
+      "dev": true
     },
     "figures": {
       "version": "2.0.0",
@@ -38536,7 +37517,7 @@
     },
     "flush-write-stream": {
       "version": "1.1.1",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
@@ -38544,7 +37525,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "2.3.7",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -38557,7 +37538,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -38573,6 +37554,11 @@
     },
     "for-in": {
       "version": "1.0.2"
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -38599,7 +37585,7 @@
     },
     "from2": {
       "version": "2.3.0",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
@@ -38607,7 +37593,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "2.3.7",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -38620,16 +37606,12 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
         }
       }
-    },
-    "fs-constants": {
-      "version": "1.0.0",
-      "optional": true
     },
     "fs-extra": {
       "version": "8.1.0",
@@ -38648,7 +37630,7 @@
     },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "iferr": "^0.1.5",
@@ -38658,7 +37640,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "2.3.7",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -38671,7 +37653,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -38772,6 +37754,14 @@
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1"
+      }
+    },
+    "get-orientation": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/get-orientation/-/get-orientation-1.1.2.tgz",
+      "integrity": "sha512-/pViTfifW+gBbh/RnlFYHINvELT9Znt+SYyDKAUL6uV6By019AK/s+i9XP4jSwq7lwP38Fd8HVeTxym3+hkwmQ==",
+      "requires": {
+        "stream-parser": "^0.3.1"
       }
     },
     "get-package-type": {
@@ -39195,10 +38185,6 @@
         "ini": "^1.3.2"
       }
     },
-    "github-from-package": {
-      "version": "0.0.0",
-      "optional": true
-    },
     "glob": {
       "version": "7.1.6",
       "requires": {
@@ -39346,6 +38332,8 @@
     },
     "hash-base": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+      "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
       "requires": {
         "inherits": "^2.0.4",
         "readable-stream": "^3.6.0",
@@ -39353,12 +38341,16 @@
       },
       "dependencies": {
         "safe-buffer": {
-          "version": "5.2.1"
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         }
       }
     },
     "hash.js": {
       "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
       "requires": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
@@ -39386,6 +38378,8 @@
     },
     "hmac-drbg": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "requires": {
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
@@ -39393,7 +38387,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.8.8",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "devOptional": true
     },
     "html-encoding-sniffer": {
@@ -39456,7 +38452,9 @@
       }
     },
     "https-browserify": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+      "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
     },
     "https-proxy-agent": {
       "version": "2.2.4",
@@ -39499,7 +38497,7 @@
     },
     "iferr": {
       "version": "0.1.5",
-      "devOptional": true
+      "dev": true
     },
     "ignore": {
       "version": "4.0.6",
@@ -39550,7 +38548,7 @@
     },
     "infer-owner": {
       "version": "1.0.4",
-      "devOptional": true
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
@@ -39564,7 +38562,7 @@
     },
     "ini": {
       "version": "1.3.8",
-      "devOptional": true
+      "dev": true
     },
     "init-package-json": {
       "version": "1.10.3",
@@ -39629,6 +38627,14 @@
         "kind-of": "^6.0.0"
       }
     },
+    "is-arguments": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.0.tgz",
+      "integrity": "sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==",
+      "requires": {
+        "call-bind": "^1.0.0"
+      }
+    },
     "is-arrayish": {
       "version": "0.2.1"
     },
@@ -39642,8 +38648,7 @@
       "version": "1.1.6"
     },
     "is-callable": {
-      "version": "1.2.3",
-      "dev": true
+      "version": "1.2.3"
     },
     "is-ci": {
       "version": "2.0.0",
@@ -39664,8 +38669,7 @@
       }
     },
     "is-date-object": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "is-descriptor": {
       "version": "1.0.2",
@@ -39715,15 +38719,28 @@
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
       "dev": true
     },
+    "is-generator-function": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.9.tgz",
+      "integrity": "sha512-ZJ34p1uvIfptHCN7sFTjGibB9/oBg17sHqzDLfuwhvmN/qLVvIQXRQ8licZQ35WJ8KuEQt/etnnzQFI9C9Ue/A=="
+    },
     "is-glob": {
       "version": "4.0.1",
       "requires": {
         "is-extglob": "^2.1.1"
       }
     },
+    "is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      }
+    },
     "is-negative-zero": {
-      "version": "2.0.1",
-      "dev": true
+      "version": "2.0.1"
     },
     "is-number": {
       "version": "3.0.0",
@@ -39759,7 +38776,6 @@
     },
     "is-regex": {
       "version": "1.1.2",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-symbols": "^1.0.1"
@@ -39777,7 +38793,6 @@
     },
     "is-symbol": {
       "version": "1.0.3",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.1"
       }
@@ -39787,6 +38802,18 @@
       "dev": true,
       "requires": {
         "text-extensions": "^1.0.0"
+      }
+    },
+    "is-typed-array": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.5.tgz",
+      "integrity": "sha512-S+GRDgJlR3PyEbsX/Fobd9cqpZBuvUS+8asRqYDMLCb2qMzt1oz5m5oxQCxOgUDxiWsOVNi4yaF+/uvdlHlYug==",
+      "requires": {
+        "available-typed-arrays": "^1.0.2",
+        "call-bind": "^1.0.2",
+        "es-abstract": "^1.18.0-next.2",
+        "foreach": "^2.0.5",
+        "has-symbols": "^1.0.1"
       }
     },
     "is-typedarray": {
@@ -43419,6 +42446,7 @@
     },
     "jest-worker": {
       "version": "24.9.0",
+      "dev": true,
       "requires": {
         "merge-stream": "^2.0.0",
         "supports-color": "^6.1.0"
@@ -43426,6 +42454,7 @@
       "dependencies": {
         "supports-color": {
           "version": "6.1.0",
+          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -43670,21 +42699,6 @@
         "type-check": "~0.3.2"
       }
     },
-    "line-column": {
-      "version": "1.0.2",
-      "requires": {
-        "isarray": "^1.0.0",
-        "isobject": "^2.0.0"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "2.1.0",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        }
-      }
-    },
     "lines-and-columns": {
       "version": "1.1.6",
       "dev": true
@@ -43698,31 +42712,6 @@
         "pify": "^4.0.1",
         "strip-bom": "^3.0.0",
         "type-fest": "^0.3.0"
-      }
-    },
-    "loader-runner": {
-      "version": "2.4.0",
-      "optional": true,
-      "peer": true
-    },
-    "loader-utils": {
-      "version": "1.4.0",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^1.0.1"
-      },
-      "dependencies": {
-        "json5": {
-          "version": "1.0.1",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "minimist": "^1.2.0"
-          }
-        }
       }
     },
     "locate-path": {
@@ -43819,7 +42808,7 @@
     },
     "lru-cache": {
       "version": "5.1.1",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "yallist": "^3.0.2"
       }
@@ -43878,43 +42867,12 @@
     },
     "md5.js": {
       "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
-      }
-    },
-    "memory-fs": {
-      "version": "0.4.1",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "errno": "^0.1.3",
-        "readable-stream": "^2.0.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
       }
     },
     "meow": {
@@ -44005,7 +42963,9 @@
           },
           "dependencies": {
             "hosted-git-info": {
-              "version": "2.8.8",
+              "version": "2.8.9",
+              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+              "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
               "dev": true
             },
             "normalize-package-data": {
@@ -44611,6 +43571,7 @@
       "version": "0.64.0",
       "peer": true,
       "requires": {
+        "@babel/core": "^7.0.0",
         "@babel/plugin-proposal-class-properties": "^7.0.0",
         "@babel/plugin-proposal-export-default-from": "^7.0.0",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
@@ -44661,6 +43622,7 @@
       "version": "0.64.0",
       "peer": true,
       "requires": {
+        "@babel/core": "^7.0.0",
         "babel-preset-fbjs": "^3.3.0",
         "metro-babel-transformer": "0.64.0",
         "metro-react-native-babel-preset": "0.64.0",
@@ -44785,13 +43747,17 @@
     },
     "miller-rabin": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "requires": {
         "bn.js": "^4.0.0",
         "brorand": "^1.0.1"
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.12.0"
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         }
       }
     },
@@ -44811,19 +43777,19 @@
     "mimic-fn": {
       "version": "1.2.0"
     },
-    "mimic-response": {
-      "version": "3.1.0",
-      "optional": true
-    },
     "min-indent": {
       "version": "1.0.1",
       "dev": true
     },
     "minimalistic-assert": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "minimalistic-crypto-utils": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -44860,7 +43826,7 @@
     },
     "mississippi": {
       "version": "3.0.0",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "concat-stream": "^1.5.0",
         "duplexify": "^3.4.2",
@@ -44876,7 +43842,7 @@
       "dependencies": {
         "concat-stream": {
           "version": "1.6.2",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "buffer-from": "^1.0.0",
             "inherits": "^2.0.3",
@@ -44886,7 +43852,7 @@
         },
         "readable-stream": {
           "version": "2.3.7",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -44899,14 +43865,14 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
         },
         "through2": {
           "version": "2.0.5",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "readable-stream": "~2.3.6",
             "xtend": "~4.0.1"
@@ -44927,10 +43893,6 @@
         "minimist": "^1.2.5"
       }
     },
-    "mkdirp-classic": {
-      "version": "0.5.3",
-      "optional": true
-    },
     "mkdirp-promise": {
       "version": "5.0.1",
       "dev": true,
@@ -44944,7 +43906,7 @@
     },
     "move-concurrently": {
       "version": "1.0.1",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "aproba": "^1.1.1",
         "copy-concurrently": "^1.0.0",
@@ -44956,7 +43918,7 @@
       "dependencies": {
         "aproba": {
           "version": "1.2.0",
-          "devOptional": true
+          "dev": true
         }
       }
     },
@@ -44992,7 +43954,9 @@
       "peer": true
     },
     "nanoid": {
-      "version": "3.1.20"
+      "version": "3.1.23",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
+      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -45009,10 +43973,6 @@
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.1"
       }
-    },
-    "napi-build-utils": {
-      "version": "1.0.2",
-      "optional": true
     },
     "native-url": {
       "version": "0.3.4",
@@ -45034,45 +43994,60 @@
       "version": "2.6.2"
     },
     "next": {
-      "version": "10.0.7",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/next/-/next-10.2.0.tgz",
+      "integrity": "sha512-PKDKCSF7s82xudu3kQhOEaokxggpbLEWouEUtzP6OqV0YqKYHF+Ff+BFLycEem8ixtTM2M6ElN0VRJcskJfxPQ==",
       "requires": {
         "@babel/runtime": "7.12.5",
         "@hapi/accept": "5.0.1",
-        "@next/env": "10.0.7",
-        "@next/polyfill-module": "10.0.7",
-        "@next/react-dev-overlay": "10.0.7",
-        "@next/react-refresh-utils": "10.0.7",
+        "@next/env": "10.2.0",
+        "@next/polyfill-module": "10.2.0",
+        "@next/react-dev-overlay": "10.2.0",
+        "@next/react-refresh-utils": "10.2.0",
         "@opentelemetry/api": "0.14.0",
+        "assert": "2.0.0",
         "ast-types": "0.13.2",
+        "browserify-zlib": "0.2.0",
         "browserslist": "4.16.1",
         "buffer": "5.6.0",
         "caniuse-lite": "^1.0.30001179",
         "chalk": "2.4.2",
         "chokidar": "3.5.1",
+        "constants-browserify": "1.0.0",
         "crypto-browserify": "3.12.0",
-        "cssnano-simple": "1.2.2",
+        "cssnano-simple": "2.0.0",
+        "domain-browser": "4.19.0",
+        "encoding": "0.1.13",
         "etag": "1.8.1",
         "find-cache-dir": "3.3.1",
-        "jest-worker": "24.9.0",
+        "get-orientation": "1.1.2",
+        "https-browserify": "1.0.0",
+        "jest-worker": "27.0.0-next.5",
         "native-url": "0.3.4",
         "node-fetch": "2.6.1",
         "node-html-parser": "1.4.9",
         "node-libs-browser": "^2.2.1",
+        "os-browserify": "0.3.0",
         "p-limit": "3.1.0",
         "path-browserify": "1.0.1",
         "pnp-webpack-plugin": "1.6.4",
-        "postcss": "8.1.7",
+        "postcss": "8.2.13",
         "process": "0.11.10",
         "prop-types": "15.7.2",
+        "querystring-es3": "0.2.1",
         "raw-body": "2.4.1",
         "react-is": "16.13.1",
         "react-refresh": "0.8.3",
-        "sharp": "0.26.3",
         "stream-browserify": "3.0.0",
+        "stream-http": "3.1.1",
+        "string_decoder": "1.3.0",
         "styled-jsx": "3.3.2",
+        "timers-browserify": "2.0.12",
+        "tty-browserify": "0.0.1",
         "use-subscription": "1.5.1",
+        "util": "0.12.3",
         "vm-browserify": "1.1.2",
-        "watchpack": "2.0.0-beta.13"
+        "watchpack": "2.1.1"
       },
       "dependencies": {
         "@babel/runtime": {
@@ -45098,23 +44073,34 @@
             "ieee754": "^1.1.4"
           }
         },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "jest-worker": {
+          "version": "27.0.0-next.5",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.0-next.5.tgz",
+          "integrity": "sha512-mk0umAQ5lT+CaOJ+Qp01N6kz48sJG2kr2n1rX0koqKf6FIygQV0qLOdN9SCYID4IVeSigDOcPeGLozdMLYfb5g==",
+          "requires": {
+            "@types/node": "*",
+            "merge-stream": "^2.0.0",
+            "supports-color": "^8.0.0"
+          }
+        },
         "p-limit": {
           "version": "3.1.0",
           "requires": {
             "yocto-queue": "^0.1.0"
           }
         },
-        "postcss": {
-          "version": "8.1.7",
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
           "requires": {
-            "colorette": "^1.2.1",
-            "line-column": "^1.0.2",
-            "nanoid": "^3.1.16",
-            "source-map": "^0.6.1"
+            "has-flag": "^4.0.0"
           }
-        },
-        "source-map": {
-          "version": "0.6.1"
         }
       }
     },
@@ -45124,23 +44110,6 @@
     "nocache": {
       "version": "2.1.0",
       "peer": true
-    },
-    "node-abi": {
-      "version": "2.20.0",
-      "optional": true,
-      "requires": {
-        "semver": "^5.4.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "optional": true
-        }
-      }
-    },
-    "node-addon-api": {
-      "version": "3.1.0",
-      "optional": true
     },
     "node-dir": {
       "version": "0.1.17",
@@ -45195,6 +44164,8 @@
     },
     "node-libs-browser": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
+      "integrity": "sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==",
       "requires": {
         "assert": "^1.1.1",
         "browserify-zlib": "^0.2.0",
@@ -45221,20 +44192,54 @@
         "vm-browserify": "^1.0.1"
       },
       "dependencies": {
-        "events": {
-          "version": "3.3.0"
+        "assert": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
+          "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
+          "requires": {
+            "object-assign": "^4.1.1",
+            "util": "0.10.3"
+          },
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+            },
+            "util": {
+              "version": "0.10.3",
+              "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+              "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+              "requires": {
+                "inherits": "2.0.1"
+              }
+            }
+          }
+        },
+        "domain-browser": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
+          "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
         },
         "inherits": {
-          "version": "2.0.3"
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "path-browserify": {
-          "version": "0.0.1"
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
+          "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ=="
         },
         "punycode": {
-          "version": "1.4.1"
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         },
         "readable-stream": {
           "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -45247,19 +44252,42 @@
         },
         "stream-browserify": {
           "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
+          "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
           "requires": {
             "inherits": "~2.0.1",
             "readable-stream": "^2.0.2"
           }
         },
+        "stream-http": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
+          "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
+          "requires": {
+            "builtin-status-codes": "^3.0.0",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.3.6",
+            "to-arraybuffer": "^1.0.0",
+            "xtend": "^4.0.0"
+          }
+        },
         "string_decoder": {
           "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
           }
         },
+        "tty-browserify": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+          "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
+        },
         "util": {
           "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
+          "integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
           "requires": {
             "inherits": "2.0.3"
           }
@@ -45618,10 +44646,6 @@
       "version": "1.13.2",
       "peer": true
     },
-    "noop-logger": {
-      "version": "0.1.1",
-      "optional": true
-    },
     "nopt": {
       "version": "4.0.3",
       "dev": true,
@@ -45810,8 +44834,16 @@
       }
     },
     "object-inspect": {
-      "version": "1.9.0",
-      "dev": true
+      "version": "1.9.0"
+    },
+    "object-is": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
     },
     "object-keys": {
       "version": "1.1.1"
@@ -45911,7 +44943,9 @@
       }
     },
     "os-browserify": {
-      "version": "0.3.0"
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+      "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
     },
     "os-homedir": {
       "version": "1.0.2",
@@ -46002,11 +45036,13 @@
       }
     },
     "pako": {
-      "version": "1.0.11"
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "parallel-transform": {
       "version": "1.2.0",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "cyclist": "^1.0.1",
         "inherits": "^2.0.3",
@@ -46015,7 +45051,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "2.3.7",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -46028,7 +45064,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -46037,6 +45073,8 @@
     },
     "parse-asn1": {
       "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
+      "integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
       "requires": {
         "asn1.js": "^5.2.0",
         "browserify-aes": "^1.0.0",
@@ -46122,7 +45160,9 @@
       }
     },
     "pbkdf2": {
-      "version": "3.1.1",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
+      "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
       "requires": {
         "create-hash": "^1.1.2",
         "create-hmac": "^1.1.4",
@@ -46167,15 +45207,19 @@
       }
     },
     "platform": {
-      "version": "1.3.6"
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
     },
     "plist": {
-      "version": "3.0.1",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.2.tgz",
+      "integrity": "sha512-MSrkwZBdQ6YapHy87/8hDU8MnIcyxBKjeF+McXnr5A9MtffPewTs7G3hlpodT5TacyfIyFTaJEhh3GGcmasTgQ==",
       "peer": true,
       "requires": {
-        "base64-js": "^1.2.3",
+        "base64-js": "^1.5.1",
         "xmlbuilder": "^9.0.7",
-        "xmldom": "0.1.x"
+        "xmldom": "^0.5.0"
       }
     },
     "pluralize": {
@@ -46194,46 +45238,20 @@
     "posix-character-classes": {
       "version": "0.1.1"
     },
-    "prebuild-install": {
-      "version": "6.0.1",
-      "optional": true,
+    "postcss": {
+      "version": "8.2.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.13.tgz",
+      "integrity": "sha512-FCE5xLH+hjbzRdpbRb1IMCvPv9yZx2QnDarBEYSN0N0HYk+TcXsEhwdFcFb+SRWOKzKGErhIEbBK2ogyLdTtfQ==",
       "requires": {
-        "detect-libc": "^1.0.3",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^1.0.1",
-        "node-abi": "^2.7.0",
-        "noop-logger": "^0.1.1",
-        "npmlog": "^4.0.1",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^3.0.3",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0",
-        "which-pm-runs": "^1.0.0"
+        "colorette": "^1.2.2",
+        "nanoid": "^3.1.22",
+        "source-map": "^0.6.1"
       },
       "dependencies": {
-        "decompress-response": {
-          "version": "4.2.1",
-          "optional": true,
-          "requires": {
-            "mimic-response": "^2.0.0"
-          }
-        },
-        "mimic-response": {
-          "version": "2.1.0",
-          "optional": true
-        },
-        "simple-get": {
-          "version": "3.1.0",
-          "optional": true,
-          "requires": {
-            "decompress-response": "^4.2.0",
-            "once": "^1.3.1",
-            "simple-concat": "^1.0.0"
-          }
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
@@ -46338,7 +45356,9 @@
       }
     },
     "process": {
-      "version": "0.11.10"
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "process-nextick-args": {
       "version": "2.0.1"
@@ -46352,7 +45372,7 @@
     },
     "promise-inflight": {
       "version": "1.0.1",
-      "devOptional": true
+      "dev": true
     },
     "promise-retry": {
       "version": "1.1.1",
@@ -46406,11 +45426,6 @@
         "genfun": "^5.0.0"
       }
     },
-    "prr": {
-      "version": "1.0.1",
-      "optional": true,
-      "peer": true
-    },
     "pseudomap": {
       "version": "1.0.2",
       "optional": true,
@@ -46422,6 +45437,8 @@
     },
     "public-encrypt": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
       "requires": {
         "bn.js": "^4.1.0",
         "browserify-rsa": "^4.0.0",
@@ -46432,7 +45449,9 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.12.0"
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         }
       }
     },
@@ -46445,7 +45464,7 @@
     },
     "pumpify": {
       "version": "1.5.1",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "duplexify": "^3.6.0",
         "inherits": "^2.0.3",
@@ -46454,7 +45473,7 @@
       "dependencies": {
         "pump": {
           "version": "2.0.1",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "end-of-stream": "^1.1.0",
             "once": "^1.3.1"
@@ -46487,7 +45506,9 @@
       "version": "0.2.0"
     },
     "querystring-es3": {
-      "version": "0.2.1"
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
     },
     "quick-lru": {
       "version": "4.0.1",
@@ -46495,12 +45516,16 @@
     },
     "randombytes": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "requires": {
         "safe-buffer": "^5.1.0"
       }
     },
     "randomfill": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "requires": {
         "randombytes": "^2.0.5",
         "safe-buffer": "^5.1.0"
@@ -46517,22 +45542,6 @@
         "http-errors": "1.7.3",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
-      }
-    },
-    "rc": {
-      "version": "1.2.8",
-      "optional": true,
-      "requires": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "dependencies": {
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "optional": true
-        }
       }
     },
     "react": {
@@ -46612,7 +45621,9 @@
       }
     },
     "react-refresh": {
-      "version": "0.8.3"
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",
+      "integrity": "sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg=="
     },
     "react-transition-group": {
       "version": "4.4.1",
@@ -46970,6 +45981,8 @@
     },
     "ripemd160": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
@@ -46984,14 +45997,14 @@
     },
     "run-queue": {
       "version": "1.0.3",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "aproba": "^1.1.1"
       },
       "dependencies": {
         "aproba": {
           "version": "1.2.0",
-          "devOptional": true
+          "dev": true
         }
       }
     },
@@ -47250,16 +46263,6 @@
         "object-assign": "^4.1.1"
       }
     },
-    "schema-utils": {
-      "version": "1.0.0",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "ajv": "^6.1.0",
-        "ajv-errors": "^1.0.0",
-        "ajv-keywords": "^3.1.0"
-      }
-    },
     "scss-tokenizer": {
       "version": "0.2.3",
       "optional": true,
@@ -47328,14 +46331,6 @@
       "version": "2.1.0",
       "peer": true
     },
-    "serialize-javascript": {
-      "version": "4.0.0",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "randombytes": "^2.1.0"
-      }
-    },
     "serve-static": {
       "version": "1.14.1",
       "peer": true,
@@ -47376,13 +46371,17 @@
       }
     },
     "setimmediate": {
-      "version": "1.0.5"
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
     "setprototypeof": {
       "version": "1.1.1"
     },
     "sha.js": {
       "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -47393,42 +46392,6 @@
       "dev": true,
       "requires": {
         "kind-of": "^6.0.2"
-      }
-    },
-    "sharp": {
-      "version": "0.26.3",
-      "optional": true,
-      "requires": {
-        "array-flatten": "^3.0.0",
-        "color": "^3.1.3",
-        "detect-libc": "^1.0.3",
-        "node-addon-api": "^3.0.2",
-        "npmlog": "^4.1.2",
-        "prebuild-install": "^6.0.0",
-        "semver": "^7.3.2",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.1.1",
-        "tunnel-agent": "^0.6.0"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "6.0.0",
-          "optional": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "semver": {
-          "version": "7.3.4",
-          "optional": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "optional": true
-        }
       }
     },
     "shebang-command": {
@@ -47462,19 +46425,6 @@
     "signal-exit": {
       "version": "3.0.3"
     },
-    "simple-concat": {
-      "version": "1.0.1",
-      "optional": true
-    },
-    "simple-get": {
-      "version": "4.0.0",
-      "optional": true,
-      "requires": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
     "simple-plist": {
       "version": "1.1.1",
       "peer": true,
@@ -47482,19 +46432,6 @@
         "bplist-creator": "0.0.8",
         "bplist-parser": "0.2.0",
         "plist": "^3.0.1"
-      }
-    },
-    "simple-swizzle": {
-      "version": "0.2.2",
-      "optional": true,
-      "requires": {
-        "is-arrayish": "^0.3.1"
-      },
-      "dependencies": {
-        "is-arrayish": {
-          "version": "0.3.2",
-          "optional": true
-        }
       }
     },
     "sisteransi": {
@@ -47661,11 +46598,6 @@
         "is-plain-obj": "^1.0.0"
       }
     },
-    "source-list-map": {
-      "version": "2.0.1",
-      "optional": true,
-      "peer": true
-    },
     "source-map": {
       "version": "0.5.7"
     },
@@ -47761,8 +46693,10 @@
       }
     },
     "ssri": {
-      "version": "6.0.1",
-      "devOptional": true,
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+      "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
+      "dev": true,
       "requires": {
         "figgy-pudding": "^3.5.1"
       }
@@ -47903,7 +46837,7 @@
     },
     "stream-each": {
       "version": "1.2.3",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "stream-shift": "^1.0.0"
@@ -47917,38 +46851,42 @@
       }
     },
     "stream-http": {
-      "version": "2.8.3",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.1.1.tgz",
+      "integrity": "sha512-S7OqaYu0EkFpgeGFb/NPOoPLxFko7TPqtEeFg5DXPB4v/KETHG0Ln6fRFrNezoelpaDKmycEmmZ81cC9DAwgYg==",
       "requires": {
         "builtin-status-codes": "^3.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.3.6",
-        "to-arraybuffer": "^1.0.0",
-        "xtend": "^4.0.0"
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "xtend": "^4.0.2"
+      }
+    },
+    "stream-parser": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/stream-parser/-/stream-parser-0.3.1.tgz",
+      "integrity": "sha1-FhhUhpRCACGhGC/wrxkRwSl2F3M=",
+      "requires": {
+        "debug": "2"
       },
       "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "ms": "2.0.0"
           }
         },
-        "string_decoder": {
-          "version": "1.1.1",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
     "stream-shift": {
       "version": "1.0.1",
-      "devOptional": true
+      "dev": true
     },
     "strict-uri-encode": {
       "version": "2.0.0",
@@ -48018,7 +46956,6 @@
     },
     "string.prototype.trimend": {
       "version": "1.0.4",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -48026,7 +46963,6 @@
     },
     "string.prototype.trimstart": {
       "version": "1.0.4",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -48164,11 +47100,6 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
-    "tapable": {
-      "version": "1.1.3",
-      "optional": true,
-      "peer": true
-    },
     "tar": {
       "version": "4.4.13",
       "dev": true,
@@ -48180,27 +47111,6 @@
         "mkdirp": "^0.5.0",
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.3"
-      }
-    },
-    "tar-fs": {
-      "version": "2.1.1",
-      "optional": true,
-      "requires": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "tar-stream": {
-      "version": "2.2.0",
-      "optional": true,
-      "requires": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
       }
     },
     "teeny-request": {
@@ -48318,56 +47228,6 @@
         }
       }
     },
-    "terser": {
-      "version": "4.8.0",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "commander": "^2.20.0",
-        "source-map": "~0.6.1",
-        "source-map-support": "~0.5.12"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "optional": true,
-          "peer": true
-        }
-      }
-    },
-    "terser-webpack-plugin": {
-      "version": "1.4.5",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "cacache": "^12.0.2",
-        "find-cache-dir": "^2.1.0",
-        "is-wsl": "^1.1.0",
-        "schema-utils": "^1.0.0",
-        "serialize-javascript": "^4.0.0",
-        "source-map": "^0.6.1",
-        "terser": "^4.1.2",
-        "webpack-sources": "^1.4.0",
-        "worker-farm": "^1.7.0"
-      },
-      "dependencies": {
-        "find-cache-dir": {
-          "version": "2.1.0",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "commondir": "^1.0.1",
-            "make-dir": "^2.0.0",
-            "pkg-dir": "^3.0.0"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "optional": true,
-          "peer": true
-        }
-      }
-    },
     "test-exclude": {
       "version": "5.2.3",
       "dev": true,
@@ -48425,6 +47285,8 @@
     },
     "timers-browserify": {
       "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
+      "integrity": "sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==",
       "requires": {
         "setimmediate": "^1.0.4"
       }
@@ -48440,7 +47302,9 @@
       "version": "1.0.4"
     },
     "to-arraybuffer": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+      "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
     },
     "to-fast-properties": {
       "version": "2.0.0"
@@ -48515,7 +47379,9 @@
       "version": "1.14.1"
     },
     "tty-browserify": {
-      "version": "0.0.0"
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
+      "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw=="
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -48549,7 +47415,7 @@
     },
     "typedarray": {
       "version": "0.0.6",
-      "devOptional": true
+      "dev": true
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",
@@ -48636,14 +47502,14 @@
     },
     "unique-filename": {
       "version": "1.1.1",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "unique-slug": "^2.0.0"
       }
     },
     "unique-slug": {
       "version": "2.0.2",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "imurmurhash": "^0.1.4"
       }
@@ -48728,6 +47594,19 @@
         "object-assign": "^4.1.1"
       }
     },
+    "util": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.3.tgz",
+      "integrity": "sha512-I8XkoQwE+fPQEhy9v012V+TSdH2kp9ts29i20TaaDUXsg7x/onePbhFJUExBfv/2ay1ZOp/Vsm3nDlmnFGSAog==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "safe-buffer": "^5.1.2",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "util-deprecate": {
       "version": "1.0.2"
     },
@@ -48808,7 +47687,9 @@
       "peer": true
     },
     "vm-browserify": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
+      "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
     },
     "w3c-hr-time": {
       "version": "1.0.2",
@@ -48841,14 +47722,18 @@
       }
     },
     "watchpack": {
-      "version": "2.0.0-beta.13",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.1.1.tgz",
+      "integrity": "sha512-Oo7LXCmc1eE1AjyuSBmtC3+Wy4HcV8PxWh2kP6fOl8yTlNS7r0K9l1ao2lrrUza7V39Y3D/BbJgY8VeSlc5JKw==",
       "requires": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
       },
       "dependencies": {
         "glob-to-regexp": {
-          "version": "0.4.1"
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+          "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
         }
       }
     },
@@ -48860,70 +47745,6 @@
     },
     "webidl-conversions": {
       "version": "4.0.2"
-    },
-    "webpack": {
-      "version": "4.46.0",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/helper-module-context": "1.9.0",
-        "@webassemblyjs/wasm-edit": "1.9.0",
-        "@webassemblyjs/wasm-parser": "1.9.0",
-        "acorn": "^6.4.1",
-        "ajv": "^6.10.2",
-        "ajv-keywords": "^3.4.1",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^4.5.0",
-        "eslint-scope": "^4.0.3",
-        "json-parse-better-errors": "^1.0.2",
-        "loader-runner": "^2.4.0",
-        "loader-utils": "^1.2.3",
-        "memory-fs": "^0.4.1",
-        "micromatch": "^3.1.10",
-        "mkdirp": "^0.5.3",
-        "neo-async": "^2.6.1",
-        "node-libs-browser": "^2.2.1",
-        "schema-utils": "^1.0.0",
-        "tapable": "^1.1.3",
-        "terser-webpack-plugin": "^1.4.3",
-        "watchpack": "^1.7.4",
-        "webpack-sources": "^1.4.1"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "6.4.2",
-          "optional": true,
-          "peer": true
-        },
-        "watchpack": {
-          "version": "1.7.5",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "chokidar": "^3.4.1",
-            "graceful-fs": "^4.1.2",
-            "neo-async": "^2.5.0",
-            "watchpack-chokidar2": "^2.0.1"
-          }
-        }
-      }
-    },
-    "webpack-sources": {
-      "version": "1.4.3",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "source-list-map": "^2.0.0",
-        "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "optional": true,
-          "peer": true
-        }
-      }
     },
     "whatwg-encoding": {
       "version": "1.0.5",
@@ -48981,9 +47802,19 @@
     "which-module": {
       "version": "2.0.0"
     },
-    "which-pm-runs": {
-      "version": "1.0.0",
-      "optional": true
+    "which-typed-array": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.4.tgz",
+      "integrity": "sha512-49E0SpUe90cjpoc7BOJwyPHRqSAd12c10Qm2amdEZrJPCY2NDxaW01zHITrem+rnETY3dwrbH3UUrUwagfCYDA==",
+      "requires": {
+        "available-typed-arrays": "^1.0.2",
+        "call-bind": "^1.0.0",
+        "es-abstract": "^1.18.0-next.1",
+        "foreach": "^2.0.5",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.1",
+        "is-typed-array": "^1.1.3"
+      }
     },
     "wide-align": {
       "version": "1.1.3",
@@ -49008,14 +47839,6 @@
     "wordwrap": {
       "version": "1.0.0",
       "dev": true
-    },
-    "worker-farm": {
-      "version": "1.7.0",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "errno": "~0.1.7"
-      }
     },
     "wrap-ansi": {
       "version": "5.1.0",
@@ -49142,7 +47965,9 @@
       }
     },
     "xmldom": {
-      "version": "0.1.31",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
+      "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==",
       "peer": true
     },
     "xtend": {
@@ -49153,7 +47978,7 @@
     },
     "yallist": {
       "version": "3.1.1",
-      "devOptional": true
+      "dev": true
     },
     "yargs": {
       "version": "15.4.1",


### PR DESCRIPTION
to top off the recent cleanups I ran `npm audit fix` from a fresh `npm clean-install` after `git reset --hard upstream/master`.

That updated the bids-validator versions in the package-lock.json to `1.7.3-dev.0` as they should be .

It also fixed some minor security issues.