### PR TITLE
bids-specification schema validation for data types

### DIFF
--- a/bids-validator/package.json
+++ b/bids-validator/package.json
@@ -53,6 +53,7 @@
     "semver": "^7.3.2",
     "stream-browserify": "^3.0.0",
     "table": "^5.2.3",
+    "yaml": "^1.10.2",
     "yargs": "^16.2.0"
   },
   "devDependencies": {
@@ -82,6 +83,7 @@
     "stream": "stream-browserify"
   },
   "files": [
-    "dist/*"
+    "dist/*",
+    "schema/*"
   ]
 }

--- a/bids-validator/schema/README.md
+++ b/bids-validator/schema/README.md
@@ -1,0 +1,3 @@
+# BIDS-schema
+
+https://github.com/bids-standard/bids-specification/tree/v1.6.0/src/schema

--- a/bids-validator/schema/associated_data.yaml
+++ b/bids-validator/schema/associated_data.yaml
@@ -1,0 +1,9 @@
+---
+- code/:
+    - required: false
+- derivatives/:
+    - required: false
+- sourcedata/:
+    - required: false
+- stimuli/:
+    - required: false

--- a/bids-validator/schema/datatypes/anat.yaml
+++ b/bids-validator/schema/datatypes/anat.yaml
@@ -1,0 +1,174 @@
+---
+# Nonparametric
+- suffixes:
+    - T1w
+    - T2w
+    - PDw
+    - T2starw
+    - FLAIR
+    - inplaneT1
+    - inplaneT2
+    - PDT2
+    - angio
+    - T2star  # deprecated
+    - FLASH  # deprecated
+    - PD  # deprecated
+  extensions:
+    - .nii.gz
+    - .nii
+    - .json
+  entities:
+    subject: required
+    session: optional
+    run: optional
+    acquisition: optional
+    ceagent: optional
+    reconstruction: optional
+    part: optional
+# Parametric
+- suffixes:
+    - T1map
+    - T2map
+    - T2starmap
+    - R1map
+    - R2map
+    - R2starmap
+    - PDmap
+    - MTRmap
+    - MTsat
+    - UNIT1
+    - T1rho
+    - MWFmap
+    - MTVmap
+    - PDT2map
+    - Chimap
+    - S0map
+    - M0map
+  extensions:
+    - .nii.gz
+    - .nii
+    - .json
+  entities:
+    subject: required
+    session: optional
+    run: optional
+    acquisition: optional
+    ceagent: optional
+    reconstruction: optional
+# Defacemask
+- suffixes:
+    - defacemask
+  extensions:
+    - .nii.gz
+    - .nii
+    - .json
+  entities:
+    subject: required
+    session: optional
+    run: optional
+    acquisition: optional
+    ceagent: optional
+    reconstruction: optional
+    modality: optional
+# Multi-echo
+- suffixes:
+    - MESE
+    - MEGRE
+  extensions:
+    - .nii.gz
+    - .nii
+    - .json
+  entities:
+    subject: required
+    session: optional
+    run: optional
+    acquisition: optional
+    ceagent: optional
+    reconstruction: optional
+    echo: required
+    part: optional
+# Multi-flip
+- suffixes:
+    - VFA
+  extensions:
+    - .nii.gz
+    - .nii
+    - .json
+  entities:
+    subject: required
+    session: optional
+    run: optional
+    acquisition: optional
+    ceagent: optional
+    reconstruction: optional
+    flip: required
+    part: optional
+# Multi-inv
+- suffixes:
+    - IRT1
+  extensions:
+    - .nii.gz
+    - .nii
+    - .json
+  entities:
+    subject: required
+    session: optional
+    run: optional
+    acquisition: optional
+    ceagent: optional
+    reconstruction: optional
+    inversion: required
+    part: optional
+# MP2RAGE
+- suffixes:
+    - MP2RAGE
+  extensions:
+    - .nii.gz
+    - .nii
+    - .json
+  entities:
+    subject: required
+    session: optional
+    run: optional
+    acquisition: optional
+    ceagent: optional
+    reconstruction: optional
+    echo: optional
+    flip: optional
+    inversion: required
+    part: optional
+# VFA+MT
+- suffixes:
+    - MPM
+    - MTS
+  extensions:
+    - .nii.gz
+    - .nii
+    - .json
+  entities:
+    subject: required
+    session: optional
+    run: optional
+    acquisition: optional
+    ceagent: optional
+    reconstruction: optional
+    echo: optional
+    flip: required
+    mtransfer: required
+    part: optional
+# MTR
+- suffixes:
+    - MTR
+  extensions:
+    - .nii.gz
+    - .nii
+    - .json
+  entities:
+    subject: required
+    session: optional
+    run: optional
+    acquisition: optional
+    ceagent: optional
+    reconstruction: optional
+    mtransfer: required
+    part: optional

--- a/bids-validator/schema/datatypes/beh.yaml
+++ b/bids-validator/schema/datatypes/beh.yaml
@@ -1,0 +1,28 @@
+---
+# First group
+- suffixes:
+    - stim
+    - physio
+  extensions:
+    - .tsv.gz
+    - .json
+  entities:
+    subject: required
+    session: optional
+    task: required
+    acquisition: optional
+    run: optional
+    recording: optional
+# Second group
+- suffixes:
+    - events
+    - beh
+  extensions:
+    - .tsv
+    - .json
+  entities:
+    subject: required
+    session: optional
+    task: required
+    acquisition: optional
+    run: optional

--- a/bids-validator/schema/datatypes/dwi.yaml
+++ b/bids-validator/schema/datatypes/dwi.yaml
@@ -1,0 +1,31 @@
+---
+# DWI
+- suffixes:
+    - dwi
+  extensions:
+    - .nii.gz
+    - .nii
+    - .json
+    - .bvec
+    - .bval
+  entities:
+    subject: required
+    session: optional
+    acquisition: optional
+    direction: optional
+    run: optional
+    part: optional
+# Single-band reference images
+- suffixes:
+    - sbref
+  extensions:
+    - .nii.gz
+    - .nii
+    - .json
+  entities:
+    subject: required
+    session: optional
+    acquisition: optional
+    direction: optional
+    run: optional
+    part: optional

