### PR TITLE
fix: Avoid missing arguments when bids-validator script is called directly

### DIFF
--- a/bids-validator/bin/bids-validator
+++ b/bids-validator/bin/bids-validator
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 try {
   const { default: cli } = require('bids-validator/cli')
-  cli().catch((code) => {
+  cli(process.argv.slice(2)).catch(code => {
     process.exit(code)
   })
 } catch (err) {


### PR DESCRIPTION
This was changed in bids-standard/legacy-validator#1294 to allow tests to call the options parser but it broke directly calling the script (`./bin/bids-validator`)