### PR TITLE
feat: Extend modality summary with secondary modalities

### DIFF
--- a/bids-validator/tests/bids.spec.js
+++ b/bids-validator/tests/bids.spec.js
@@ -99,7 +99,7 @@ describe('BIDS example datasets ', function() {
       assert(summary.sessions.length === 0)
       assert(summary.subjects.length === 16)
       assert.deepEqual(summary.tasks, ['balloon analog risk task'])
-      assert(summary.modalities.includes('MRI'))
+      expect(summary.modalities).toEqual(['MRI'])
       assert(summary.totalFiles === 134)
       assert.deepEqual(errors.length, 1)
       assert(warnings.length === 2)
@@ -124,7 +124,7 @@ describe('BIDS example datasets ', function() {
       assert(summary.subjects.length === 1)
       assert.deepEqual(summary.tasks, ['rhyme judgment'])
       assert.isFalse(summary.dataProcessed)
-      assert(summary.modalities.includes('MRI'))
+      expect(summary.modalities).toEqual(['MRI'])
       expect(summary.totalFiles).toEqual(8)
       assert(
         errors.findIndex(error => error.code === 60) > -1,

--- a/bids-validator/utils/summary/__tests__/collectModalities.spec.js
+++ b/bids-validator/utils/summary/__tests__/collectModalities.spec.js
@@ -5,29 +5,53 @@ import {
   ds002718,
   ds003400,
 } from '../../../tests/data/collectModalities-data'
-import { collect } from '../collectModalities'
+import { collectModalities } from '../collectModalities'
 
 describe('collectModalities()', () => {
   it('returns correct values for a PET dataset', () => {
-    expect(collect(ds001421)).toEqual(['PET', 'MRI'])
+    expect(collectModalities(ds001421)).toEqual({
+      primary: ['PET', 'MRI'],
+      secondary: ['MRI_Structural'],
+    })
   })
   it('returns correct values for an MRI dataset', () => {
-    expect(collect(ds001734)).toEqual(['MRI'])
+    expect(collectModalities(ds001734)).toEqual({
+      primary: ['MRI'],
+      secondary: ['MRI_Functional', 'MRI_Structural'],
+    })
   })
   it('returns correct values for an EEG dataset', () => {
-    expect(collect(ds002718)).toEqual(['EEG', 'MRI'])
+    expect(collectModalities(ds002718)).toEqual({
+      primary: ['EEG', 'MRI'],
+      secondary: ['MRI_Structural'],
+    })
   })
   it('returns correct values for an iEEG dataset', () => {
-    expect(collect(ds003400)).toEqual(['iEEG'])
+    expect(collectModalities(ds003400)).toEqual({
+      primary: ['iEEG'],
+      secondary: [],
+    })
   })
   it('returns correct values for an MEG dataset', () => {
-    expect(collect(ds000247)).toEqual(['MEG', 'MRI'])
+    expect(collectModalities(ds000247)).toEqual({
+      primary: ['MEG', 'MRI'],
+      secondary: ['MRI_Structural'],
+    })
   })
   it('sorts other modalities ahead of MRI on ties', () => {
     const tied = [
       '/sub-01/ses-02/pet/sub-01_ses-02_pet.nii.gz',
       '/sub-01/ses-02/anat/sub-01_ses-02_T1w.nii',
     ]
-    expect(collect(tied)).toEqual(['PET', 'MRI'])
+    expect(collectModalities(tied)).toEqual({
+      primary: ['PET', 'MRI'],
+      secondary: ['MRI_Structural'],
+    })
+  })
+  it('returns empty arrays when no matches are found', () => {
+    expect(collectModalities([])).toEqual({
+      primary: [],
+      secondary: [],
+    })
   })
 })

--- a/bids-validator/utils/summary/collectModalities.js
+++ b/bids-validator/utils/summary/collectModalities.js
@@ -1,6 +1,6 @@
 import type from '../type'
 
-export const collect = filenames => {
+export const collectModalities = filenames => {
   const modalities = {
     MRI: 0,
     PET: 0,
@@ -8,35 +8,61 @@ export const collect = filenames => {
     EEG: 0,
     iEEG: 0,
   }
+  const secondary = {
+    MRI_Diffusion: 0,
+    MRI_Structural: 0,
+    MRI_Functional: 0,
+    MRI_Perfusion: 0,
+    PET_Static: 0,
+    PET_Dynamic: 0,
+    iEEG_ECoG: 0,
+    iEEG_SEEG: 0,
+  }
   for (const path of filenames) {
     // MRI files
-    if (
-      type.file.isAnat(path) ||
-      type.file.isDWI(path) ||
-      type.file.isFieldMap(path) ||
-      type.file.isFuncBold(path)
-    ) {
-      modalities['MRI']++
+    if (type.file.isAnat(path)) {
+      modalities.MRI++
+      secondary.MRI_Structural++
+    }
+    if (type.file.isDWI(path)) {
+      modalities.MRI++
+      secondary.MRI_Diffusion++
+    }
+    if (type.file.isAsl(path)) {
+      modalities.MRI++
+      secondary.MRI_Perfusion++
+    }
+    if (type.file.isFunc(path) || type.file.isFuncBold(path)) {
+      modalities.MRI++
+      secondary.MRI_Functional++
+    }
+    if (type.file.isFieldMap(path)) {
+      modalities.MRI++
     }
     if (type.file.isPET(path) || type.file.isPETBlood(path)) {
-      modalities['PET']++
+      modalities.PET++
+      if (path.match('rec-acstat') || path.match('rec-nacstat')) {
+        secondary.PET_Static++
+      } else if (path.match('rec-acdyn') || path.match('rec-nacdyn')) {
+        secondary.PET_Dynamic++
+      }
     }
     if (type.file.isMeg(path)) {
-      modalities['MEG']++
+      modalities.MEG++
     }
     if (type.file.isEEG(path)) {
-      modalities['EEG']++
+      modalities.EEG++
     }
     if (type.file.isIEEG(path)) {
-      modalities['iEEG']++
+      modalities.iEEG++
     }
   }
   // Order by matching file count
   const nonZero = Object.keys(modalities).filter(a => modalities[a] !== 0)
   if (nonZero.length === 0) {
-    return []
+    return { primary: [], secondary: [] }
   }
-  return nonZero.sort((a, b) => {
+  const sortedModalities = nonZero.sort((a, b) => {
     if (modalities[b] === modalities[a]) {
       // On a tie, hand it to the non-MRI modality
       if (b === 'MRI') {
@@ -47,12 +73,13 @@ export const collect = filenames => {
     }
     return modalities[b] - modalities[a]
   })
-}
-
-// Preserve the old fileList signature
-const collectModalities = fileList => {
-  const keys = Object.keys(fileList).map(file => fileList[file].relativePath)
-  return collect(keys)
+  const nonZeroSecondary = Object.keys(secondary).filter(
+    a => secondary[a] !== 0,
+  )
+  const sortedSecondary = nonZeroSecondary.sort(
+    (a, b) => secondary[b] - secondary[a],
+  )
+  return { primary: sortedModalities, secondary: sortedSecondary }
 }
 
 export default collectModalities

--- a/bids-validator/utils/summary/collectSummary.js
+++ b/bids-validator/utils/summary/collectSummary.js
@@ -11,6 +11,7 @@ const collectSummary = (fileList, options) => {
     subjectMetadata: {},
     tasks: [],
     modalities: [],
+    secondaryModalities: [],
     totalFiles: -1,
     size: 0,
     dataProcessed: false,
@@ -28,11 +29,17 @@ const collectSummary = (fileList, options) => {
 
   summary.totalFiles = Object.keys(fileList).length
 
+  const relativePaths = Object.keys(fileList).map(
+    file => fileList[file].relativePath,
+  )
+
   //collect file directory statistics
   summary.size = files.collectDirectorySize(fileList)
 
   // collect modalities for summary
-  summary.modalities = collectModalities(fileList)
+  const { primary, secondary } = collectModalities(relativePaths)
+  summary.modalities = primary
+  summary.secondaryModalities = secondary
 
   // collect subjects
   summary.subjects = collectSubjects(fileList, options)


### PR DESCRIPTION
For MRI and PET this adds a secondary modalities field to the summary.