--- a/bids-validator/schema/datatypes/eeg.yaml
+++ b/bids-validator/schema/datatypes/eeg.yaml
@@ -1,0 +1,67 @@
+---
+- suffixes:
+    - eeg
+  extensions:
+    - .json
+    - .edf
+    - .vhdr
+    - .vmrk
+    - .eeg
+    - .set
+    - .fdt
+    - .bdf
+  entities:
+    subject: required
+    session: optional
+    task: required
+    acquisition: optional
+    run: optional
+- suffixes:
+    - channels
+  extensions:
+    - .json
+    - .tsv
+  entities:
+    subject: required
+    session: optional
+    task: required
+    acquisition: optional
+    run: optional
+- suffixes:
+    - coordsystem
+  extensions:
+    - .json
+  entities:
+    subject: required
+    session: optional
+    acquisition: optional
+    space: optional
+- suffixes:
+    - electrodes
+  extensions:
+    - .json
+    - .tsv
+  entities:
+    subject: required
+    session: optional
+    acquisition: optional
+    space: optional
+- suffixes:
+    - events
+  extensions:
+    - .json
+    - .tsv
+  entities:
+    subject: required
+    session: optional
+    task: required
+    acquisition: optional
+    run: optional
+- suffixes:
+    - photo
+  extensions:
+    - .jpg
+  entities:
+    subject: required
+    session: optional
+    acquisition: optional

--- a/bids-validator/schema/datatypes/fmap.yaml
+++ b/bids-validator/schema/datatypes/fmap.yaml
@@ -1,0 +1,123 @@
+---
+# Fieldmaps
+- suffixes:
+    - phasediff
+    - phase1
+    - phase2
+    - magnitude1
+    - magnitude2
+    - magnitude
+    - fieldmap
+  extensions:
+    - .nii.gz
+    - .nii
+    - .json
+  entities:
+    subject: required
+    session: optional
+    acquisition: optional
+    run: optional
+# PEPolar
+- suffixes:
+    - epi
+    - m0scan
+  extensions:
+    - .nii.gz
+    - .nii
+    - .json
+  entities:
+    subject: required
+    session: optional
+    acquisition: optional
+    ceagent: optional
+    direction: required
+    run: optional
+# TB1DAM
+- suffixes:
+    - TB1DAM
+  extensions:
+    - .nii.gz
+    - .nii
+    - .json
+  entities:
+    subject: required
+    session: optional
+    run: optional
+    acquisition: optional
+    ceagent: optional
+    reconstruction: optional
+    flip: required
+    inversion: optional
+    part: optional
+# TB1EPI
+- suffixes:
+    - TB1EPI
+  extensions:
+    - .nii.gz
+    - .nii
+    - .json
+  entities:
+    subject: required
+    session: optional
+    run: optional
+    acquisition: optional
+    ceagent: optional
+    reconstruction: optional
+    echo: required
+    flip: required
+    inversion: optional
+    part: optional
+# RFFieldMaps
+- suffixes:
+    - TB1AFI
+    - TB1TFL
+    - TB1RFM
+    - RB1COR
+  extensions:
+    - .nii.gz
+    - .nii
+    - .json
+  entities:
+    subject: required
+    session: optional
+    run: optional
+    acquisition: optional
+    ceagent: optional
+    reconstruction: optional
+    echo: optional
+    flip: optional
+    inversion: optional
+    part: optional
+# TB1SRGE
+- suffixes:
+    - TB1SRGE
+  extensions:
+    - .nii.gz
+    - .nii
+    - .json
+  entities:
+    subject: required
+    session: optional
+    run: optional
+    acquisition: optional
+    ceagent: optional
+    reconstruction: optional
+    echo: optional
+    flip: required
+    inversion: required
+    part: optional
+# Parametric
+- suffixes:
+    - TB1map
+    - RB1map
+  extensions:
+    - .nii.gz
+    - .nii
+    - .json
+  entities:
+    subject: required
+    session: optional
+    run: optional
+    acquisition: optional
+    ceagent: optional
+    reconstruction: optional

--- a/bids-validator/schema/datatypes/func.yaml
+++ b/bids-validator/schema/datatypes/func.yaml
@@ -1,0 +1,70 @@
+---
+# Func
+- suffixes:
+    - bold
+    - cbv
+    - sbref
+  extensions:
+    - .nii.gz
+    - .nii
+    - .json
+  entities:
+    subject: required
+    session: optional
+    task: required
+    acquisition: optional
+    ceagent: optional
+    reconstruction: optional
+    direction: optional
+    run: optional
+    echo: optional
+    part: optional
+# Phase (deprecated)
+- suffixes:
+    - phase  # deprecated
+  extensions:
+    - .nii.gz
+    - .nii
+    - .json
+  entities:
+    subject: required
+    session: optional
+    task: required
+    acquisition: optional
+    ceagent: optional
+    reconstruction: optional
+    direction: optional
+    run: optional
+    echo: optional
+# Events
+- suffixes:
+    - events
+  extensions:
+    - .tsv
+    - .json
+  entities:
+    subject: required
+    session: optional
+    task: required
+    acquisition: optional
+    ceagent: optional
+    reconstruction: optional
+    direction: optional
+    run: optional
+# Timeseries
+- suffixes:
+    - physio
+    - stim
+  extensions:
+    - .tsv.gz
+    - .json
+  entities:
+    subject: required
+    session: optional
+    task: required
+    acquisition: optional
+    ceagent: optional
+    reconstruction: optional
+    direction: optional
+    run: optional
+    recording: optional

--- a/bids-validator/schema/datatypes/ieeg.yaml
+++ b/bids-validator/schema/datatypes/ieeg.yaml
@@ -1,0 +1,68 @@
+---
+- suffixes:
+    - ieeg
+  extensions:
+    - .mefd/
+    - .json
+    - .edf
+    - .vhdr
+    - .eeg
+    - .vmrk
+    - .set
+    - .fdt
+    - .nwb
+  entities:
+    subject: required
+    session: optional
+    task: required
+    acquisition: optional
+    run: optional
+- suffixes:
+    - channels
+  extensions:
+    - .json
+    - .tsv
+  entities:
+    subject: required
+    session: optional
+    task: required
+    acquisition: optional
+    run: optional
+- suffixes:
+    - coordsystem
+  extensions:
+    - .json
+  entities:
+    subject: required
+    session: optional
+    acquisition: optional
+    space: optional
+- suffixes:
+    - electrodes
+  extensions:
+    - .json
+    - .tsv
+  entities:
+    subject: required
+    session: optional
+    acquisition: optional
+    space: optional
+- suffixes:
+    - events
+  extensions:
+    - .json
+    - .tsv
+  entities:
+    subject: required
+    session: optional
+    task: required
+    acquisition: optional
+    run: optional
+- suffixes:
+    - photo
+  extensions:
+    - .jpg
+  entities:
+    subject: required
+    session: optional
+    acquisition: optional

