### PR TITLE
Add DatasetLinks to JSON schema

### DIFF
--- a/bids-validator/bids_validator/test_bids_validator.py
+++ b/bids-validator/bids_validator/test_bids_validator.py
@@ -14,7 +14,7 @@ from bids_validator import BIDSValidator
 HOME = os.path.expanduser('~')
 
 TEST_DATA_DICT = {
-    'eeg_matchingpennies': 'https://github.com/sappelhoff/eeg_matchingpennies'
+    'eeg_matchingpennies': 'https://gin.g-node.org/sappelhoff/eeg_matchingpennies'
     }
 
 EXCLUDE_KEYWORDS = ['git', 'datalad', 'sourcedata', 'bidsignore']

--- a/bids-validator/bids_validator/test_bids_validator.py
+++ b/bids-validator/bids_validator/test_bids_validator.py
@@ -14,7 +14,9 @@ from bids_validator import BIDSValidator
 HOME = os.path.expanduser('~')
 
 TEST_DATA_DICT = {
-    'eeg_matchingpennies': 'https://gin.g-node.org/sappelhoff/eeg_matchingpennies'
+    'eeg_matchingpennies': (
+        'https://gin.g-node.org/sappelhoff/eeg_matchingpennies'
+    ),
     }
 
 EXCLUDE_KEYWORDS = ['git', 'datalad', 'sourcedata', 'bidsignore']

--- a/bids-validator/tests/json.spec.js
+++ b/bids-validator/tests/json.spec.js
@@ -484,27 +484,42 @@ describe('JSON', function() {
     })
   })
 
