### PR TITLE
fix: Use an inline build when running bin/bids-validator from source

### DIFF
--- a/bids-validator/bin/bids-validator
+++ b/bids-validator/bin/bids-validator
@@ -1,9 +1,20 @@
 #!/usr/bin/env node
-try {
-  const { default: cli } = require('bids-validator/cli')
+function entry(cli) {
   cli(process.argv.slice(2)).catch(code => {
     process.exit(code)
   })
+}
+
+try {
+  const { default: cli } = require('bids-validator/cli')
+  entry(cli)
 } catch (err) {
-  console.log(err)
+  if (err.code === 'MODULE_NOT_FOUND') {
+    // For dev, use esbuild-runner if not testing a build
+    require('esbuild-runner/register')
+    const { default: cli } = require('../cli.js')
+    entry(cli)
+  } else {
+    console.log(err)
+  }
 }

--- a/bids-validator/package.json
+++ b/bids-validator/package.json
@@ -60,6 +60,7 @@
     "chai": "",
     "codecov": "^3.1.0",
     "esbuild": "^0.11.5",
+    "esbuild-runner": "^2.2.1",
     "esbuild-plugin-globals": "^0.1.1",
     "eslint": "^5.2.0",
     "eslint-config-prettier": "^2.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "bids-validator",
       "workspaces": [
         "bids-validator",
         "bids-validator-web"
@@ -28,6 +27,7 @@
         "colors": "^1.4.0",
         "cross-fetch": "^3.0.6",
         "date-fns": "^2.7.0",
+        "esbuild-runner": "^2.2.1",
         "events": "^3.3.0",
         "hed-validator": "^3.4.0",
         "ignore": "^4.0.2",
@@ -48,8 +48,6 @@
         "bids-validator": "bin/bids-validator"
       },
       "devDependencies": {
-        "adm-zip": "",
-        "chai": "",
         "codecov": "^3.1.0",
         "esbuild": "^0.11.5",
         "esbuild-plugin-globals": "^0.1.1",
@@ -60,7 +58,9 @@
         "lockfile": "^1.0.4",
         "prettier": "^1.14.2",
         "pretty-quick": "^1.6.0",
-        "sync-request": "6.0.0"
+        "sync-request": "6.0.0",
+        "adm-zip": "",
+        "chai": ""
       },
       "engines": {
         "node": ">=12.12.0"
@@ -75,9 +75,9 @@
         "next": "^11.1.2",
         "next-transpile-modules": "^2.3.1",
         "pluralize": "^8.0.0",
-        "react": "^16.8.1",
+        "react": "^17.0.2",
         "react-bootstrap": "^1.0.0-beta.5",
-        "react-dom": "^16.8.1",
+        "react-dom": "^17.0.2",
         "sass": "^1.32.8"
       }
     },
@@ -9379,7 +9379,6 @@
       "version": "0.11.23",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.11.23.tgz",
       "integrity": "sha512-iaiZZ9vUF5wJV8ob1tl+5aJTrwDczlvGP0JoMmnpC2B0ppiMCu8n8gmy5ZTGl5bcG081XBVn+U+jP+mPFm5T5Q==",
-      "dev": true,
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -9393,6 +9392,26 @@
       "engines": {
         "node": ">=7"
       }