--- a/bids-validator/schema/datatypes/meg.yaml
+++ b/bids-validator/schema/datatypes/meg.yaml
@@ -1,0 +1,85 @@
+---
+# First group
+- suffixes:
+    - meg
+  extensions:
+    - /  # corresponds to BTi/4D data
+    - .ds/
+    - .json
+    - .fif
+    - .sqd
+    - .con
+    - .raw
+    - .ave
+    - .mrk
+    - .kdf
+    - .mhd
+  entities:
+    subject: required
+    session: optional
+    task: required
+    acquisition: optional
+    run: optional
+    processing: optional
+    split: optional
+# Second group
+- suffixes:
+    - headshape
+  extensions:
+    - "*"
+  entities:
+    subject: required
+    session: optional
+    acquisition: optional
+# Third group
+- suffixes:
+    - markers
+  extensions:
+    - .sqd
+    - .mrk
+  entities:
+    subject: required
+    session: optional
+    task: optional
+    acquisition: optional
+    space: optional
+# Fourth
+- suffixes:
+    - coordsystem
+  extensions:
+    - .json
+  entities:
+    subject: required
+    session: optional
+    acquisition: optional
+- suffixes:
+    - channels
+  extensions:
+    - .json
+    - .tsv
+  entities:
+    subject: required
+    session: optional
+    task: required
+    acquisition: optional
+    run: optional
+    processing: optional
+- suffixes:
+    - events
+  extensions:
+    - .json
+    - .tsv
+  entities:
+    subject: required
+    session: optional
+    task: required
+    acquisition: optional
+    run: optional
+- suffixes:
+    - photo
+  extensions:
+    - .jpg
+  entities:
+    subject: required
+    session: optional
+    acquisition: optional

--- a/bids-validator/schema/datatypes/perf.yaml
+++ b/bids-validator/schema/datatypes/perf.yaml
@@ -1,0 +1,40 @@
+---
+# First group
+- suffixes:
+    - asl
+    - m0scan
+  extensions:
+    - .nii.gz
+    - .nii
+    - .json
+  entities:
+    subject: required
+    session: optional
+    acquisition: optional
+    reconstruction: optional
+    direction: optional
+    run: optional
+# Second group
+- suffixes:
+    - aslcontext
+  extensions:
+    - .tsv
+    - .json
+  entities:
+    subject: required
+    session: optional
+    acquisition: optional
+    reconstruction: optional
+    direction: optional
+    run: optional
+# Third group
+- suffixes:
+    - asllabeling
+  extensions:
+    - .jpg
+  entities:
+    subject: required
+    session: optional
+    acquisition: optional
+    reconstruction: optional
+    run: optional

--- a/bids-validator/schema/datatypes/pet.yaml
+++ b/bids-validator/schema/datatypes/pet.yaml
@@ -1,0 +1,42 @@
+---
+# PET recordings
+- suffixes:
+    - pet
+  extensions:
+    - .nii.gz
+    - .nii
+    - .json
+  entities:
+    subject: required
+    session: optional
+    task: optional
+    tracer: optional
+    reconstruction: optional
+    run: optional
+# Blood recordings
+- suffixes:
+    - blood
+  extensions:
+    - .tsv
+    - .json
+  entities:
+    subject: required
+    session: optional
+    task: optional
+    tracer: optional
+    reconstruction: optional
+    run: optional
+    recording: required
+# Events
+- suffixes:
+    - events
+  extensions:
+    - .tsv
+    - .json
+  entities:
+    subject: required
+    session: optional
+    task: required
+    tracer: optional
+    reconstruction: optional
+    run: optional

