### PR TITLE
Fix NO_AUTHORS evidence zero length array passing array type as evidence

### DIFF
--- a/bids-validator/validators/bids/checkDatasetDescription.js
+++ b/bids-validator/validators/bids/checkDatasetDescription.js
@@ -59,7 +59,7 @@ const checkAuthorField = authors => {
     // if there are no authors,
     // warn user that errors could occur during doi minting
     // and that snapshots on OpenNeuro will not be allowed
-    issues.push(new Issue({ code: 113, evidence: authors }))
+    issues.push(new Issue({ code: 113, evidence: JSON.stringify(authors) }))
   }
   return issues
 }


### PR DESCRIPTION
Authors can be a an array with zero length, which falls to the no authors error correctly. Evidence is passed as an empty array when it is required to be a string for OpenNeuro's issue schema.

Fixes issue #1414