### PR TITLE
Migrate placeholder validation to hed-validator

### DIFF
--- a/bids-validator/package-lock.json
+++ b/bids-validator/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "1.7.3-dev.0",
+      "version": "1.8.1-dev.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.9.0",
@@ -15,7 +15,7 @@
         "cross-fetch": "^3.0.6",
         "date-fns": "^2.7.0",
         "esm": "^3.2.25",
-        "hed-validator": "^3.2.1",
+        "hed-validator": "^3.4.0",
         "ignore": "^4.0.2",
         "is-utf8": "^0.2.1",
         "jshint": "^2.9.6",
@@ -2395,9 +2395,9 @@
       }
     },
     "node_modules/hed-validator": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/hed-validator/-/hed-validator-3.2.1.tgz",
-      "integrity": "sha512-WNcDy42OUYFLACS+3urpgXn4ikLfMfopQXx2RDtEc5ZKaSPdmcvZuqXpGD6EbYMFoN55OSYsHLjFw1te8acidQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/hed-validator/-/hed-validator-3.4.0.tgz",
+      "integrity": "sha512-d5N//YgCwmvFWctSdHwD3AjSa54mvlIyUxQzsZOhN5lUIOdMao6gUIkEfn+JcuTMXiXcNrL2GS5i721k37YB4A==",
       "dependencies": {
         "date-and-time": "^0.14.2",
         "date-fns": "^2.17.0",
@@ -6269,9 +6269,9 @@
       "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
     },
     "hed-validator": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/hed-validator/-/hed-validator-3.2.1.tgz",
-      "integrity": "sha512-WNcDy42OUYFLACS+3urpgXn4ikLfMfopQXx2RDtEc5ZKaSPdmcvZuqXpGD6EbYMFoN55OSYsHLjFw1te8acidQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/hed-validator/-/hed-validator-3.4.0.tgz",
+      "integrity": "sha512-d5N//YgCwmvFWctSdHwD3AjSa54mvlIyUxQzsZOhN5lUIOdMao6gUIkEfn+JcuTMXiXcNrL2GS5i721k37YB4A==",
       "requires": {
         "date-and-time": "^0.14.2",
         "date-fns": "^2.17.0",

--- a/bids-validator/package.json
+++ b/bids-validator/package.json
@@ -27,7 +27,7 @@
     "cross-fetch": "^3.0.6",
     "date-fns": "^2.7.0",
     "esm": "^3.2.25",
-    "hed-validator": "^3.2.1",
+    "hed-validator": "^3.4.0",
     "ignore": "^4.0.2",
     "is-utf8": "^0.2.1",
     "jshint": "^2.9.6",

--- a/bids-validator/tests/events.spec.js
+++ b/bids-validator/tests/events.spec.js
@@ -795,6 +795,47 @@ describe('Events', function() {
       })
     })
 
+    it('should throw an issue if a sidecar HED categorical column has any number signs', () => {
+      const events = [
+        {
+          file: { path: '/sub01/sub01_task-test_events.tsv' },
+          path: '/sub01/sub01_task-test_events.tsv',
+          contents:
+            'onset\tduration\ttestingCodes\tmyValue\n' +
+            '7\tsomething\tfirst\t0.5\n',
+        },
+      ]
+      const jsonDictionary = {
+        '/sub01/sub01_task-test_events.json': {
+          testingCodes: {
+            HED: {
+              first:
+                'Event/Label/Test,Event/Category/Miscellaneous/Test,Event/Description/Test,Attribute/Visual/Color/Red/#',
+              second:
+                'Event/Label/Test,Event/Category/Miscellaneous/Test,Event/Description/Test,Attribute/Visual/Color/Blue/#',
+            },
+          },
+          myValue: {
+            HED: 'Attribute/Visual/Color/Green/#',
+          },
+        },
+        '/dataset_description.json': { HEDVersion: '7.1.1' },
+      }
+
+      return validate.Events.validateEvents(
+        events,
+        [],
+        headers,
+        jsonDictionary,
+        jsonFiles,
+        '',
+      ).then(issues => {
+        assert.strictEqual(issues.length, 2)
+        assert.strictEqual(issues[0].code, 104)
+        assert.strictEqual(issues[1].code, 104)
+      })
+    })
+
     it('should not throw an issue if the HED string is valid in a previous remote schema version', () => {
       const events = [
         {

--- a/bids-validator/tests/events.spec.js
+++ b/bids-validator/tests/events.spec.js
@@ -172,8 +172,9 @@ describe('Events', function() {
         jsonFiles,
         '',
       ).then(issues => {
-        assert.strictEqual(issues.length, 1)
+        assert.strictEqual(issues.length, 2)
         assert.strictEqual(issues[0].code, 104)
+        assert.strictEqual(issues[1].code, 104)
       })
     })
 
@@ -289,8 +290,9 @@ describe('Events', function() {
         jsonFiles,
         '',
       ).then(issues => {
-        assert.strictEqual(issues.length, 1)
+        assert.strictEqual(issues.length, 2)
         assert.strictEqual(issues[0].code, 104)
+        assert.strictEqual(issues[1].code, 104)
       })
     })
 
@@ -394,8 +396,9 @@ describe('Events', function() {
         jsonFiles,
         '',
       ).then(issues => {
-        assert.strictEqual(issues.length, 1)
+        assert.strictEqual(issues.length, 2)
         assert.strictEqual(issues[0].code, 104)
+        assert.strictEqual(issues[1].code, 104)
       })
     })
 
@@ -508,8 +511,9 @@ describe('Events', function() {
         jsonFiles,
         '',
       ).then(issues => {
-        assert.strictEqual(issues.length, 1)
+        assert.strictEqual(issues.length, 2)
         assert.strictEqual(issues[0].code, 104)
+        assert.strictEqual(issues[1].code, 104)
       })
     })
 
