### PR TITLE
FIX: Validate VolumeTiming as an array of numbers in schema

### DIFF
--- a/bids-validator/validators/json/schemas/bold.json
+++ b/bids-validator/validators/json/schemas/bold.json
@@ -39,8 +39,11 @@
       "type": "string"
     },
     "VolumeTiming": {
-      "type": "number",
-      "exclusiveMinimum": 0
+      "type": "array",
+      "items": {
+        "type": "number",
+        "minimum": 0
+      }
     }
   }
 }


### PR DESCRIPTION
fix  #1289

VolumeTiming should be an array of number, instead of number.