### PR TITLE
fix: Resolve npm package name conflict warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "bids-validator",
+  "name": "bids-validator-monorepo",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "bids-validator",
+      "name": "bids-validator-monorepo",
       "workspaces": [
         "bids-validator",
         "bids-validator-web"
@@ -19,7 +19,7 @@
       }
     },
     "bids-validator": {
-      "version": "1.8.5-dev.0",
+      "version": "1.8.6-dev.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.9.0",
@@ -50,8 +50,6 @@
         "bids-validator": "bin/bids-validator"
       },
       "devDependencies": {
-        "adm-zip": "",
-        "chai": "",
         "codecov": "^3.1.0",
         "esbuild": "^0.11.5",
         "esbuild-plugin-globals": "^0.1.1",
@@ -63,14 +61,16 @@
         "lockfile": "^1.0.4",
         "prettier": "^1.14.2",
         "pretty-quick": "^1.6.0",
-        "sync-request": "6.0.0"
+        "sync-request": "6.0.0",
+        "adm-zip": "",
+        "chai": ""
       },
       "engines": {
         "node": ">=12.12.0"
       }
     },
     "bids-validator-web": {
-      "version": "1.8.5-dev.0",
+      "version": "1.8.6-dev.0",
       "license": "MIT",
       "dependencies": {
         "bootstrap": "^4.3.0",
@@ -27752,10 +27752,8 @@
       "version": "file:bids-validator",
       "requires": {
         "@aws-sdk/client-s3": "^3.9.0",
-        "adm-zip": "",
         "ajv": "^6.5.2",
         "bytes": "^3.0.0",
-        "chai": "",
         "codecov": "^3.1.0",
         "colors": "^1.4.0",
         "cross-fetch": "^3.0.6",
@@ -27767,7 +27765,7 @@
         "eslint-config-prettier": "^2.9.0",
         "eslint-plugin-prettier": "^2.6.2",
         "events": "^3.3.0",
-        "hed-validator": "3.5.0",
+        "hed-validator": "^3.5.0",
         "husky": "^1.0.0-rc.13",
         "ignore": "^4.0.2",
         "is-utf8": "^0.2.1",
@@ -27787,7 +27785,9 @@
         "sync-request": "6.0.0",
         "table": "^5.2.3",
         "yaml": "^1.10.2",
-        "yargs": "^16.2.0"
+        "yargs": "^16.2.0",
+        "adm-zip": "",
+        "chai": ""
       },
       "dependencies": {
         "ansi-styles": {

--- a/package.json
+++ b/package.json
@@ -29,5 +29,5 @@
     "jest-environment-node": "^24.9.0",
     "lerna": "^4.0.0"
   },
-  "name": "bids-validator"
+  "name": "bids-validator-monorepo"
 }


### PR DESCRIPTION
Fixes this error seen in CI:
```
jest-haste-map: Haste module naming collision: bids-validator
  The following files share their name; please adjust your hasteImpl:
    * <rootDir>/bids-validator/package.json
    * <rootDir>/package.json
```