--- a/bids-validator/schema/entities.yaml
+++ b/bids-validator/schema/entities.yaml
@@ -1,0 +1,277 @@
+---
+subject:
+  name: Subject
+  entity: sub
+  description: |
+    A person or animal participating in the study.
+  format: label
+session:
+  name: Session
+  entity: ses
+  description: |
+    A logical grouping of neuroimaging and behavioral data consistent across
+    subjects.
+    Session can (but doesn't have to) be synonymous to a visit in a
+    longitudinal study.
+    In general, subjects will stay in the scanner during one session.
+    However, for example, if a subject has to leave the scanner room and then
+    be re-positioned on the scanner bed, the set of MRI acquisitions will still
+    be considered as a session and match sessions acquired in other subjects.
+    Similarly, in situations where different data types are obtained over
+    several visits (for example fMRI on one day followed by DWI the day after)
+    those can be grouped in one session.
+    Defining multiple sessions is appropriate when several identical or similar
+    data acquisitions are planned and performed on all -or most- subjects,
+    often in the case of some intervention between sessions
+    (for example, training).
+  format: label
+task:
+  name: Task
+  entity: task
+  format: label
+  description: |
+    Each task has a unique label that MUST only consist of letters and/or
+    numbers (other characters, including spaces and underscores, are not
+    allowed).
+    Those labels MUST be consistent across subjects and sessions.
+acquisition:
+  name: Acquisition
+  entity: acq
+  description: |
+    The `acq-<label>` key/value pair corresponds to a custom label the
+    user MAY use to distinguish a different set of parameters used for
+    acquiring the same modality.
+    For example this should be used when a study includes two T1w images - one
+    full brain low resolution and and one restricted field of view but high
+    resolution.
+    In such case two files could have the following names:
+    `sub-01_acq-highres_T1w.nii.gz` and `sub-01_acq-lowres_T1w.nii.gz`, however
+    the user is free to choose any other label than highres and lowres as long
+    as they are consistent across subjects and sessions.
+    In case different sequences are used to record the same modality
+    (for example, RARE and FLASH for T1w)
+    this field can also be used to make that distinction.
+    At what level of detail to make the distinction (for example,
+    just between RARE and FLASH, or between RARE, FLASH, and FLASHsubsampled)
+    remains at the discretion of the researcher.
+  format: label
+ceagent:
+  name: Contrast Enhancing Agent
+  entity: ce
+  description: |
+    The `ce-<label>` key/value can be used to distinguish
+    sequences using different contrast enhanced images.
+    The label is the name of the contrast agent.
+    The key `ContrastBolusIngredient` MAY also be added in the JSON file,
+    with the same label.
+  format: label
+tracer:
+  name: Tracer
+  entity: trc
+  description: |
+    The `trc-<label>` key/value can be used to distinguish
+    sequences using different tracers.
+    The key `TracerName` MUST also be included in the associated JSON file,
+    although the label may be different.
+  format: label
+reconstruction:
+  name: Reconstruction
+  entity: rec
+  description: |
+    The `rec-<label>` key/value can be used to distinguish
+    different reconstruction algorithms (for example ones using motion
+    correction).
+  format: label
+direction:
+  name: Phase-Encoding Direction
+  entity: dir
+  description: |
+    The `dir-<label>` key/value can be set to an arbitrary alphanumeric label
+    (for example, `dir-LR` or `dir-AP`) to distinguish different phase-encoding
+    directions.
+  format: label
+run:
+  name: Run
+  entity: run
+  description: |
+    If several scans with the same acquisition parameters are acquired in the same session,
+    they MUST be indexed with the [`run-<index>`](../99-appendices/09-entities.md#run) entity:
+    `_run-1`, `_run-2`, `_run-3`, and so on (only nonnegative integers are allowed as
+    run labels).
+
+    If different entities apply,
+    such as a different session indicated by [`ses-<label>`](../99-appendices/09-entities.md#ses),
+    or different acquisition parameters indicated by
+    [`acq-<label>`](../99-appendices/09-entities.md#acq),
+    then `run` is not needed to distinguish the scans and MAY be omitted.
+  format: index
+modality:
+  name: Corresponding Modality
+  entity: mod
+  description: |
+    The `mod-<label>` key/value pair corresponds to modality label for defacing
+    masks, for example, T1w, inplaneT1, referenced by a defacemask image.
+    For example, `sub-01_mod-T1w_defacemask.nii.gz`.
+  format: label
+echo:
+  name: Echo
+  entity: echo
+  description: |
+    If files belonging to an entity-linked file collection are acquired at different
+    echo times, the `_echo-<index>` key/value pair MUST be used to distinguish
+    individual files.
+    This entity represents the `EchoTime` metadata field. Please note that the `<index>`
+    denotes the number/index (in the form of a nonnegative integer), not the
+    `EchoTime` value which needs to be stored in the field `EchoTime` of the separate
+    JSON file.
+  format: index
+flip:
+  name: Flip Angle
+  entity: flip
+  description: |
+    If files belonging to an entity-linked file collection are acquired at different
+    flip angles, the `_flip-<index>` key/value pair MUST be used to distinguish
+    individual files.
+    This entity represents the `FlipAngle` metadata field. Please note that the `<index>`
+    denotes the number/index (in the form of a nonnegative integer), not the `FlipAngle`
+    value which needs to be stored in the field `FlipAngle` of the separate JSON file.
+  format: index
+inversion:
+  name: Inversion Time
+  entity: inv
+  description: |
+    If files belonging to an entity-linked file collection are acquired at different
+    inversion times, the `_inv-<index>` key/value pair MUST be used to distinguish
+    individual files.
+    This entity represents the `InversionTime` metadata field. Please note that the `<index>`
+    denotes the number/index (in the form of a nonnegative integer), not the `InversionTime`
+    value which needs to be stored in the field `InversionTime` of the separate JSON file.
+  format: index
+mtransfer:
+  name: Magnetization Transfer
+  entity: mt
+  description: |
+    If files belonging to an entity-linked file collection are acquired at different
+    magnetization transfer (MT) states, the `_mt-<label>` key/value pair MUST be used to
+    distinguish individual files.
+    This entity represents the `MTState` metadata field. Allowed label values for this
+    entity are `on` and `off`, for images acquired in presence and absence of an MT pulse,
+    respectively.
+  format: label
+part:
+  name: Part
+  entity: part
+  description: |
+    This entity is used to indicate which component of the complex
+    representation of the MRI signal is represented in voxel data.
+    The `part-<label>` key/value pair is associated with the DICOM tag
+    `0008,9208`.
+    Allowed label values for this entity are `phase`, `mag`, `real` and `imag`,
+    which are typically used in `part-mag`/`part-phase` or
+    `part-real`/`part-imag` pairs of files.
+
+    Phase images MAY be in radians or in arbitrary units.
+    The sidecar JSON file MUST include the units of the `phase` image.
+    The possible options are `rad` or `arbitrary`.
+
+    When there is only a magnitude image of a given type, the `part` key MAY be
+    omitted.
+  format: label
+recording:
+  name: Recording
+  entity: recording
+  description: |
+    More than one continuous recording file can be included (with different
+    sampling frequencies).
+    In such case use different labels.
+    For example: `_recording-contrast`, `_recording-saturation`.
+  format: label
+processing:
+  name: Processed (on device)
+  entity: proc
+  description: |
+    The proc label is analogous to rec for MR and denotes a variant of a file
+    that was a result of particular processing performed on the device.
+    This is useful for files produced in particular by Elekta’s MaxFilter
+    (for example, sss, tsss, trans, quat or mc),
+    which some installations impose to be run on raw data because of active
+    shielding software corrections before the MEG data can actually be
+    exploited.
+  format: label
+space:
+  name: Space
+  entity: space
+  description: |
+    The space entity can be used to indicate
+    the way in which electrode positions are interpreted
+    (for EEG/MEG/iEEG data) or
+    the spatial reference to which a file has been aligned (for MRI data).
+    The space `<label>` MUST be taken from one of the modality specific lists in
+    [Appendix VIII](../99-appendices/08-coordinate-systems.md).
+    For example for iEEG data, the restricted keywords listed under
+    [iEEG Specific Coordinate Systems](../99-appendices/08-coordinate-systems.md#ieeg-specific-coordinate-systems)
+    are acceptable for `<label>`.
+
+    For EEG/MEG/iEEG data, this entity can be applied to raw data, but
+    for other data types, it is restricted to derivative data.
+  format: label
+split:
+  name: Split
+  entity: split
+  description: |
+    In the case of long data recordings that exceed a file size of 2Gb, the
+    .fif files are conventionally split into multiple parts.
+    Each of these files has an internal pointer to the next file.
+    This is important when renaming these split recordings to the BIDS
+    convention.
+
+    Instead of a simple renaming, files should be read in and saved under their
+    new names with dedicated tools like [MNE-Python](https://mne.tools/),
+    which will ensure that not only the file names, but also the internal file
+    pointers will be updated.
+    It is RECOMMENDED that .fif files with multiple parts use the
+    `split-<index>` entity to indicate each part.
+    If there are multiple parts of a recording and the optional `scans.tsv` is provided,
+    remember to list all files separately in `scans.tsv` and that the entries for the
+    `acq_time` column in `scans.tsv` MUST all be identical, as described in
+    [Scans file](../03-modality-agnostic-files.md#scans-file).
+  format: index
+resolution:
+  name: Resolution
+  entity: res
+  description: |
+    Resolution of regularly sampled N-dimensional data.
+    MUST have a corresponding `Resolution` metadata field to provide
+    interpretation.
+
+    This entity is only applicable to derivative data.
+  format: label
+density:
+  name: Density
+  entity: den
+  description: |
+    Density of non-parametric surfaces.
+    MUST have a corresponding `Density` metadata field to provide
+    interpretation.
+
+    This entity is only applicable to derivative data.
+  format: label
+label:
+  name: Label
+  entity: label
+  description: |
+    Tissue-type label, following a prescribed vocabulary.
+    Applies to binary masks and probabilistic/partial volume segmentations
+    that describe a single tissue type.
+
+    This entity is only applicable to derivative data.
+  format: label
+description:
+  name: Description
+  entity: desc
+  description: |
+    When necessary to distinguish two files that do not otherwise have a
+    distinguishing entity, the `_desc-<label>` keyword-value SHOULD be used.
+
+    This entity is only applicable to derivative data.
+  format: label

--- a/bids-validator/schema/modalities.yaml
+++ b/bids-validator/schema/modalities.yaml
@@ -1,0 +1,29 @@
+---
+mri:
+  name: Magnetic Resonance Imaging
+  datatypes:
+    - anat
+    - dwi
+    - fmap
+    - func
+    - perf
+eeg:
+  name: Electroencephalography
+  datatypes:
+    - eeg
+ieeg:
+  name: Intracranial Electroencephalography
+  datatypes:
+    - ieeg
+meg:
+  name: Magnetoencephalography
+  datatypes:
+    - meg
+beh:
+  name: Behavioral experiments
+  datatypes:
+    - beh
+pet:
+  name: Positron Emission Tomography
+  datatypes:
+    - pet

--- a/bids-validator/schema/top_level_files.yaml
+++ b/bids-validator/schema/top_level_files.yaml
@@ -1,0 +1,26 @@
+---
+README:
+  required: true
+  extensions:
+    - None
+CHANGES:
+  required: true
+  extensions:
+    - None
+LICENSE:
+  required: false
+  extensions:
+    - None
+dataset_description:
+  required: true
+  extensions:
+    - .json
+genetic_info:
+  required: false
+  extensions:
+    - .json
+participants:
+  required: false
+  extensions:
+    - .tsv
+    - .json

--- a/bids-validator/src/options.js
+++ b/bids-validator/src/options.js
@@ -60,6 +60,13 @@ export function parseOptions(argumentOverride) {
       'A less accurate check that reads filenames one per line from stdin.',
     )
     .hide('filenames')
+    .option('schema', {
+      alias: 's',
+      describe:
+        'BIDS specification schema version to use for validation, e.g. "v1.6.0" (beta)',
+      default: 'disable',
+      choices: ['disable', 'v1.6.0', 'master'],
+    })
     .epilogue(
       'This tool checks if a dataset in a given directory is \
 compatible with the Brain Imaging Data Structure specification. To learn \

--- a/bids-validator/src/schemaTypes.js
+++ b/bids-validator/src/schemaTypes.js
@@ -1,0 +1,155 @@
+import yaml from 'js-yaml'
+import isNode from '../utils/isNode'
+
+// Version implemented by the internal rules or the included schema version
+const localVersion = 'v1.6.0'
+
+const modalities = [
+  'anat',
+  'beh',
+  'dwi',
+  'eeg',
+  'fmap',
+  'func',
+  'ieeg',
+  'meg',
+  'pet',
+]
+
+async function loadYaml(base, path, local) {
+  const url = `${base}/${path}`
+  try {
+    let text // Loaded raw yaml
+    if (local) {
+      throw Error('Defaulting to embedded bids-specification schema')
+    } else {
+      const res = await fetch(url)
+      if (res.status !== 200) {
+        throw Error(
+          `Loading remote bids-specification schema failed, falling back to embedded bids-specification@${localVersion}`,
+        )
+      }
+      text = await res.text()
+    }
+    return yaml.safeLoad(text)
+  } catch (err) {
+    if (isNode) {
+      const fs = require('fs')
+      const text = fs.readFileSync(url, 'utf-8')
+      return yaml.safeLoad(text)
+    } else {
+      // TODO - handle the case where no yaml is available in the browser
+      throw Error(
+        `Loading remote bids-specification schema failed, and internal validation rules will be used instead`,
+      )
+    }
+  }
+}
+
+/**
+ * Load schema files from network or embedded copies
+ * @param {string} base Base URL or path
+ * @param {boolean} local Avoid any network access
+ */
+async function loadSchema(base, local = false) {
+  const top = 'top_level_files.yaml'
+  const entities = 'entities.yaml'
+  return {
+    top_level_files: await loadYaml(base, top, local),
+    entities: await loadYaml(base, entities, local),
+    datatypes: {
+      anat: await loadYaml(base, `datatypes/anat.yaml`, local),
+      beh: await loadYaml(base, `datatypes/beh.yaml`, local),
+      dwi: await loadYaml(base, `datatypes/dwi.yaml`, local),
+      eeg: await loadYaml(base, `datatypes/eeg.yaml`, local),
+      fmap: await loadYaml(base, `datatypes/fmap.yaml`, local),
+      func: await loadYaml(base, `datatypes/func.yaml`, local),
+      ieeg: await loadYaml(base, 'datatypes/ieeg.yaml', local),
+      meg: await loadYaml(base, 'datatypes/meg.yaml', local),
+      pet: await loadYaml(base, 'datatypes/pet.yaml', local),
+    },
+  }
+}
+
+/**
+ * Generate matching regular expressions based on the most recent bids-specification schema
+ * @param {*} schema Loaded yaml schemas (js-yaml)
+ * @param {boolean} pythonRegex Boolean flag to enable/disable Python compatible regex generation
+ * @returns
+ */
+export async function generateRegex(schema, pythonRegex = false) {
+  // Python regex needs a 'P' before matching group name
+  const P = pythonRegex ? 'P' : ''
+  const regex = {
+    label: '[a-zA-Z0-9]+',
+    index: '[0-9]+',
+    sub_ses_dirs:
+      '^[\\/\\\\](sub-[a-zA-Z0-9]+)[\\/\\\\](?:(ses-[a-zA-Z0-9]+)[\\/\\\\])?',
+    type_dir: '[\\/\\\\]',
+    sub_ses_entity: '\\1(_\\2)?',
+    optional: '?',
+    required: '',
+  }
+
+  const exportRegex = {
+    top_level_files: '',
+    datatypes: {
+      anat: [],
+      beh: [],
+      dwi: [],
+      eeg: [],
+      fmap: [],
+      func: [],
+      ieeg: [],
+      meg: [],
+      pet: [],
+    },
+  }
+
+  for (const mod of modalities) {
+    const modality_datatype_schema = schema.datatypes[mod]
+    for (const datatype of modality_datatype_schema) {
+      let file_regex = `${regex.sub_ses_dirs}${mod}${regex.type_dir}${regex.sub_ses_entity}`
+      for (const entity of Object.keys(datatype.entities)) {
+        // sub and ses entities in file name handled by directory pattern matching groups
+        if (
+          entity === 'sub' ||
+          entity === 'ses' ||
+          entity === 'subject' ||
+          entity === 'session'
+        ) {
+          continue
+        }
+        const format = regex[schema.entities[entity].format]
+        if (format) {
+          // Limitation here is that if format is missing an essential entity may be skipped
+          file_regex += `(?${P}<${entity}>_${entity}-${format})${
+            regex[datatype.entities[entity]]
+          }`
+        }
+      }
+      const suffix_regex = `_(?${P}<suffix>${datatype.suffixes.join('|')})`
+      // Workaround v1.6.0 MEG extension "*"
+      const wildcard_extensions = datatype.extensions.map(ext =>
+        ext === '*' ? '.*?' : ext,
+      )
+      const ext_regex = `(?${P}<ext>${wildcard_extensions.join('|')})`
+      exportRegex.datatypes[mod].push(
+        new RegExp(file_regex + suffix_regex + ext_regex + '$'),
+      )
+    }
+  }
+  return exportRegex
+}
+
+export async function schemaRegex(version = localVersion, options = {}) {
+  let schema
+  if ('local' in options) {
+    schema = await loadSchema('./bids-validator/schema', true)
+  } else {
+    schema = await loadSchema(
+      `https://raw.githubusercontent.com/bids-standard/bids-specification/${version}/src/schema`,
+    )
+  }
+  return generateRegex(schema)
+}

--- a/bids-validator/src/schemaTypes.js
+++ b/bids-validator/src/schemaTypes.js
@@ -110,22 +110,21 @@ export async function generateRegex(schema, pythonRegex = false) {
     const modality_datatype_schema = schema.datatypes[mod]
     for (const datatype of modality_datatype_schema) {
       let file_regex = `${regex.sub_ses_dirs}${mod}${regex.type_dir}${regex.sub_ses_entity}`
-      for (const entity of Object.keys(datatype.entities)) {
-        // sub and ses entities in file name handled by directory pattern matching groups
-        if (
-          entity === 'sub' ||
-          entity === 'ses' ||
-          entity === 'subject' ||
-          entity === 'session'
-        ) {
-          continue
-        }
-        const format = regex[schema.entities[entity].format]
-        if (format) {
-          // Limitation here is that if format is missing an essential entity may be skipped
-          file_regex += `(?${P}<${entity}>_${entity}-${format})${
-            regex[datatype.entities[entity]]
-          }`
+      for (const entity of Object.keys(schema.entities)) {
+        const entityDefinion = schema.entities[entity]
+        if (entity in datatype.entities) {
+          // sub and ses entities in file name handled by directory pattern matching groups
+          if (entity === 'subject' || entity === 'session') {
+            continue
+          }
+          const entityKey = entityDefinion.entity
+          const format = regex[schema.entities[entity].format]
+          if (format) {
+            // Limitation here is that if format is missing an essential entity may be skipped
+            file_regex += `(?${P}<${entity}>_${entityKey}-${format})${
+              regex[datatype.entities[entity]]
+            }`
+          }
         }
       }
       const suffix_regex = `_(?${P}<suffix>${datatype.suffixes.join('|')})`

--- a/bids-validator/src/schemaTypes.js
+++ b/bids-validator/src/schemaTypes.js
@@ -92,7 +92,7 @@ export async function generateRegex(schema, pythonRegex = false) {
   }
 
   const exportRegex = {
-    top_level_files: '',
+    top_level_files: [],
     datatypes: {
       anat: [],
       beh: [],
@@ -104,6 +104,15 @@ export async function generateRegex(schema, pythonRegex = false) {
       meg: [],
       pet: [],
     },
+  }
+
+  // Modality agnostic top level files
+  for (const root of Object.keys(schema.top_level_files)) {
+    const extensions = schema.top_level_files[root].extensions.join('|')
+    const root_level = `[\\/\\\\]${root}${
+      extensions === 'None' ? '' : `(?${P}<suffix>${extensions})`
+    }$`
+    exportRegex.top_level_files.push(new RegExp(root_level))
   }
 
   for (const mod of modalities) {

--- a/bids-validator/utils/__tests__/type.spec.js
+++ b/bids-validator/utils/__tests__/type.spec.js
@@ -57,15 +57,45 @@ describe('type.js', () => {
           ),
         ).toBe(true)
       })
-
-      it('does not throw an error for recording entity in physio data', () => {
+      it('allows a func example', () => {
+        expect(
+          type.isBIDS('/sub-10159/func/sub-10159_task-bart_bold.nii.gz'),
+        ).toBe(true)
+        expect(type.isBIDS('/sub-10159/sub-10159_bold_task-bart.nii.gz')).toBe(
+          false,
+        )
+      })
+      it('allows an eeg example', () => {
         expect(
           type.isBIDS(
-            '/sub-05/eeg/sub-05_task-matchingpennies_recording-eyetracking_physio.tsv.gz',
+            '/sub-014/ses-t1/eeg/sub-014_ses-t1_task-resteyesc_eeg.edf',
           ),
         ).toBe(true)
       })
-
+      it('allows an ieeg example', () => {
+        expect(
+          type.isBIDS(
+            '/sub-31/ses-iemu/ieeg/sub-31_ses-iemu_task-film_acq-clinical_run-1_ieeg.eeg',
+          ),
+        ).toBe(true)
+      })
+      it('allows an meg example', () => {
+        expect(
+          type.isBIDS(
+            '/sub-015/ses-01/meg/sub-015_ses-01_task-AversiveLearningReplay_run-02_meg.fif',
+          ),
+        ).toBe(true)
+        expect(
+          type.isBIDS(
+            '/sub-015/ses-01/meg/sub-015_ses-01_run-02_task-AversiveLearningReplay_meg.fif',
+          ),
+        ).toBe(false)
+      })
+      it('allows expected top level files', () => {
+        expect(type.isBIDS('/README')).toBe(true)
+        expect(type.isBIDS('/dataset_description.json')).toBe(true)
+        expect(type.isBIDS('/not-bids.json')).toBe(false)
+      })
       it('does not throw an error for recording entity in physio data at root of the dataset', () => {
         expect(
           type.isBIDS(

--- a/bids-validator/utils/__tests__/type.spec.js
+++ b/bids-validator/utils/__tests__/type.spec.js
@@ -1,4 +1,5 @@
-import type from '../type.js'
+import { schemaRegex } from '../../src/schemaTypes.js'
+import type, { schemaSetup } from '../type.js'
 
 describe('type.js', () => {
   describe('isBids()', () => {
@@ -20,9 +21,7 @@ describe('type.js', () => {
 
     it('does not throw an error for recording entity in physio data at root of the dataset', () => {
       expect(
-        type.isBIDS(
-          '/task-matchingpennies_recording-eyetracking_physio.json',
-        ),
+        type.isBIDS('/task-matchingpennies_recording-eyetracking_physio.json'),
       ).toBe(true)
     })
 
@@ -32,6 +31,45 @@ describe('type.js', () => {
         expect(
           type.isBIDS(
             `/sub-05/${mod}/sub-05_task-matchingpennies_recording-eyetracking_physio.tsv.gz`,
+          ),
+        ).toBe(true)
+      })
+    })
+  })
+  describe('schema mode tests', () => {
+    beforeAll(async () => {
+      const schema = await schemaRegex('v1.6.0', { local: true })
+      schemaSetup(schema)
+    })
+    afterAll(() => {
+      schemaSetup()
+    })
+    describe('isAnat()', () => {
+      it('does not throw an error when matching basic anat data files', () => {
+        expect(type.file.isAnat('/sub-01/anat/sub-01_T1w.nii.gz')).toBe(true)
+      })
+    })
+    describe('isBIDS()', () => {
+      it('does not throw an error for valid defacemask filenames', () => {
+        expect(
+          type.isBIDS(
+            '/sub-rid000043/anat/sub-rid000043_run-02_mod-T1w_defacemask.nii.gz',
+          ),
+        ).toBe(true)
+      })
+
+      it('does not throw an error for recording entity in physio data', () => {
+        expect(
+          type.isBIDS(
+            '/sub-05/eeg/sub-05_task-matchingpennies_recording-eyetracking_physio.tsv.gz',
+          ),
+        ).toBe(true)
+      })
+
+      it('does not throw an error for recording entity in physio data at root of the dataset', () => {
+        expect(
+          type.isBIDS(
+            '/task-matchingpennies_recording-eyetracking_physio.json',
           ),
         ).toBe(true)
       })

--- a/bids-validator/utils/options.js
+++ b/bids-validator/utils/options.js
@@ -22,6 +22,7 @@ export default {
       remoteFiles: Boolean(options.remoteFiles),
       gitRef: options.gitRef || 'HEAD',
       config: options.config || {},
+      schema: options.schema !== 'disable' ? options.schema : false,
     }
     if (options.config && typeof options.config !== 'boolean') {
       this.parseConfig(dir, options.config, function(issues, config) {

--- a/bids-validator/utils/type.js
+++ b/bids-validator/utils/type.js
@@ -17,6 +17,13 @@ import session_level_rules from '../bids_validator/rules/session_level_rules.jso
 import subject_level_rules from '../bids_validator/rules/subject_level_rules.json'
 import top_level_rules from '../bids_validator/rules/top_level_rules.json'
 
+let bids_schema
+
+// Alternative method of loading from bids-specification schema
+export function schemaSetup(schema) {
+  bids_schema = schema
+}
+
 // Associated data
 const associatedData = buildRegExp(associated_data_rules.associated_data)
 // File level
@@ -195,39 +202,51 @@ export default {
      * Check if the file has a name appropriate for an anatomical scan
      */
     isAnat: function(path) {
-      return (
-        conditionalMatch(anatNonparametric, path) ||
-        conditionalMatch(anatParametric, path) ||
-        conditionalMatch(anatDefacemask, path) ||
-        conditionalMatch(anatMultiEcho, path) ||
-        conditionalMatch(anatMultiFlip, path) ||
-        conditionalMatch(anatMultiInv, path) ||
-        conditionalMatch(anatMP2RAGE, path) ||
-        conditionalMatch(anatVFAMT, path) ||
-        conditionalMatch(anatMTR, path)
-      )
+      if (bids_schema) {
+        return bids_schema.datatypes['anat'].some(regex => regex.exec(path))
+      } else {
+        return (
+          conditionalMatch(anatNonparametric, path) ||
+          conditionalMatch(anatParametric, path) ||
+          conditionalMatch(anatDefacemask, path) ||
+          conditionalMatch(anatMultiEcho, path) ||
+          conditionalMatch(anatMultiFlip, path) ||
+          conditionalMatch(anatMultiInv, path) ||
+          conditionalMatch(anatMP2RAGE, path) ||
+          conditionalMatch(anatVFAMT, path) ||
+          conditionalMatch(anatMTR, path)
+        )
+      }
     },
 
     /**
      * Check if the file has a name appropriate for a diffusion scan
      */
     isDWI: function(path) {
-      return conditionalMatch(dwiData, path)
+      if (bids_schema) {
+        return bids_schema.datatypes['dwi'].some(regex => regex.exec(path))
+      } else {
+        return conditionalMatch(dwiData, path)
+      }
     },
 
     /**
      * Check if the file has a name appropriate for a fieldmap scan
      */
     isFieldMap: function(path) {
-      return (
-        conditionalMatch(fmapGre, path) ||
-        conditionalMatch(fmapPepolarAsl, path) ||
-        conditionalMatch(fmapTB1DAM, path) ||
-        conditionalMatch(fmapTB1EPI, path) ||
-        conditionalMatch(fmapTB1SRGE, path) ||
-        conditionalMatch(fmapRF, path) ||
-        conditionalMatch(fmapParametric, path)
-      )
+      if (bids_schema) {
+        return bids_schema.datatypes['fmap'].some(regex => regex.exec(path))
+      } else {
+        return (
+          conditionalMatch(fmapGre, path) ||
+          conditionalMatch(fmapPepolarAsl, path) ||
+          conditionalMatch(fmapTB1DAM, path) ||
+          conditionalMatch(fmapTB1EPI, path) ||
+          conditionalMatch(fmapTB1SRGE, path) ||
+          conditionalMatch(fmapRF, path) ||
+          conditionalMatch(fmapParametric, path)
+        )
+      }
     },
 
     isFieldMapMainNii: function(path) {
@@ -248,12 +267,16 @@ export default {
      * Check if the file has a name appropriate for a functional scan
      */
     isFunc: function(path) {
-      return (
-        conditionalMatch(func, path) ||
-        conditionalMatch(funcPhaseDeprecated, path) ||
-        conditionalMatch(funcEvents, path) ||
-        conditionalMatch(funcTimeseries, path)
-      )
+      if (bids_schema) {
+        return bids_schema.datatypes['func'].some(regex => regex.exec(path))
+      } else {
+        return (
+          conditionalMatch(func, path) ||
+          conditionalMatch(funcPhaseDeprecated, path) ||
+          conditionalMatch(funcEvents, path) ||
+          conditionalMatch(funcTimeseries, path)
+        )
+      }
     },
 
     isAsl: function(path) {
@@ -261,7 +284,11 @@ export default {
     },
 
     isPET: function(path) {
-      return conditionalMatch(petData, path)
+      if (bids_schema) {
+        return bids_schema.datatypes['pet'].some(regex => regex.exec(path))
+      } else {
+        return conditionalMatch(petData, path)
+      }
     },
 
     isPETBlood: function(path) {
@@ -269,23 +296,39 @@ export default {
     },
 
     isMeg: function(path) {
-      return (
-        conditionalMatch(megData, path) ||
-        conditionalMatch(megCalibrationData, path) ||
-        conditionalMatch(megCrosstalkData, path)
-      )
+      if (bids_schema) {
+        return bids_schema.datatypes['meg'].some(regex => regex.exec(path))
+      } else {
+        return (
+          conditionalMatch(megData, path) ||
+          conditionalMatch(megCalibrationData, path) ||
+          conditionalMatch(megCrosstalkData, path)
+        )
+      }
     },
 
     isEEG: function(path) {
-      return conditionalMatch(eegData, path)
+      if (bids_schema) {
+        return bids_schema.datatypes['eeg'].some(regex => regex.exec(path))
+      } else {
+        return conditionalMatch(eegData, path)
+      }
     },
 
     isIEEG: function(path) {
-      return conditionalMatch(ieegData, path)
+      if (bids_schema) {
+        return bids_schema.datatypes['ieeg'].some(regex => regex.exec(path))
+      } else {
+        return conditionalMatch(ieegData, path)
+      }
     },
 
     isBehavioral: function(path) {
-      return conditionalMatch(behavioralData, path)
+      if (bids_schema) {
+        return bids_schema.datatypes['beh'].some(regex => regex.exec(path))
+      } else {
+        return conditionalMatch(behavioralData, path)
+      }
     },
 
     isFuncBold: function(path) {
@@ -341,10 +384,13 @@ export default {
 
     return values
   },
+
+  // CommonJS default export
+  schemaSetup,
 }
 
 function conditionalMatch(expression, path) {
-  var match = expression.exec(path)
+  const match = expression.exec(path)
 
   // we need to do this because JS does not support conditional groups
   if (match) {

--- a/bids-validator/utils/type.js
+++ b/bids-validator/utils/type.js
@@ -122,19 +122,35 @@ export default {
      * Check if the file has appropriate name for a top level file
      */
     isTopLevel: function(path) {
-      return (
-        rootTop.test(path) ||
-        funcTop.test(path) ||
-        aslTop.test(path) ||
-        dwiTop.test(path) ||
-        anatTop.test(path) ||
-        multiDirFieldmap.test(path) ||
-        otherTopFiles.test(path) ||
-        megTop.test(path) ||
-        eegTop.test(path) ||
-        ieegTop.test(path) ||
-        petTop.test(path)
-      )
+      if (bids_schema) {
+        return (
+          bids_schema.top_level_files.some(regex => regex.exec(path)) ||
+          funcTop.test(path) ||
+          aslTop.test(path) ||
+          dwiTop.test(path) ||
+          anatTop.test(path) ||
+          multiDirFieldmap.test(path) ||
+          otherTopFiles.test(path) ||
+          megTop.test(path) ||
+          eegTop.test(path) ||
+          ieegTop.test(path) ||
+          petTop.test(path)
+        )
+      } else {
+        return (
+          rootTop.test(path) ||
+          funcTop.test(path) ||
+          aslTop.test(path) ||
+          dwiTop.test(path) ||
+          anatTop.test(path) ||
+          multiDirFieldmap.test(path) ||
+          otherTopFiles.test(path) ||
+          megTop.test(path) ||
+          eegTop.test(path) ||
+          ieegTop.test(path) ||
+          petTop.test(path)
+        )
+      }
     },
 
     /**

--- a/bids-validator/validators/bids/fullTest.js
+++ b/bids-validator/validators/bids/fullTest.js
@@ -25,7 +25,7 @@ import collectPetFields from '../../utils/summary/collectPetFields'
  * Takes on an array of files, callback, and boolean inidicating if git-annex is used.
  * Starts the validation process for a BIDS package.
  */
-const fullTest = (fileList, options, annexed, dir, callback) => {
+const fullTest = (fileList, options, annexed, dir, schema, callback) => {
   const self = BIDS
   self.options = options
 
@@ -43,7 +43,7 @@ const fullTest = (fileList, options, annexed, dir, callback) => {
 
   const tsvs = []
 
-  const summary = utils.collectSummary(fileList, self.options)
+  const summary = utils.collectSummary(fileList, self.options, schema)
 
   // remove size redundancies
   for (const key in fileList) {

--- a/bids-validator/validators/bids/start.js
+++ b/bids-validator/validators/bids/start.js
@@ -5,6 +5,8 @@ import quickTest from './quickTest'
 import quickTestError from './quickTestError'
 import fullTest from './fullTest'
 import utils from '../../utils'
+import { schemaRegex } from '../../src/schemaTypes'
+import { schemaSetup } from '../../utils/type'
 
 /**
  * Start
@@ -17,29 +19,37 @@ import utils from '../../utils'
  * arguments to the callback.
  */
 const start = (dir, options, callback) => {
-  // eslint-disable-next-line
-  if (!options.json) console.log(`bids-validator@${version}\n`)
+  if (!options.json) {
+    // eslint-disable-next-line
+    console.log(`bids-validator@${version}`)
+    // eslint-disable-next-line
+    console.log(`bids-specification@${options.schema}`)
+  }
 
-  utils.options.parse(dir, options, function(issues, options) {
+  utils.options.parse(dir, options, async function (issues, options) {
     if (issues && issues.length > 0) {
       // option parsing issues
       callback({ config: issues })
     } else {
       BIDS.options = options
       reset(BIDS)
-      utils.files.readDir(dir, options).then(files => {
-        const couldBeBIDS = quickTest(files)
-        if (couldBeBIDS) {
-          // Is the dir using git-annex?
-          const annexed = utils.files.remoteFiles.isGitAnnex(dir)
-          fullTest(files, BIDS.options, annexed, dir, callback)
-        } else {
-          // Return an error immediately if quickTest fails
-          const issue = quickTestError(dir)
-          BIDS.summary.totalFiles = Object.keys(files).length
-          callback(utils.issues.format([issue], BIDS.summary, options))
-        }
-      })
+      // Load the bids-spec schema ahead of any validation
+      let schema
+      if (options.schema) {
+        schema = await schemaRegex(options.schema)
+        schemaSetup(schema)
+      }
+      const files = await utils.files.readDir(dir, options)
+      if (quickTest(files)) {
+        // Is the dir using git-annex?
+        const annexed = utils.files.remoteFiles.isGitAnnex(dir)
+        fullTest(files, BIDS.options, annexed, dir, schema, callback)
+      } else {
+        // Return an error immediately if quickTest fails
+        const issue = quickTestError(dir)
+        BIDS.summary.totalFiles = Object.keys(files).length
+        callback(utils.issues.format([issue], BIDS.summary, options))
+      }
     }
   })
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "semver": "^7.3.2",
         "stream-browserify": "^3.0.0",
         "table": "^5.2.3",
+        "yaml": "^1.10.2",
         "yargs": "^16.2.0"
       },
       "bin": {
@@ -22014,6 +22015,14 @@
         "node": ">= 6"
       }
     },
+    "node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/yargs": {
       "version": "15.4.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
@@ -27815,6 +27824,7 @@
         "stream-browserify": "^3.0.0",
         "sync-request": "6.0.0",
         "table": "^5.2.3",
+        "yaml": "^1.10.2",
         "yargs": "^16.2.0",
         "adm-zip": "",
         "chai": ""
@@ -39473,6 +39483,11 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
       "dev": true
+    },
+    "yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
     },
     "yargs": {
       "version": "15.4.1",


### PR DESCRIPTION
This adds an option to apply the bids-specification schema to some parts of validation. The top level schema is also loaded but not used for validation here. Based on @rwblair's start in #1126, this integrates a schema flag that takes a tag for the bids-specification repo and loads the yaml definitions (with a fallback to a bundled copy of v1.6.0 for when network access is unavailable and tests).