### PR TITLE
[WIP] BEP020 Eyetracking

### DIFF
--- a/bids-validator-web/package.json
+++ b/bids-validator-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bids-validator-web",
-  "version": "1.9.1-dev.0",
+  "version": "1.9.3-dev.0",
   "description": "web client for bids-validator",
   "main": "index.js",
   "license": "MIT",

--- a/bids-validator/bids_validator/rules/file_level_rules.json
+++ b/bids-validator/bids_validator/rules/file_level_rules.json
@@ -160,6 +160,17 @@
     }
   },
 
+  "eyetrack": {
+    "regexp": "^[\\/\\\\](sub-[a-zA-Z0-9]+)[\\/\\\\](?:(ses-[a-zA-Z0-9]+)[\\/\\\\])?eyetrack[\\/\\\\]\\1(_\\2)?_task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(@@@_eyetrack_ext_@@@)$",
+    "tokens": {
+      "@@@_eyetrack_ext@@@": [
+        "_eyetrack\\.json",
+        "_eyetrack\\.tsv",
+        "_events\\.tsv"
+      ]
+    }
+  },
+
   "dwi": {
     "regexp": "^[\\/\\\\](sub-[a-zA-Z0-9]+)[\\/\\\\](?:(ses-[a-zA-Z0-9]+)[\\/\\\\])?dwi[\\/\\\\]\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_dir-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_part-(imag|mag|phase|real))?((?:@@@_dwi_ext_@@@)|(?:_recording-[a-zA-Z0-9]+)?(?:@@@_cont_ext_@@@))$",
     "tokens": {
@@ -547,22 +558,13 @@
         "_OCT",
         "_SPIM"
       ],
-      "@@@_microscopy_ext_@@@": [
-        ".ome\\.tif",
-        ".ome\\.btf",
-        ".tif",
-        ".png"
-      ]
+      "@@@_microscopy_ext_@@@": [".ome\\.tif", ".ome\\.btf", ".tif", ".png"]
     }
   },
   "microscopy_photo": {
     "regexp": "^[\\/\\\\](sub-[a-zA-Z0-9]+)[\\/\\\\](?:(ses-[a-zA-Z0-9]+)[\\/\\\\])?micr[\\/\\\\](sub-[a-zA-Z0-9]+)(?:(_ses-[a-zA-Z0-9]+))?(?:_sample-[a-zA-Z0-9]+)(?:_acq-[a-zA-Z0-9]+)?(@@@_photo_ext_@@@)$",
-    "tokens":{
-      "@@@_photo_ext_@@@": [
-        "_photo\\.jpg",
-        "_photo\\.png",
-        "_photo\\.tif"
-      ]
+    "tokens": {
+      "@@@_photo_ext_@@@": ["_photo\\.jpg", "_photo\\.png", "_photo\\.tif"]
     }
   },
   "microscopy_json": {

--- a/bids-validator/bids_validator/rules/file_level_rules.json
+++ b/bids-validator/bids_validator/rules/file_level_rules.json
@@ -161,9 +161,9 @@
   },
 
   "eyetrack": {
-    "regexp": "^[\\/\\\\](sub-[a-zA-Z0-9]+)[\\/\\\\](?:(ses-[a-zA-Z0-9]+)[\\/\\\\])?eyetrack[\\/\\\\]\\1(_\\2)?_task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(@@@_eyetrack_ext_@@@)$",
+    "regexp": "^[\\/\\\\](sub-[a-zA-Z0-9]+)[\\/\\\\]eyetrack[\\/\\\\]\\1(?:(_ses-[a-zA-Z0-9]+))?_task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(@@@_eyetrack_ext_@@@)$",
     "tokens": {
-      "@@@_eyetrack_ext@@@": [
+      "@@@_eyetrack_ext_@@@": [
         "_eyetrack\\.json",
         "_eyetrack\\.tsv",
         "_events\\.tsv"

--- a/bids-validator/bids_validator/tsv/non_custom_columns.json
+++ b/bids-validator/bids_validator/tsv/non_custom_columns.json
@@ -44,5 +44,12 @@
   "scans": ["acq_time", "filename"],
   "sessions": ["acq_time", "session_id"],
   "aslcontext": ["volume_type"],
-  "blood": ["time", "plasma_radioactivity", "whole_blood_radioactivity", "metabolite_parent_fraction", "hplc_recovery_fractions"]
+  "blood": [
+    "time",
+    "plasma_radioactivity",
+    "whole_blood_radioactivity",
+    "metabolite_parent_fraction",
+    "hplc_recovery_fractions"
+  ],
+  "eyetrack": ["eventIdentifier", "aoi"]
 }

--- a/bids-validator/package.json
+++ b/bids-validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bids-validator",
-  "version": "1.9.2",
+  "version": "1.9.3-dev.0",
   "description": "",
   "main": "./dist/commonjs/index.js",
   "exports": {

--- a/bids-validator/utils/issues/list.js
+++ b/bids-validator/utils/issues/list.js
@@ -712,7 +712,8 @@ export default {
   139: {
     key: 'BLACKLISTED_MODALITY',
     severity: 'error',
-    reason: 'Found a modality that has been blacklisted through validator configuration.',
+    reason:
+      'Found a modality that has been blacklisted through validator configuration.',
   },
   140: {
     key: '140_EMPTY',
@@ -1117,5 +1118,10 @@ export default {
     key: 'INCONSISTENT_TIFF_EXTENSION',
     severity: 'error',
     reason: 'Inconsistent TIFF file type and extension',
+  },
+  228: {
+    key: 'MISSING_EVENTIDENTIFIER_COLUMN',
+    severity: 'error',
+    reason: 'Eyetracking _event.tsv files require an eventIdentifier column',
   },
 }

--- a/bids-validator/utils/summary/collectModalities.js
+++ b/bids-validator/utils/summary/collectModalities.js
@@ -8,6 +8,7 @@ export const collectModalities = filenames => {
     EEG: 0,
     iEEG: 0,
     Microscopy: 0,
+    EyeTracking: 0,
   }
   const secondary = {
     MRI_Diffusion: 0,
@@ -59,6 +60,9 @@ export const collectModalities = filenames => {
     }
     if (type.file.isMicroscopy(path)) {
       modalities.Microscopy++
+    }
+    if (type.file.isEyetrack(path)) {
+      modalities.EyeTracking++
     }
   }
   // Order by matching file count

--- a/bids-validator/utils/type.js
+++ b/bids-validator/utils/type.js
@@ -62,6 +62,7 @@ const petBlood = buildRegExp(file_level_rules.pet_blood)
 const microscopyData = buildRegExp(file_level_rules.microscopy)
 const microscopyPhotoData = buildRegExp(file_level_rules.microscopy_photo)
 const microscopyJSON = buildRegExp(file_level_rules.microscopy_json)
+const eyetrack = buildRegExp(file_level_rules.eyetrack)
 // Phenotypic data
 const phenotypicData = buildRegExp(phenotypic_rules.phenotypic_data)
 // Session level
@@ -116,6 +117,7 @@ export default {
       this.file.isPhenotypic(path) ||
       this.file.isPET(path) ||
       this.file.isPETBlood(path) ||
+      this.file.isEyetrack(path) ||
       this.file.isMicroscopy(path) ||
       this.file.isMicroscopyJSON(path)
     )
@@ -367,6 +369,13 @@ export default {
         return conditionalMatch(behavioralData, path)
       }
     },
+    isEyetrack: function(path) {
+      if (bids_schema) {
+        return bids_schema.datatypes['eyetrack'].some(regex => regex.exec(path))
+      } else {
+        return conditionalMatch(eyetrack, path)
+      }
+    },
 
     isFuncBold: function(path) {
       return conditionalMatch(funcBoldData, path)
@@ -387,6 +396,7 @@ export default {
         this.isFuncBold(path) ||
         this.isPET(path) ||
         this.isPETBlood(path) ||
+        this.isEyetrack(path) ||
         this.isMicroscopy(path) ||
         this.isMicroscopyJSON(path)
       )

--- a/bids-validator/validators/bids/groupFileTypes.js
+++ b/bids-validator/validators/bids/groupFileTypes.js
@@ -14,6 +14,7 @@ const groupFileTypes = (fileList, options) => {
     ome: [],
     png: [],
     tif: [],
+    eyetrack: [],
     // used to check all files not already passed through testFile()
     misc: [],
   }

--- a/bids-validator/validators/json/json.js
+++ b/bids-validator/validators/json/json.js
@@ -114,7 +114,7 @@ const selectSchema = file => {
       file.name.endsWith('NLO.json') ||
       file.name.endsWith('OCT.json') ||
       file.name.endsWith('SPIM.json')
-      ) {
+    ) {
       schema = require('./schemas/microscopy.json')
     } else if (
       file.relativePath.includes('/meg/') &&
@@ -147,6 +147,8 @@ const selectSchema = file => {
       schema = require('./schemas/events.json')
     } else if (file.name.endsWith('beh.json')) {
       schema = require('./schemas/beh.json')
+    } else if (file.name.endsWith('_eyetrack.json')) {
+      schema = require('./schemas/eyetrack.json')
     }
   }
   return schema

--- a/bids-validator/validators/json/schemas/eyetrack.json
+++ b/bids-validator/validators/json/schemas/eyetrack.json
@@ -1,0 +1,73 @@
+{
+  "type": "object",
+  "properties": {
+    "TaskName": { "$ref": "common_definitions.json#/definitions/TaskName" },
+    "TaskDescription": {
+      "$ref": "common_definitions.json#/definitions/TaskDescription"
+    },
+    "Instructions": {
+      "$ref": "common_definitions.json#/definitions/Instructions"
+    },
+    "CogAtlasID": { "$ref": "common_definitions.json#/definitions/CogAtlasID" },
+    "CogPOID": { "$ref": "common_definitions.json#/definitions/CogPOID" },
+    "InstitutionName": {
+      "$ref": "common_definitions.json#/definitions/InstitutionName"
+    },
+    "InstitutionAddress": {
+      "$ref": "common_definitions.json#/definitions/InstitutionAddress"
+    },
+    "InstitutionalDepartmentName": {
+      "$ref": "common_definitions.json#/definitions/InstitutionalDepartmentName"
+    },
+    "Manufacturer": {
+      "$ref": "common_definitions.json#/definitions/Manufacturer"
+    },
+    "ManufacturersModelName": { "type": "string", "minLength": 1 },
+    "DeviceSerialNumber": {
+      "$ref": "common_definitions.json#/definitions/DeviceSerialNumber"
+    },
+    "SamplingFrequency": { "type": "number" },
+    "SampleCoordinateUnit": { "type": "string" },
+    "SampleCoordinateSystem": { "type": "string" },
+    "EventIdentifier": { "type": "string" },
+    "RawSamples": { "type": "number" },
+    "CapManufacturersModelName": { "type": "string" },
+    "DetectionAlgorithm": { "type": "string" },
+    "StartMessage": { "type": "string" },
+    "EndMessage": { "type": "string" },
+    "KeyPressMessage": { "type": "string" },
+    "CalibrationType": { "type": "string" },
+    "CalibrationPosition": { "type": "number" },
+    "CalibrationUnit": { "type": "string" },
+    "MaximalCalibrationError": { "type": "number" },
+    "CalibrationList": { "type": "number" },
+    "RecordedEye": { "type": "string" },
+    "EyeCameraSettings": { "type": "string" },
+    "FeatureDetectionSettings": { "type": "string" },
+    "GazeMappingSettings": { "type": "string" },
+    "DetectionAlgorithmSettings": { "type": "string" },
+    "DetectionAlgorithm": { "type": "string" },
+    "RawDataFilters": { "type": "string" },
+    "ScreenSize": { "type": "string" },
+    "ScreenResolution": { "type": "string" },
+    "ScreenRefreshRate": { "type": "string" },
+    "AOIDefinition": { "type": "string" },
+    "PupilPositionType": { "type": "string" },
+    "IncludedEyeMovementEvents": { "type": "string" },
+    "EnvironmentCoordinates": { "type": "string" },
+    "PupilFitMethod": { "type": "string" }
+  },
+  "required": [
+    "TaskName",
+    "DetectionAlgorithm",
+    "IncludedEyeMovementEvents",
+    "PupilFitMethod",
+    "EnvironmentCoordinates",
+    "SamplingFrequency",
+    "SampleCoordinateUnit",
+    "SampleCoordinateSystem",
+    "EventIdentifier",
+    "RawSamples"
+  ],
+  "additionalProperties": false
+}

--- a/bids-validator/validators/tsv/tsv.js
+++ b/bids-validator/validators/tsv/tsv.js
@@ -573,6 +573,20 @@ const TSV = (file, contents, fileList, callback) => {
       checkAcqTimeFormat(rows, file, issues)
     }
   }
+
+  if (
+    file.relativePath.includes('eyetrack/') &&
+    file.name.endsWith('_events.tsv')
+  ) {
+    if (headers.indexOf('eventIdentifier') === -1) {
+      issues.push(
+        new Issue({
+          file: file,
+          code: 228,
+        }),
+      )
+    }
+  }
   callback(issues, participants, stimPaths)
 }
 export default TSV

--- a/bids-validator/validators/tsv/validateTsvColumns.js
+++ b/bids-validator/validators/tsv/validateTsvColumns.js
@@ -19,6 +19,7 @@ export const getTsvType = function(file) {
     file.name.endsWith('_scans.tsv') ||
     file.name.endsWith('_sessions.tsv') ||
     file.name.endsWith('_aslcontext.tsv') ||
+    file.name.endsWith('_eyetrack.tsv') ||
     file.name.endsWith('_blood.tsv')
   ) {
     const split = file.name.split('_')
@@ -27,11 +28,12 @@ export const getTsvType = function(file) {
   return tsvType
 }
 
-const getHeaders = tsvContents => tsvContents
-  .replace(/^\uefff/, '')
-  .split('\n')[0]
-  .trim()
-  .split('\t')
+const getHeaders = tsvContents =>
+  tsvContents
+    .replace(/^\uefff/, '')
+    .split('\n')[0]
+    .trim()
+    .split('\t')
 
 /**
  *
@@ -51,7 +53,8 @@ const getCustomColumns = function(headers, type) {
   }
   return customCols
 }
-const commaSeparatedStringOf = items => items.map(item => `"${item}"`).join(', ')
+const commaSeparatedStringOf = items =>
+  items.map(item => `"${item}"`).join(', ')
 
 /**
  * Loads relevant JSON schema for given tsv modalities.
@@ -62,7 +65,7 @@ const commaSeparatedStringOf = items => items.map(item => `"${item}"`).join(', '
 const loadSchemas = tsvs => {
   const schemas = {}
   const getSchemaByType = {
-    'blood': () => require('../json/schemas/pet_blood.json')
+    blood: () => require('../json/schemas/pet_blood.json'),
   }
   const types = new Set(tsvs.map(tsv => getTsvType(tsv.file)))
   types.forEach(type => {
@@ -84,10 +87,7 @@ const validateTsvColumns = function(tsvs, jsonContentsDict, headers) {
 
   tsvs.map(tsv => {
     const tsvType = getTsvType(tsv.file)
-    const customColumns = getCustomColumns(
-      getHeaders(tsv.contents),
-      tsvType,
-    )
+    const customColumns = getCustomColumns(getHeaders(tsv.contents), tsvType)
     const isPetBlood = tsvType === 'blood'
     if (customColumns.length > 0 || isPetBlood) {
       // Get merged data dictionary for this file
@@ -113,7 +113,11 @@ const validateTsvColumns = function(tsvs, jsonContentsDict, headers) {
 
       if (isPetBlood) {
         // Check PET tsv headers required by json sidecar
-        const petBloodHeaderIssues = validatePetBloodHeaders(tsv, mergedDict, schemas['blood'])
+        const petBloodHeaderIssues = validatePetBloodHeaders(
+          tsv,
+          mergedDict,
+          schemas['blood'],
+        )
         tsvIssues.push(...petBloodHeaderIssues)
       }
     }
@@ -140,28 +144,33 @@ export const validatePetBloodHeaders = (tsv, mergedDict, schema) => {
 
   // Collect required headers and the JSON sidecar properties that require them.
   const requiredHeaders = {}
-  Object.entries(schema.properties)
-    .forEach(([ property, subSchema ]) => {
-      if (
-        subSchema.hasOwnProperty('requires_tsv_non_custom_columns')
-        && mergedDict[property] === true
-      ) {
-        subSchema.requires_tsv_non_custom_columns.forEach(header => {
-          if (header in requiredHeaders) {
-            requiredHeaders[header].push(property)
-          } else {
-            requiredHeaders[header] = [property]
-          }
-        })
-      }
-    })
+  Object.entries(schema.properties).forEach(([property, subSchema]) => {
+    if (
+      subSchema.hasOwnProperty('requires_tsv_non_custom_columns') &&
+      mergedDict[property] === true
+    ) {
+      subSchema.requires_tsv_non_custom_columns.forEach(header => {
+        if (header in requiredHeaders) {
+          requiredHeaders[header].push(property)
+        } else {
+          requiredHeaders[header] = [property]
+        }
+      })
+    }
+  })
   Object.entries(requiredHeaders).forEach(([requiredHeader, requiredBy]) => {
     if (!headers.includes(requiredHeader)) {
-      tsvIssues.push(new Issue({
-        code: 211,
-        file: tsv.file,
-        evidence: `${tsv.file.name} has headers: ${commaSeparatedStringOf(headers)}; missing header "${requiredHeader}", which is required when any of the properties (${commaSeparatedStringOf(requiredBy)}) are true in the associated JSON sidecar.`,
-      }))
+      tsvIssues.push(
+        new Issue({
+          code: 211,
+          file: tsv.file,
+          evidence: `${tsv.file.name} has headers: ${commaSeparatedStringOf(
+            headers,
+          )}; missing header "${requiredHeader}", which is required when any of the properties (${commaSeparatedStringOf(
+            requiredBy,
+          )}) are true in the associated JSON sidecar.`,
+        }),
+      )
     }
   })
   return tsvIssues
@@ -187,39 +196,49 @@ const validateASL = (tsvs, jsonContentsDict, headers) => {
 
       // get the _asl_context.tsv associated with this asl scan
       const potentialAslContext = utils.files.potentialLocations(
-        file.relativePath.replace('.gz', '').replace('asl.nii', 'aslcontext.tsv'),
+        file.relativePath
+          .replace('.gz', '')
+          .replace('asl.nii', 'aslcontext.tsv'),
       )
-      const associatedAslContext = potentialAslContext.indexOf(tsv.file.relativePath)
+      const associatedAslContext = potentialAslContext.indexOf(
+        tsv.file.relativePath,
+      )
 
-
-      if (associatedAslContext > -1)
-      {
+      if (associatedAslContext > -1) {
         const rows = tsv.contents
-        .replace(/[\r]+/g,'')
-        .split('\n')
-        .filter(row => !(!row || /^\s*$/.test(row)))
+          .replace(/[\r]+/g, '')
+          .split('\n')
+          .filter(row => !(!row || /^\s*$/.test(row)))
 
-        const m0scan_filters = ['m0scan'];
-        const filtered_m0scan_rows = rows.filter(row => m0scan_filters.includes(row))
+        const m0scan_filters = ['m0scan']
+        const filtered_m0scan_rows = rows.filter(row =>
+          m0scan_filters.includes(row),
+        )
 
-        const asl_filters = ['cbf','m0scan','label','control','deltam','volume_type'];
+        const asl_filters = [
+          'cbf',
+          'm0scan',
+          'label',
+          'control',
+          'deltam',
+          'volume_type',
+        ]
         const filtered_tsv_rows = rows.filter(row => asl_filters.includes(row))
-        if (rows.length != filtered_tsv_rows.length)
-        {
+        if (rows.length != filtered_tsv_rows.length) {
           tsvIssues.push(
             new Issue({
               code: 176,
               file: file,
-            })
+            }),
           )
         }
 
-        if (rows.length -1 != numVols) {
+        if (rows.length - 1 != numVols) {
           tsvIssues.push(
             new Issue({
               code: 165,
               file: file,
-            })
+            }),
           )
         }
 
@@ -235,94 +254,92 @@ const validateASL = (tsvs, jsonContentsDict, headers) => {
         )
 
         // check M0Type and tsv list for m0scan in case of an Included M0Type
-        if (mergedDict.hasOwnProperty('M0Type') &&
-            mergedDict['M0Type'] === "Included" &&
-            filtered_m0scan_rows.length < 1
-          )
-        {
+        if (
+          mergedDict.hasOwnProperty('M0Type') &&
+          mergedDict['M0Type'] === 'Included' &&
+          filtered_m0scan_rows.length < 1
+        ) {
           tsvIssues.push(
             new Issue({
               file: file,
               code: 154,
               reason:
-                "''M0Type' is set to 'Included' however the tsv file does not contain any m0scan volume."
+                "''M0Type' is set to 'Included' however the tsv file does not contain any m0scan volume.",
             }),
           )
         }
         // check M0Type and tsv list for m0scan in case of an Absent M0Type
-        if (mergedDict.hasOwnProperty('M0Type') &&
-            mergedDict['M0Type'] === "Absent" &&
-            filtered_m0scan_rows.length >= 1
-          )
-        {
+        if (
+          mergedDict.hasOwnProperty('M0Type') &&
+          mergedDict['M0Type'] === 'Absent' &&
+          filtered_m0scan_rows.length >= 1
+        ) {
           tsvIssues.push(
             new Issue({
               file: file,
               code: 199,
               reason:
-                "''M0Type' is set to 'Absent' however the tsv file contains an m0scan volume. This should be avoided."
+                "''M0Type' is set to 'Absent' however the tsv file contains an m0scan volume. This should be avoided.",
             }),
           )
         }
 
         // check Flip Angle requirements with LookLocker acquisitions
         if (
-            mergedDict.hasOwnProperty('FlipAngle') &&
-            mergedDict['FlipAngle'].constructor === Array
-          )
-        {
+          mergedDict.hasOwnProperty('FlipAngle') &&
+          mergedDict['FlipAngle'].constructor === Array
+        ) {
           let FlipAngle = mergedDict['FlipAngle']
           const FlipAngleLength = FlipAngle.length
-          if (FlipAngleLength !== rows.length -1) {
+          if (FlipAngleLength !== rows.length - 1) {
             tsvIssues.push(
               new Issue({
                 file: file,
                 code: 172,
                 reason:
-                  "''FlipAngle' for this file does not match the TSV length. Please make sure that the size of the FlipAngle array in the json corresponds to the number of volume listed in the tsv file."
+                  "''FlipAngle' for this file does not match the TSV length. Please make sure that the size of the FlipAngle array in the json corresponds to the number of volume listed in the tsv file.",
               }),
             )
           }
         }
         // check Labelling Duration matching with TSV length only for PCASL or CASL
-        if
-        (
+        if (
           mergedDict.hasOwnProperty('LabelingDuration') &&
           mergedDict['LabelingDuration'].constructor === Array &&
           mergedDict.hasOwnProperty('ArterialSpinLabelingType') &&
-          (mergedDict['ArterialSpinLabelingType'] == 'CASL' || mergedDict['ArterialSpinLabelingType'] == 'PCASL')
-        )
-        {
+          (mergedDict['ArterialSpinLabelingType'] == 'CASL' ||
+            mergedDict['ArterialSpinLabelingType'] == 'PCASL')
+        ) {
           let LabelingDuration = mergedDict['LabelingDuration']
           const LabelingDurationLength = LabelingDuration.length
-          if (LabelingDurationLength !== rows.length -1) {
+          if (LabelingDurationLength !== rows.length - 1) {
             tsvIssues.push(
               new Issue({
                 file: file,
                 code: 175,
                 reason:
-                  "''LabelingDuration' for this file does not match the TSV length. Please be sure that the size of the LabelingDuration array in the json corresponds to the number of volume listed in the tsv file."
+                  "''LabelingDuration' for this file does not match the TSV length. Please be sure that the size of the LabelingDuration array in the json corresponds to the number of volume listed in the tsv file.",
               }),
             )
           }
         }
 
         // check VolumeTiming with TSV length
-        if
-        (
+        if (
           mergedDict.hasOwnProperty('RepetitionTimePreparation') &&
           mergedDict['RepetitionTimePreparation'].constructor === Array
-        )
-        {
-          let RepetitionTimePreparation = mergedDict['RepetitionTimePreparation']
-          const RepetitionTimePreparationLength = RepetitionTimePreparation.length
-          if (RepetitionTimePreparationLength !== rows.length -1) {
+        ) {
+          let RepetitionTimePreparation =
+            mergedDict['RepetitionTimePreparation']
+          const RepetitionTimePreparationLength =
+            RepetitionTimePreparation.length
+          if (RepetitionTimePreparationLength !== rows.length - 1) {
             tsvIssues.push(
               new Issue({
                 file: file,
                 code: 177,
                 reason:
-                  "''RepetitionTimePreparation' for this file do not match the TSV length. Please be sure that the size of the RepetitionTimePreparation array in the json corresponds to the number of volume listed in the tsv file."
+                  "''RepetitionTimePreparation' for this file do not match the TSV length. Please be sure that the size of the RepetitionTimePreparation array in the json corresponds to the number of volume listed in the tsv file.",
               }),
             )
           }
@@ -330,52 +347,51 @@ const validateASL = (tsvs, jsonContentsDict, headers) => {
 
         // check Post Labelling Delays matching with TSV length
         if (
-            mergedDict.hasOwnProperty('PostLabelingDelay') &&
-            mergedDict['PostLabelingDelay'].constructor === Array
-          )
-        {
+          mergedDict.hasOwnProperty('PostLabelingDelay') &&
+          mergedDict['PostLabelingDelay'].constructor === Array
+        ) {
           let PostLabelingDelay = mergedDict['PostLabelingDelay']
           const PostLabelingDelayLength = PostLabelingDelay.length
-          if (PostLabelingDelayLength !== rows.length -1) {
+          if (PostLabelingDelayLength !== rows.length - 1) {
             tsvIssues.push(
               new Issue({
                 file: file,
                 code: 174,
                 reason:
-                  "''PostLabelingDelay' for this file do not match the TSV length. Please be sure that the size of the PostLabelingDelay array in the json corresponds to the number of volume listed in the tsv file."
+                  "''PostLabelingDelay' for this file do not match the TSV length. Please be sure that the size of the PostLabelingDelay array in the json corresponds to the number of volume listed in the tsv file.",
               }),
             )
           }
         }
 
-        if ( mergedDict.hasOwnProperty('TotalAcquiredVolumes') ) {
+        if (mergedDict.hasOwnProperty('TotalAcquiredVolumes')) {
           let TotalAcquiredVolumes = mergedDict['TotalAcquiredVolumes']
           const TotalAcquiredVolumesLength = TotalAcquiredVolumes.length
-          if (TotalAcquiredVolumesLength !== rows.length -1) {
+          if (TotalAcquiredVolumesLength !== rows.length - 1) {
             tsvIssues.push(
               new Issue({
                 file: file,
                 code: 181,
                 reason:
-                  "''TotalAcquiredVolumes' for this file do not match the TSV length. Please be sure that the size of the TotalAcquiredVolumes array in the json corresponds to the number of volume listed in the tsv file."
+                  "''TotalAcquiredVolumes' for this file do not match the TSV length. Please be sure that the size of the TotalAcquiredVolumes array in the json corresponds to the number of volume listed in the tsv file.",
               }),
             )
           }
         }
 
         if (
-             mergedDict.hasOwnProperty('EchoTime') &&
-             mergedDict['EchoTime'].constructor === Array
-             ) {
+          mergedDict.hasOwnProperty('EchoTime') &&
+          mergedDict['EchoTime'].constructor === Array
+        ) {
           let EchoTime = mergedDict['EchoTime']
           const EchoTimeLength = EchoTime.length
-          if (EchoTimeLength !== rows.length -1) {
+          if (EchoTimeLength !== rows.length - 1) {
             tsvIssues.push(
               new Issue({
                 file: file,
                 code: 196,
                 reason:
-                  "''EchoTime' for this file do not match the TSV length. Please be sure that the size of the EchoTime array in the json corresponds to the number of volume listed in the tsv file."
+                  "''EchoTime' for this file do not match the TSV length. Please be sure that the size of the EchoTime array in the json corresponds to the number of volume listed in the tsv file.",
               }),
             )
           }

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
     "bids-validator",
     "bids-validator-web"
   ],
-  "version": "1.9.2"
+  "version": "1.9.3-dev.0"
 }


### PR DESCRIPTION
Based off google doc.

todo/issues:
- [ ] json schema does not have correct types for any of the object of objects, from the examples I could see some of these may be arrays of arrays of strings.
- [ ] file regex does not include .asc as this was not in the google doc template but should be a valid template
- [ ] regex only allows for file in eyetrack/ this may change to allow eyetracking data appear next to any modality.
- [ ] template and example datasets have session in filename but not as a directory, validator throws and error for this as historically both were required and had to match for a given file name.
- [ ] events tsv validation logic will need to be updated if the above is allowed.
- [ ] events.tsv does not cross reference sidecar and _events.tsv eventIdentifier field to ensure they share the same values.
- [ ] json tests
- [ ] tsv tests
- [ ] filename tests

Will be able to resolve these as main specification PR progresses and bids-examples are added.

@mszinte Looking forward to the specification and examples PR. If you have any questions about whats going on here let me know.