### PR TITLE
fix(schema): Generate regex for directory data types

### DIFF
--- a/bids-validator/src/schemaTypes.js
+++ b/bids-validator/src/schemaTypes.js
@@ -138,9 +138,15 @@ export async function generateRegex(schema, pythonRegex = false) {
       }
       const suffix_regex = `_(?${P}<suffix>${datatype.suffixes.join('|')})`
       // Workaround v1.6.0 MEG extension "*"
-      const wildcard_extensions = datatype.extensions.map(ext =>
-        ext === '*' ? '.*?' : ext,
-      )
+      const wildcard_extensions = datatype.extensions.map((ext) => {
+        if (ext === '*') {
+          return '.*?'
+        } else if (ext.includes('/')) {
+          return ext.replace('/', '[\\/\\\\].*')
+        } else {
+          return ext
+        }
+      })
       const ext_regex = `(?${P}<ext>${wildcard_extensions.join('|')})`
       exportRegex.datatypes[mod].push(
         new RegExp(file_regex + suffix_regex + ext_regex + '$'),

--- a/bids-validator/utils/__tests__/type.spec.js
+++ b/bids-validator/utils/__tests__/type.spec.js
@@ -103,6 +103,18 @@ describe('type.js', () => {
           ),
         ).toBe(true)
       })
+      it('allows an directiories within datatypes', () => {
+        expect(
+          type.isBIDS(
+            '/sub-0001/meg/sub-0001_task-AEF_run-01_meg.ds/sub-0001_task-AEF_run-01_meg.acq',
+          ),
+        ).toBe(true)
+        expect(
+          type.isBIDS(
+            '/sub-0001/meg/sub-0001_task-AEF_run-01_meg.ds/BadChannels',
+          ),
+        ).toBe(true)
+      })
     })
   })
 })


### PR DESCRIPTION
When using the schema generated regular expressions this interprets '/' in extensions to mean a directory with arbitrary filenames within.