-  it('dataset_description.json should raise on empty key in DatasetLinks', function() {
+  it('dataset_description.json should raise on bad keys in DatasetLinks', function() {
     var jsonObj = {
       Name: 'Example Name',
       BIDSVersion: '1.4.0',
       DatasetLinks: {
         mylink: 'https://www.google.com',
         '': 'https://www.yahoo.com',
+        'mylink!': ':/path',
+        'my link': ':/another/path',
       },
     }
     jsonDict[dataset_description_file.relativePath] = jsonObj
     validate.JSON(dataset_description_file, jsonDict, function(issues) {
-      assert(issues.length === 2)
+      assert(issues.length === 6)
       assert(
         issues[0].evidence ==
           '.DatasetLinks should NOT be shorter than 1 characters',
       )
       assert(issues[1].evidence == ".DatasetLinks property name '' is invalid")
+      assert(
+        issues[2].evidence ==
+          '.DatasetLinks should match pattern "^[a-zA-Z0-9]*$"',
+      )
+      assert(
+        issues[3].evidence ==
+          ".DatasetLinks property name 'mylink!' is invalid",
+      )
+      assert(issues[4].evidence == issues[2].evidence)
+      assert(
+        issues[5].evidence ==
+          ".DatasetLinks property name 'my link' is invalid",
+      )
     })
   })
 
-  it('dataset_description.json should raise on wrong key in DatasetLinks', function() {
+  it('dataset_description.json should raise on non-object value in DatasetLinks', function() {
     var jsonObj = {
       Name: 'Example Name',
       BIDSVersion: '1.4.0',
@@ -524,23 +539,18 @@ describe('JSON', function() {
       DatasetLinks: {
         mylink1: 'https://www.google.com',
         mylink2: 1,
-        mylink3: 'nope',
         '': 'https://www.yahoo.com',
       },
     }
     jsonDict[dataset_description_file.relativePath] = jsonObj
     validate.JSON(dataset_description_file, jsonDict, function(issues) {
-      assert(issues.length === 4)
+      assert(issues.length === 3)
       assert(
         issues[0].evidence ==
           '.DatasetLinks should NOT be shorter than 1 characters',
       )
       assert(issues[1].evidence == ".DatasetLinks property name '' is invalid")
       assert(issues[2].evidence == ".DatasetLinks['mylink2'] should be string")
-      assert(
-        issues[3].evidence ==
-          '.DatasetLinks[\'mylink3\'] should match format "uri"',
-      )
     })
   })
 

--- a/bids-validator/tests/json.spec.js
+++ b/bids-validator/tests/json.spec.js
@@ -473,6 +473,9 @@ describe('JSON', function() {
       BIDSVersion: '1.4.0',
       DatasetLinks: {
         mylink: 'https://www.google.com',
+        deriv1: 'derivatives/derivative1',
+        phantoms: 'file:///data/phantoms',
+        ds000001: 'doi:10.18112/openneuro.ds000001.v1.0.0',
       },
     }
     jsonDict[dataset_description_file.relativePath] = jsonObj

--- a/bids-validator/tests/json.spec.js
+++ b/bids-validator/tests/json.spec.js
@@ -472,7 +472,7 @@ describe('JSON', function() {
       Name: 'Example Name',
       BIDSVersion: '1.4.0',
       DatasetLinks: {
-        "mylink": "https://www.google.com"
+        mylink: 'https://www.google.com',
       },
     }
     jsonDict[dataset_description_file.relativePath] = jsonObj
@@ -486,14 +486,14 @@ describe('JSON', function() {
       Name: 'Example Name',
       BIDSVersion: '1.4.0',
       DatasetLinks: {
-        "mylink": "https://www.google.com",
-        "": "https://www.yahoo.com"
+        mylink: 'https://www.google.com',
+        '': 'https://www.yahoo.com',
       },
     }
     jsonDict[dataset_description_file.relativePath] = jsonObj
     validate.JSON(dataset_description_file, jsonDict, function(issues) {
       assert(issues.length === 1)
-      assert(issues[0].evidence==".DatasetLinks should NOT be valid")
+      assert(issues[0].evidence == '.DatasetLinks should NOT be valid')
     })
   })
 
@@ -501,13 +501,13 @@ describe('JSON', function() {
     var jsonObj = {
       Name: 'Example Name',
       BIDSVersion: '1.4.0',
-      DatasetLinks: "https://www.google.com"
+      DatasetLinks: 'https://www.google.com',
     }
     jsonDict[dataset_description_file.relativePath] = jsonObj
     validate.JSON(dataset_description_file, jsonDict, function(issues) {
       assert(issues.length === 2)
-      assert(issues[0].evidence==".DatasetLinks should be object")
-      assert(issues[1].evidence==".DatasetLinks should NOT be valid")
+      assert(issues[0].evidence == '.DatasetLinks should be object')
+      assert(issues[1].evidence == '.DatasetLinks should NOT be valid')
     })
   })
 
@@ -516,18 +516,20 @@ describe('JSON', function() {
       Name: 'Example Name',
       BIDSVersion: '1.4.0',
       DatasetLinks: {
-        "mylink1": "https://www.google.com",
-        "mylink2": 1,
-        "mylink3": "nope",
-        "": "https://www.yahoo.com",
+        mylink1: 'https://www.google.com',
+        mylink2: 1,
+        mylink3: 'nope',
+        '': 'https://www.yahoo.com',
       },
     }
     jsonDict[dataset_description_file.relativePath] = jsonObj
     validate.JSON(dataset_description_file, jsonDict, function(issues) {
-      assert(issues[0].evidence==".DatasetLinks['mylink2'] should be string")
-      assert(issues[1].evidence==".DatasetLinks['mylink3'] should match format \"uri\"")
-      assert(issues[2].evidence==".DatasetLinks should NOT be valid")
-
+      assert(issues[0].evidence == ".DatasetLinks['mylink2'] should be string")
+      assert(
+        issues[1].evidence ==
+          '.DatasetLinks[\'mylink3\'] should match format "uri"',
+      )
+      assert(issues[2].evidence == '.DatasetLinks should NOT be valid')
     })
   })
 

--- a/bids-validator/tests/json.spec.js
+++ b/bids-validator/tests/json.spec.js
@@ -492,8 +492,12 @@ describe('JSON', function() {
     }
     jsonDict[dataset_description_file.relativePath] = jsonObj
     validate.JSON(dataset_description_file, jsonDict, function(issues) {
-      assert(issues.length === 1)
-      assert(issues[0].evidence == '.DatasetLinks should NOT be valid')
+      assert(issues.length === 2)
+      assert(
+        issues[0].evidence ==
+          '.DatasetLinks should NOT be shorter than 1 characters',
+      )
+      assert(issues[1].evidence == ".DatasetLinks property name '' is invalid")
     })
   })
 
@@ -505,9 +509,8 @@ describe('JSON', function() {
     }
     jsonDict[dataset_description_file.relativePath] = jsonObj
     validate.JSON(dataset_description_file, jsonDict, function(issues) {
-      assert(issues.length === 2)
+      assert(issues.length === 1)
       assert(issues[0].evidence == '.DatasetLinks should be object')
-      assert(issues[1].evidence == '.DatasetLinks should NOT be valid')
     })
   })
 
@@ -524,12 +527,17 @@ describe('JSON', function() {
     }
     jsonDict[dataset_description_file.relativePath] = jsonObj
     validate.JSON(dataset_description_file, jsonDict, function(issues) {
-      assert(issues[0].evidence == ".DatasetLinks['mylink2'] should be string")
+      assert(issues.length === 4)
       assert(
-        issues[1].evidence ==
+        issues[0].evidence ==
+          '.DatasetLinks should NOT be shorter than 1 characters',
+      )
+      assert(issues[1].evidence == ".DatasetLinks property name '' is invalid")
+      assert(issues[2].evidence == ".DatasetLinks['mylink2'] should be string")
+      assert(
+        issues[3].evidence ==
           '.DatasetLinks[\'mylink3\'] should match format "uri"',
       )
-      assert(issues[2].evidence == '.DatasetLinks should NOT be valid')
     })
   })
 

--- a/bids-validator/tests/json.spec.js
+++ b/bids-validator/tests/json.spec.js
@@ -467,6 +467,70 @@ describe('JSON', function() {
     relativePath: '/dataset_description.json',
   }
 
+  it('dataset_description.json should validate DatasetLinks', function() {
+    var jsonObj = {
+      Name: 'Example Name',
+      BIDSVersion: '1.4.0',
+      DatasetLinks: {
+        "mylink": "https://www.google.com"
+      },
+    }
+    jsonDict[dataset_description_file.relativePath] = jsonObj
+    validate.JSON(dataset_description_file, jsonDict, function(issues) {
+      assert(issues.length === 0)
+    })
+  })
+
+  it('dataset_description.json should raise on empty key in DatasetLinks', function() {
+    var jsonObj = {
+      Name: 'Example Name',
+      BIDSVersion: '1.4.0',
+      DatasetLinks: {
+        "mylink": "https://www.google.com",
+        "": "https://www.yahoo.com"
+      },
+    }
+    jsonDict[dataset_description_file.relativePath] = jsonObj
+    validate.JSON(dataset_description_file, jsonDict, function(issues) {
+      assert(issues.length === 1)
+      assert(issues[0].evidence==".DatasetLinks should NOT be valid")
+    })
+  })
+
+  it('dataset_description.json should raise on wrong key in DatasetLinks', function() {
+    var jsonObj = {
+      Name: 'Example Name',
+      BIDSVersion: '1.4.0',
+      DatasetLinks: "https://www.google.com"
+    }
+    jsonDict[dataset_description_file.relativePath] = jsonObj
+    validate.JSON(dataset_description_file, jsonDict, function(issues) {
+      assert(issues.length === 2)
+      assert(issues[0].evidence==".DatasetLinks should be object")
+      assert(issues[1].evidence==".DatasetLinks should NOT be valid")
+    })
+  })
+
+  it('dataset_description.json should raise on invalid values in DatasetLinks', function() {
+    var jsonObj = {
+      Name: 'Example Name',
+      BIDSVersion: '1.4.0',
+      DatasetLinks: {
+        "mylink1": "https://www.google.com",
+        "mylink2": 1,
+        "mylink3": "nope",
+        "": "https://www.yahoo.com",
+      },
+    }
+    jsonDict[dataset_description_file.relativePath] = jsonObj
+    validate.JSON(dataset_description_file, jsonDict, function(issues) {
+      assert(issues[0].evidence==".DatasetLinks['mylink2'] should be string")
+      assert(issues[1].evidence==".DatasetLinks['mylink3'] should match format \"uri\"")
+      assert(issues[2].evidence==".DatasetLinks should NOT be valid")
+
+    })
+  })
+
   it('dataset_description.json should validate with enum of DatasetType', function() {
     var jsonObj = {
       Name: 'Example Name',

--- a/bids-validator/validators/json/schemas/dataset_description.json
+++ b/bids-validator/validators/json/schemas/dataset_description.json
@@ -62,7 +62,7 @@
       },
       "additionalProperties": {
         "type": "string",
-        "format": "uri"
+        "format": "uri-reference"
       }
     },
     "GeneratedBy": {

--- a/bids-validator/validators/json/schemas/dataset_description.json
+++ b/bids-validator/validators/json/schemas/dataset_description.json
@@ -55,14 +55,14 @@
     "DatasetLinks": {
       "type": "object",
       "properties": { },
+      "propertyNames": {
+        "type": "string",
+        "minLength": 1,
+        "pattern": "^[a-zA-Z0-9]*$"
+      },
       "additionalProperties": {
         "type": "string",
         "format": "uri"
-      },
-      "not": {
-        "anyOf": [
-          { "required": [ "" ] }
-        ]
       }
     },
     "GeneratedBy": {

--- a/bids-validator/validators/json/schemas/dataset_description.json
+++ b/bids-validator/validators/json/schemas/dataset_description.json
@@ -52,6 +52,18 @@
     "DatasetDOI": {
       "type": "string"
     },
+    "DatasetLinks": {
+      "type": "object",
+      "properties": {
+        "^.*$": { "type": "uri" }
+      },
+      "not": {
+        "anyOf": [
+          { "required": [ "" ] }
+        ]
+      }
+
+    },
     "GeneratedBy": {
       "type": "array",
       "minItems": 1,

--- a/bids-validator/validators/json/schemas/dataset_description.json
+++ b/bids-validator/validators/json/schemas/dataset_description.json
@@ -54,15 +54,16 @@
     },
     "DatasetLinks": {
       "type": "object",
-      "properties": {
-        "^.*$": { "type": "uri" }
+      "properties": { },
+      "additionalProperties": {
+        "type": "string",
+        "format": "uri"
       },
       "not": {
         "anyOf": [
           { "required": [ "" ] }
         ]
       }
-
     },
     "GeneratedBy": {
       "type": "array",


### PR DESCRIPTION
addresses point one of #1393: Adding the `DatasetLinks` metadata field to the `dataset_description.json` JSON schema.

xref https://github.com/bids-standard/bids-specification/pull/918