### PR TITLE
[ENH] Accept additional properties within beh.json JSON schema

### DIFF
--- a/bids-validator/tests/json.spec.js
+++ b/bids-validator/tests/json.spec.js
@@ -587,4 +587,22 @@ describe('JSON', function() {
       assert(issues[1].evidence == '.CogPOID should match format "uri"')
     })
   })
+
+  it('*beh.json with extra content throws no error', function() {
+    var jsonObj = {
+      TaskName: 'stroop',
+      trial: {
+        LongName: 'Trial name',
+        Description: 'Indicator of the type of trial',
+        Levels: {
+          congruent: 'Word and color font are congruent.',
+          incongruent: 'Word and color font are not congruent.',
+        },
+      },
+    }
+    jsonDict[beh_file.relativePath] = jsonObj
+    validate.JSON(beh_file, jsonDict, function(issues) {
+      assert(issues.length === 0)
+    })
+  })
 })

--- a/bids-validator/validators/json/schemas/beh.json
+++ b/bids-validator/validators/json/schemas/beh.json
@@ -10,5 +10,5 @@
     "InstitutionAddress": { "$ref": "common_definitions.json#/definitions/InstitutionAddress" },
     "InstitutionalDepartmentName": { "$ref": "common_definitions.json#/definitions/InstitutionalDepartmentName" }
   },
-  "additionalProperties": false
+  "additionalProperties": true
 }


### PR DESCRIPTION
fixes https://github.com/bids-standard/bids-validator/issues/1364 when merged

- [x] allow additional properties for beh.json
- [ ] throw warning for columns of `beh.tsv` with no data_dictionary (is this too strict???)
- [ ] throw warning if `beh.tsv` has `onset` and `duration` column (it should probably be an `events.tsv` in this case)