### PR TITLE
Skip single author check if author is not string.

### DIFF
--- a/bids-validator/validators/bids/checkDatasetDescription.js
+++ b/bids-validator/validators/bids/checkDatasetDescription.js
@@ -49,7 +49,7 @@ const checkAuthorField = authors => {
     if (authors.length == 1) {
       const author = authors[0]
       // check the number of commas in the single author field
-      if (author.split(',').length <= 2) {
+      if (typeof author == 'string' && author.split(',').length <= 2) {
         // if there is one or less comma in the author field,
         // we suspect that the curator has not listed everyone involved
         issues.push(new Issue({ code: 102, evidence: author }))


### PR DESCRIPTION
will then fail during json schema validation as expected.
fixes #1389