### PR TITLE
Behavior schema and validation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,6 +157,8 @@ You can get a good impression using the following links:
 - [How JSON schemas are tested](https://github.com/bids-standard/bids-validator/blob/master/bids-validator/tests/json.spec.js)
 - [How TSV files are tested](https://github.com/bids-standard/bids-validator/blob/master/bids-validator/tests/tsv.spec.js)
 
+For more information on how to run the tests check the [testing section](./README.md#testing) of the README.
+
 [link_git]: https://git-scm.com/
 [link_handbook]: https://guides.github.com/introduction/git-handbook/
 [link_swc_intro]: http://swcarpentry.github.io/git-novice/

--- a/bids-validator/tests/json.spec.js
+++ b/bids-validator/tests/json.spec.js
@@ -587,5 +587,4 @@ describe('JSON', function() {
       assert(issues[1].evidence == '.CogPOID should match format "uri"')
     })
   })
-
 })

--- a/bids-validator/tests/json.spec.js
+++ b/bids-validator/tests/json.spec.js
@@ -578,7 +578,7 @@ describe('JSON', function() {
       CogAtlasID:
         'we did a search on https://ww.idontexist.com for the word "atlas"',
       CogPOID:
-        'we did a search on https://ww.idontexisteither.com for the word "paradigm"',        
+        'we did a search on https://ww.idontexisteither.com for the word "paradigm"',
     }
     jsonDict[beh_file.relativePath] = jsonObj
     validate.JSON(beh_file, jsonDict, function(issues) {
@@ -587,6 +587,5 @@ describe('JSON', function() {
       assert(issues[1].evidence == '.CogPOID should match format "uri"')
     })
   })
-
 
 })

--- a/bids-validator/tests/json.spec.js
+++ b/bids-validator/tests/json.spec.js
@@ -566,4 +566,27 @@ describe('JSON', function() {
       )
     })
   })
+
+  var beh_file = {
+    name: 'sub-01_run-01_beh.json',
+    relativePath: '/sub-01_run-01_beh.json',
+  }
+
+  it('*beh.json sidecars with CogPOID or CogAtlasID fields should require a uri format', function() {
+    var jsonObj = {
+      TaskName: 'stroop',
+      CogAtlasID:
+        'we did a search on https://ww.idontexist.com for the word "atlas"',
+      CogPOID:
+        'we did a search on https://ww.idontexisteither.com for the word "paradigm"',        
+    }
+    jsonDict[beh_file.relativePath] = jsonObj
+    validate.JSON(beh_file, jsonDict, function(issues) {
+      assert(issues.length === 2)
+      assert(issues[0].evidence == '.CogAtlasID should match format "uri"')
+      assert(issues[1].evidence == '.CogPOID should match format "uri"')
+    })
+  })
+
+
 })

--- a/bids-validator/validators/json/json.js
+++ b/bids-validator/validators/json/json.js
@@ -119,18 +119,15 @@ const selectSchema = file => {
     } else if (file.name.endsWith('genetic_info.json')) {
       schema = require('./schemas/genetic_info.json')
     } else if (
-        file.name.endsWith('physio.json') ||
-        file.name.endsWith('stim.json')
+      file.name.endsWith('physio.json') ||
+      file.name.endsWith('stim.json')
     ) {
       schema = require('./schemas/physio.json')
     } else if (file.name.endsWith('events.json')) {
       schema = require('./schemas/events.json')
-    } else if (
-      file.relativePath.includes('/beh/') &&
-      file.name.endsWith('beh.json')
-    ) {
+    } else if (file.name.endsWith('beh.json')) {
       schema = require('./schemas/beh.json')
-    } 
+    }
   }
   return schema
 }

--- a/bids-validator/validators/json/json.js
+++ b/bids-validator/validators/json/json.js
@@ -125,7 +125,12 @@ const selectSchema = file => {
       schema = require('./schemas/physio.json')
     } else if (file.name.endsWith('events.json')) {
       schema = require('./schemas/events.json')
-    }
+    } else if (
+      file.relativePath.includes('/beh/') &&
+      file.name.endsWith('beh.json')
+    ) {
+      schema = require('./schemas/beh.json')
+    } 
   }
   return schema
 }

--- a/bids-validator/validators/json/schemas/beh.json
+++ b/bids-validator/validators/json/schemas/beh.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "TaskName": { "$ref": "common_definitions.json#/definitions/TaskName" },
+    "TaskDescription": { "$ref": "common_definitions.json#/definitions/TaskDescription" },
+    "Instructions": { "$ref": "common_definitions.json#/definitions/Instructions" },
+    "CogAtlasID": { "$ref": "common_definitions.json#/definitions/CogAtlasID" },
+    "CogPOID": { "$ref": "common_definitions.json#/definitions/CogPOID" },
+    "InstitutionName": { "$ref": "common_definitions.json#/definitions/InstitutionName" },
+    "InstitutionAddress": { "$ref": "common_definitions.json#/definitions/InstitutionAddress" }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
To keep in line with https://github.com/bids-standard/bids-specification/pull/804 to introduce some metadata for behavioral experiments this PR:
- creates a `beh.json` file
- makes sure it is used during validation

Question: none of the beh field is "required" so the json schema has no "required" key.