### PR TITLE
Relax NIfTI IntendedFor check when BIDS-URIs are used

### DIFF
--- a/.github/workflows/test-bids-examples.yml
+++ b/.github/workflows/test-bids-examples.yml
@@ -39,10 +39,8 @@ jobs:
           echo "./node_modules/.bin" >> $GITHUB_PATH
 
       - name: Get bids-examples data
-        # temporarily test IntendedFor bids URI branch (remove before merging this PR)
-        #git clone --depth 1 https://github.com/bids-standard/bids-examples -b ${{ matrix.bids-examples-branch }}
         run: |
-          git clone --depth 1 https://github.com/sappelhoff/bids-examples -b bids-uris
+          git clone --depth 1 https://github.com/bids-standard/bids-examples -b ${{ matrix.bids-examples-branch }}
 
       - name: Display versions and environment information
         run: |

--- a/.github/workflows/test-bids-examples.yml
+++ b/.github/workflows/test-bids-examples.yml
@@ -39,8 +39,10 @@ jobs:
           echo "./node_modules/.bin" >> $GITHUB_PATH
 
       - name: Get bids-examples data
+        # temporarily test IntendedFor bids URI branch (remove before merging this PR)
+        #git clone --depth 1 https://github.com/bids-standard/bids-examples -b ${{ matrix.bids-examples-branch }}
         run: |
-          git clone --depth 1 https://github.com/bids-standard/bids-examples -b ${{ matrix.bids-examples-branch }}
+          git clone --depth 1 https://github.com/sappelhoff/bids-examples -b bids-uris
 
       - name: Display versions and environment information
         run: |

--- a/bids-validator/validators/nifti/nii.js
+++ b/bids-validator/validators/nifti/nii.js
@@ -1258,11 +1258,10 @@ export default function NIFTI(
         const intendedForFile = intendedFor[key]
         // Only check for presence of IntendedFor files if not a BIDS-URI
         // https://github.com/bids-standard/bids-validator/issues/1393
-        if (!intendedForFile.startsWith("bids:")) {
+        if (!intendedForFile.startsWith('bids:')) {
           checkIfIntendedExists(intendedForFile, fileList, issues, file)
           checkIfValidFiletype(intendedForFile, issues, file)
         }
-
       }
     }
   }

--- a/bids-validator/validators/nifti/nii.js
+++ b/bids-validator/validators/nifti/nii.js
@@ -1256,8 +1256,13 @@ export default function NIFTI(
 
       for (let key = 0; key < intendedFor.length; key++) {
         const intendedForFile = intendedFor[key]
-        checkIfIntendedExists(intendedForFile, fileList, issues, file)
-        checkIfValidFiletype(intendedForFile, issues, file)
+        // Only check for presence of IntendedFor files if not a BIDS-URI
+        // https://github.com/bids-standard/bids-validator/issues/1393
+        if (!intendedForFile.startsWith("bids:")) {
+          checkIfIntendedExists(intendedForFile, fileList, issues, file)
+          checkIfValidFiletype(intendedForFile, issues, file)
+        }
+
       }
     }
   }

--- a/bids-validator/validators/nifti/nii.js
+++ b/bids-validator/validators/nifti/nii.js
@@ -1257,8 +1257,12 @@ export default function NIFTI(
       for (let key = 0; key < intendedFor.length; key++) {
         const intendedForFile = intendedFor[key]
         // Only check for presence of IntendedFor files if not a BIDS-URI
+        // pointing to an **external** dataset (local is allowed --> 'bids::')
         // https://github.com/bids-standard/bids-validator/issues/1393
-        if (!intendedForFile.startsWith('bids:')) {
+        if (
+          !intendedForFile.startsWith('bids:') ||
+          intendedForFile.startsWith('bids::')
+        ) {
           checkIfIntendedExists(intendedForFile, fileList, issues, file)
           checkIfValidFiletype(intendedForFile, issues, file)
         }

--- a/bids-validator/validators/nifti/nii.js
+++ b/bids-validator/validators/nifti/nii.js
@@ -1257,12 +1257,8 @@ export default function NIFTI(
       for (let key = 0; key < intendedFor.length; key++) {
         const intendedForFile = intendedFor[key]
         // Only check for presence of IntendedFor files if not a BIDS-URI
-        // pointing to an **external** dataset (local is allowed --> 'bids::')
         // https://github.com/bids-standard/bids-validator/issues/1393
-        if (
-          !intendedForFile.startsWith('bids:') ||
-          intendedForFile.startsWith('bids::')
-        ) {
+        if (!intendedForFile.startsWith('bids:')) {
           checkIfIntendedExists(intendedForFile, fileList, issues, file)
           checkIfValidFiletype(intendedForFile, issues, file)
         }


### PR DESCRIPTION
see:

- https://github.com/bids-standard/bids-specification/pull/918
- https://github.com/bids-standard/bids-validator/issues/1393#issuecomment-1019520428
- https://github.com/bids-standard/bids-examples/pull/304#issuecomment-1019521206

In this PR I want to relax the check for IntendedFor data to actually exist **IF** the IntendedFor field is a BIDS-URI. That is, it it's a bids-uri, we don't raise if a file doesn't exist ... else, we still do.
