### PR TITLE
feat: Add entrypoint for consoleFormat (used by openneuro/cli)

### DIFF
--- a/bids-validator/esbuild.mjs
+++ b/bids-validator/esbuild.mjs
@@ -7,6 +7,7 @@ await esbuild.build({
   entryPoints: [
     path.join(process.cwd(), 'index.js'),
     path.join(process.cwd(), 'cli.js'),
+    path.join(process.cwd(), 'utils', 'consoleFormat.js'),
   ],
   outdir: path.join(process.cwd(), 'dist', 'commonjs'),
   target: 'node12',

--- a/bids-validator/package.json
+++ b/bids-validator/package.json
@@ -10,6 +10,9 @@
     },
     "./cli": {
       "require": "./dist/commonjs/cli.js"
+    },
+    "./utils/consoleFormat": {
+      "require": "./dist/commonjs/consoleFormat.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
@openneuro/cli uses this to provide the same console formatting as the validator.