### PR TITLE
Exclude vendor files from Code Climate analyzes

### DIFF
--- a/bids-validator/.codeclimate.yml
+++ b/bids-validator/.codeclimate.yml
@@ -1,3 +1,4 @@
+---
 version: '2'
 checks:
   similar-code:
@@ -11,3 +12,6 @@ plugins:
     enabled: true
     config:
       count_threshold: 3
+exclude_patterns:
+  - "**/versioneer.py"
+  - "**/_version.py"


### PR DESCRIPTION
Required by #1336 to pass tests.

See [Excluding Files and Folders](https://docs.codeclimate.com/docs/excluding-files-and-folders).