+    },
+    "node_modules/esbuild-runner": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/esbuild-runner/-/esbuild-runner-2.2.1.tgz",
+      "integrity": "sha512-VP0VfJJZiZ3cKzdOH59ZceDxx/GzBKra7tiGM8MfFMLv6CR1/cpsvtQ3IsJI3pz7HyeYxtbPyecj3fHwR+3XcQ==",
+      "dependencies": {
+        "source-map-support": "0.5.19",
+        "tslib": "2.3.1"
+      },
+      "bin": {
+        "esr": "bin/esr.js"
+      },
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
+    "node_modules/esbuild-runner/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -19934,7 +19953,6 @@
       "version": "0.5.19",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
       "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-      "dev": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -19944,7 +19962,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -27767,16 +27784,15 @@
       "version": "file:bids-validator",
       "requires": {
         "@aws-sdk/client-s3": "^3.9.0",
-        "adm-zip": "",
         "ajv": "^6.5.2",
         "bytes": "^3.0.0",
-        "chai": "",
         "codecov": "^3.1.0",
         "colors": "^1.4.0",
         "cross-fetch": "^3.0.6",
         "date-fns": "^2.7.0",
         "esbuild": "^0.11.5",
         "esbuild-plugin-globals": "^0.1.1",
+        "esbuild-runner": "^2.2.1",
         "eslint": "^5.2.0",
         "eslint-config-prettier": "^2.9.0",
         "eslint-plugin-prettier": "^2.6.2",
@@ -27799,7 +27815,9 @@
         "stream-browserify": "^3.0.0",
         "sync-request": "6.0.0",
         "table": "^5.2.3",
-        "yargs": "^16.2.0"
+        "yargs": "^16.2.0",
+        "adm-zip": "",
+        "chai": ""
       },
       "dependencies": {
         "ansi-styles": {
@@ -27897,12 +27915,12 @@
       "requires": {
         "bootstrap": "^4.3.0",
         "bowser": "^1.0.0",
-        "next": "11.1.2",
+        "next": "^11.1.2",
         "next-transpile-modules": "^2.3.1",
         "pluralize": "^8.0.0",
-        "react": "^16.8.1",
+        "react": "^17.0.2",
         "react-bootstrap": "^1.0.0-beta.5",
-        "react-dom": "^16.8.1",
+        "react-dom": "^17.0.2",
         "sass": "^1.32.8"
       },
       "dependencies": {
@@ -27917,8 +27935,7 @@
           }
         },
         "react-dom": {
-          "version": "16.14.0",
-          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+          "version": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
           "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
           "requires": {
             "loose-envify": "^1.1.0",
@@ -29574,14 +29591,29 @@
     "esbuild": {
       "version": "0.11.23",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.11.23.tgz",
-      "integrity": "sha512-iaiZZ9vUF5wJV8ob1tl+5aJTrwDczlvGP0JoMmnpC2B0ppiMCu8n8gmy5ZTGl5bcG081XBVn+U+jP+mPFm5T5Q==",
-      "dev": true
+      "integrity": "sha512-iaiZZ9vUF5wJV8ob1tl+5aJTrwDczlvGP0JoMmnpC2B0ppiMCu8n8gmy5ZTGl5bcG081XBVn+U+jP+mPFm5T5Q=="
     },
     "esbuild-plugin-globals": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/esbuild-plugin-globals/-/esbuild-plugin-globals-0.1.1.tgz",
       "integrity": "sha512-BK0OJ02paAPJp4tGyFBum/YHerGYeRvonCRuRpkIbJemQrFHw3uWy6MEXcKgOwecAyXo3fOY5opl8ude2kHVrw==",
       "dev": true
+    },
+    "esbuild-runner": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/esbuild-runner/-/esbuild-runner-2.2.1.tgz",
+      "integrity": "sha512-VP0VfJJZiZ3cKzdOH59ZceDxx/GzBKra7tiGM8MfFMLv6CR1/cpsvtQ3IsJI3pz7HyeYxtbPyecj3fHwR+3XcQ==",
+      "requires": {
+        "source-map-support": "0.5.19",
+        "tslib": "2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
     },
     "escalade": {
       "version": "3.1.1",
@@ -37792,7 +37824,6 @@
       "version": "0.5.19",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
       "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -37801,8 +37832,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },


### PR DESCRIPTION
This uses esbuild-runner to transpile everything on the fly while running ./bin/bids-validator in a development source tree. That way you can test without needing to rebuild but still get an accurate idea if things are likely to work when the esbuild version is published.

Fixes #1329