### PR TITLE
Allow .md .txt or .rst for README

### DIFF
--- a/bids-validator/bids_validator/rules/top_level_rules.json
+++ b/bids-validator/bids_validator/rules/top_level_rules.json
@@ -4,6 +4,9 @@
     "tokens": {
       "@@@_root_files_@@@": [
         "README",
+        "README.md",
+        "README.rst",
+        "README.txt",
         "CHANGES",
         "LICENSE",
         "dataset_description.json",


### PR DESCRIPTION
fixes #1431 

If we seriously start expanding extensions for top level files these rules should be split out for clarity.