### PR TITLE
[FIX] Update ScanDate for PET schema

### DIFF
--- a/bids-validator/validators/json/schemas/pet.json
+++ b/bids-validator/validators/json/schemas/pet.json
@@ -70,7 +70,7 @@
     "FrameDuration": { "type": "array", "items": { "type": "number" } },
     "ScanDate": {
       "type": "string",
-      "pattern": "date"
+      "pattern": "^(19|20)[0-9][0-9]-(0[0-9]|1[0-2])-(0[1-9]|([12][0-9]|3[01]))T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$"
     },
     "InjectionEnd": { "type": "number" },
 

--- a/bids-validator/validators/json/schemas/pet.json
+++ b/bids-validator/validators/json/schemas/pet.json
@@ -68,10 +68,6 @@
     "InjectionStart": { "type": "number" },
     "FrameTimesStart": {"type": "array", "items": { "type": "number" } },
     "FrameDuration": { "type": "array", "items": { "type": "number" } },
-    "ScanDate": {
-      "type": "string",
-      "pattern": "^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(.\d+)?)?Z?$"
-    },
     "InjectionEnd": { "type": "number" },
 
     "AcquisitionMode": { "type": "string", "minLength": 1 },

--- a/bids-validator/validators/json/schemas/pet.json
+++ b/bids-validator/validators/json/schemas/pet.json
@@ -70,7 +70,7 @@
     "FrameDuration": { "type": "array", "items": { "type": "number" } },
     "ScanDate": {
       "type": "string",
-      "pattern": "^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(.\d+)?Z?$"
+      "pattern": "^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(.\d+)?)?Z?$"
     },
     "InjectionEnd": { "type": "number" },
 

--- a/bids-validator/validators/json/schemas/pet.json
+++ b/bids-validator/validators/json/schemas/pet.json
@@ -70,7 +70,7 @@
     "FrameDuration": { "type": "array", "items": { "type": "number" } },
     "ScanDate": {
       "type": "string",
-      "pattern": "^(19|20)[0-9][0-9]-(0[0-9]|1[0-2])-(0[1-9]|([12][0-9]|3[01]))T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$"
+      "pattern": "^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(.\d+)?Z?$"
     },
     "InjectionEnd": { "type": "number" },
 


### PR DESCRIPTION
This PR updates the `ScanDate` regexp to be in accordance with the specification's definition for dates. 

closes #1282 