### PR TITLE
fix: Provide evidence strings for Issues 130 and 131

### DIFF
--- a/bids-validator/tests/tsv.spec.js
+++ b/bids-validator/tests/tsv.spec.js
@@ -527,6 +527,26 @@ describe('TSV', function() {
     })
   })
 
+  it('should return a string value for evidence for issue 130', function() {
+    const tsv =
+      'name\ttype\tunits\tlow_cutoff\thigh_cutoff\tstatus\n' +
+      'value-name\teeg\tmV\tvalue-lowcut\tvalue-highcut\tgood'
+    validate.TSV.TSV(channelsFileEEG, tsv, [], function(issues) {
+      assert(issues.length === 1 && issues[0].code === 130)
+      expect(typeof issues[0].evidence).toBe('string')
+    })
+  })
+
+  it('should return a string value for evidence for issue 131', function() {
+    const tsv =
+      'name\ttype\tunits\tlow_cutoff\thigh_cutoff\tstatus\n' +
+      'value-name\tMEEG\tmV\tvalue-lowcut\tvalue-highcut\tgood'
+    validate.TSV.TSV(channelsFileIEEG, tsv, [], function(issues) {
+      assert(issues.length === 1 && issues[0].code === 131)
+      expect(typeof issues[0].evidence).toBe('string')
+    })
+  })
+
   it('should not allow EEG channels.tsv files with value other than accepted values in type column', function() {
     var tsv =
       'name\ttype\tunits\tlow_cutoff\thigh_cutoff\tstatus\n' +

--- a/bids-validator/validators/tsv/checkTypeCol.js
+++ b/bids-validator/validators/tsv/checkTypeCol.js
@@ -77,7 +77,7 @@ const checkTypeCol = function(rows, file, issues) {
         issues.push(
           new Issue({
             file: file,
-            evidence: line,
+            evidence: line.join(', '),
             line: i + 1,
             reason:
               'the type column values should only consist of values specified for *_channels.tsv file',
@@ -89,7 +89,7 @@ const checkTypeCol = function(rows, file, issues) {
         issues.push(
           new Issue({
             file: file,
-            evidence: line,
+            evidence: line.join(', '),
             line: i + 1,
             reason: 'the type column values upper-cased',
             code: 130,


### PR DESCRIPTION
Issues 130 and 131 return an array for evidence which isn't understood by OpenNeuro, this fixes missing validation data for ds002034.