### PR TITLE
fix(cli): Prefer to run the development tree over installed module

### DIFF
--- a/bids-validator/bin/bids-validator
+++ b/bids-validator/bin/bids-validator
@@ -6,13 +6,15 @@ function entry(cli) {
 }
 
 try {
-  const { default: cli } = require('bids-validator/cli')
+  // Test if there's a development tree to run
+  require.resolve('../cli.js')
+  // For dev, use esbuild-runner
+  require('esbuild-runner/register')
+  const { default: cli } = require('../cli.js')
   entry(cli)
 } catch (err) {
   if (err.code === 'MODULE_NOT_FOUND') {
-    // For dev, use esbuild-runner if not testing a build
-    require('esbuild-runner/register')
-    const { default: cli } = require('../cli.js')
+    const { default: cli } = require('bids-validator/cli')
     entry(cli)
   } else {
     console.log(err)


### PR DESCRIPTION
I think this might be the issue found here: https://github.com/bids-standard/bids-validator/pull/1359#issuecomment-942891290.

The problem arises if you are working on the validator but have a Node-resolvable module copy as well. The script will ignore your local tree and prefer the node_modules version. Flipping it around is less likely to be confusing, if you have a source tree that will always be run ahead of the installed module with this change.