@@ -746,7 +750,7 @@ describe('Events', function() {
         '',
       ).then(issues => {
         assert.strictEqual(issues.length, 1)
-        assert.strictEqual(issues[0].code, 110)
+        assert.strictEqual(issues[0].code, 104)
       })
     })
 
@@ -785,8 +789,9 @@ describe('Events', function() {
         jsonFiles,
         '',
       ).then(issues => {
-        assert.strictEqual(issues.length, 1)
-        assert.strictEqual(issues[0].code, 110)
+        assert.strictEqual(issues.length, 2)
+        assert.strictEqual(issues[0].code, 104)
+        assert.strictEqual(issues[1].code, 104)
       })
     })
 

--- a/bids-validator/utils/issues/list.js
+++ b/bids-validator/utils/issues/list.js
@@ -610,12 +610,6 @@ export default {
     reason:
       "You should define 'HEDVersion' for this file. If you don't provide this information, the HED validation will use the latest version available.",
   },
-  110: {
-    key: 'HED_WRONG_NUMBER_OF_NUMBER_SIGNS',
-    severity: 'error',
-    reason:
-      'You must have exactly one number sign in a HED value-taking string template.',
-  },
   113: {
     key: 'NO_AUTHORS',
     severity: 'warning',

--- a/bids-validator/validators/events/hed.js
+++ b/bids-validator/validators/events/hed.js
@@ -132,14 +132,14 @@ function validateSidecars(
     if (!(sidecarName in sidecarIssueTypes)) {
       const sidecarDictionary = jsonContents[sidecarName]
       const sidecarHedValueStrings = []
-      let sidecarHedCategorialStrings = []
+      let sidecarHedCategoricalStrings = []
       for (const sidecarKey in sidecarDictionary) {
         const sidecarValue = sidecarDictionary[sidecarKey]
         if (sidecarValueHasHed(sidecarValue)) {
           if (typeof sidecarValue.HED === 'string') {
             sidecarHedValueStrings.push(sidecarValue.HED)
           } else {
-            sidecarHedCategorialStrings = sidecarHedCategorialStrings.concat(
+            sidecarHedCategoricalStrings = sidecarHedCategoricalStrings.concat(
               Object.values(sidecarValue.HED),
             )
           }
@@ -169,7 +169,7 @@ function validateSidecars(
           fileIssues = fileIssues.concat(convertedIssues)
         }
       }
-      for (const hedString of sidecarHedCategorialStrings) {
+      for (const hedString of sidecarHedCategoricalStrings) {
         try {
           ;[
             isHedStringValid,

--- a/bids-validator/validators/events/hed.js
+++ b/bids-validator/validators/events/hed.js
@@ -70,18 +70,16 @@ function parseHedVersion(jsonContents, dir) {
   const datasetDescription = jsonContents['/dataset_description.json']
   const issues = []
 
-  if (datasetDescription && datasetDescription.HEDVersion) {
-    if (semver.valid(datasetDescription.HEDVersion)) {
-      schemaDefinition.version = datasetDescription.HEDVersion
-    } else {
-      schemaDefinition.path = path.join(
-        path.resolve(dir),
-        'sourcedata',
-        datasetDescription.HEDVersion,
-      )
-    }
-  } else {
+  if (!(datasetDescription && datasetDescription.HEDVersion)) {
     issues.push(new Issue({ code: 109 }))
+  } else if (semver.valid(datasetDescription.HEDVersion)) {
+    schemaDefinition.version = datasetDescription.HEDVersion
+  } else {
+    schemaDefinition.path = path.join(
+      path.resolve(dir),
+      'sourcedata',
+      datasetDescription.HEDVersion,
+    )
   }
 
   return [schemaDefinition, issues]

--- a/bids-validator/validators/events/hed.js
+++ b/bids-validator/validators/events/hed.js
@@ -58,6 +58,7 @@ function detectHed(events, jsonContents) {
 function parseHedVersion(jsonContents, dir) {
   const schemaDefinition = {}
   const datasetDescription = jsonContents['/dataset_description.json']
+  const issues = []
 
   if (datasetDescription && datasetDescription.HEDVersion) {
     if (semver.valid(datasetDescription.HEDVersion)) {
@@ -69,10 +70,7 @@ function parseHedVersion(jsonContents, dir) {
         datasetDescription.HEDVersion,
       )
     }
-  }
-
-  const issues = []
-  if (Object.entries(schemaDefinition).length === 0) {
+  } else {
     issues.push(new Issue({ code: 109 }))
   }
 

--- a/bids-validator/validators/events/hed.js
+++ b/bids-validator/validators/events/hed.js
@@ -77,8 +77,13 @@ function parseHedVersion(jsonContents, dir) {
   return [schemaDefinition, issues]
 }
 
+let sidecarIssueTypes
+let sidecarFileIssues
+
 function extractHed(events, jsonContents, jsonFiles, hedSchema) {
   let issues = []
+  sidecarIssueTypes = {}
+  sidecarFileIssues = {}
   // loop through event data files
   events.forEach(eventFile => {
     let hedStrings = []
@@ -109,8 +114,6 @@ function extractHed(events, jsonContents, jsonFiles, hedSchema) {
   })
   return issues
 }
-
-const sidecarIssueTypes = {}
 
 function validateSidecars(
   potentialSidecars,
@@ -173,10 +176,15 @@ function validateSidecars(
         })
       ) {
         sidecarErrorsFound = true
+        sidecarIssueTypes[sidecarName] = 'error'
+      } else if (fileIssues.length > 0) {
+        sidecarIssueTypes[sidecarName] = 'warning'
       }
       issues = issues.concat(fileIssues)
+      sidecarFileIssues[sidecarName] = fileIssues
     } else if (sidecarIssueTypes[sidecarName] === 'error') {
       sidecarErrorsFound = true
+      issues = issues.concat(sidecarFileIssues[sidecarName])
     }
   }
   return [sidecarErrorsFound, issues]

--- a/bids-validator/validators/events/hed.js
+++ b/bids-validator/validators/events/hed.js
@@ -336,23 +336,14 @@ function internalHedValidatorIssue(error) {
 function convertHedIssuesToBidsIssues(hedIssues, file) {
   const convertedIssues = []
   for (const hedIssue of hedIssues) {
-    if (hedIssue.level === 'warning') {
-      convertedIssues.push(
-        new Issue({
-          code: 105,
-          file: file,
-          evidence: hedIssue.message,
-        }),
-      )
-    } else {
-      convertedIssues.push(
-        new Issue({
-          code: 104,
-          file: file,
-          evidence: hedIssue.message,
-        }),
-      )
-    }
+    const issueCode = hedIssue.level === 'warning' ? 105 : 104
+    convertedIssues.push(
+      new Issue({
+        code: issueCode,
+        file: file,
+        evidence: hedIssue.message,
+      }),
+    )
   }
 
   return convertedIssues


### PR DESCRIPTION
hed-validator supports proper value placeholder support as of version 3.4.0, which was released today. This PR deletes the remaining placeholder validation code left over in BIDS in favor of the more robust and correct hed-validator code, while splitting the categorical and value string-level validation loops to ensure that only value strings are allowed to have non-definition value placeholders.

Issue code 110, which deals with placeholder validation, has been deleted as redundant in favor of the generic HED error issue, as this problem is now reported by hed-validator instead of the BIDS code. This is the last major change in the HED-related BIDS issue codes that foresee at this time.