### PR TITLE
[SCHEMA] Add test for valid_headers and enable .bidsignore rule handling

### DIFF
--- a/bids-validator/src/compat/fulltest.ts
+++ b/bids-validator/src/compat/fulltest.ts
@@ -16,7 +16,7 @@ export async function fullTestAdapter(
   options: ValidatorOptions,
 ): Promise<FullTestAdapterReturn> {
   const fileList: Array<AdapterFile> = []
-  for await (const context of walkFileTree(tree)) {
+  for await (const context of walkFileTree(tree, undefined)) {
     const stream = await context.file.stream
     const file = new AdapterFile(context.datasetPath, context.file, stream)
     fileList.push(file)

--- a/bids-validator/src/deps/ignore.ts
+++ b/bids-validator/src/deps/ignore.ts
@@ -1,0 +1,2 @@
+export { default as ignore } from 'https://esm.sh/ignore@5.2.0'
+export type { Ignore } from 'https://esm.sh/ignore@5.2.0'

--- a/bids-validator/src/files/deno.test.ts
+++ b/bids-validator/src/files/deno.test.ts
@@ -3,6 +3,7 @@ import { readAll, readerFromStreamReader } from '../deps/stream.ts'
 import { dirname, basename, join } from '../deps/path.ts'
 import { BIDSFileDeno } from './deno.ts'
 import { requestReadPermission } from '../setup/requestPermissions.ts'
+import { FileIgnoreRulesDeno } from './ignore.ts'
 
 await requestReadPermission()
 
@@ -11,19 +12,20 @@ const testUrl = import.meta.url
 const testPath = testUrl.slice('file://'.length)
 const testDir = dirname(testPath)
 const testFilename = basename(testPath)
+const ignore = new FileIgnoreRulesDeno([])
 
 Deno.test('Deno implementation of BIDSFile', async (t) => {
   await t.step('implements basic file properties', () => {
-    const file = new BIDSFileDeno(testDir, testFilename)
+    const file = new BIDSFileDeno(testDir, testFilename, ignore)
     assertEquals(join(testDir, file.path), testPath)
   })
   await t.step('implements correct file size', async () => {
     const { size } = await Deno.stat(testPath)
-    const file = new BIDSFileDeno(testDir, testFilename)
+    const file = new BIDSFileDeno(testDir, testFilename, ignore)
     assertEquals(await file.size, size)
   })
   await t.step('can be read as ReadableStream', async () => {
-    const file = new BIDSFileDeno(testDir, testFilename)
+    const file = new BIDSFileDeno(testDir, testFilename, ignore)
     const stream = await file.stream
     const streamReader = stream.getReader()
     const denoReader = readerFromStreamReader(streamReader)

--- a/bids-validator/src/files/ignore.test.ts
+++ b/bids-validator/src/files/ignore.test.ts
@@ -14,7 +14,7 @@ Deno.test('Deno implementation of FileIgnoreRules', async (t) => {
     ]
     const rules = ['.git', '**/*.xyz']
     const ignore = new FileIgnoreRulesDeno(rules)
-    const filtered = files.filter((path) => ignore.test(path))
+    const filtered = files.filter((path) => !ignore.test(path))
     assertEquals(filtered, [
       '/sub-01/anat/sub-01_T1w.nii.gz',
       '/dataset_description.json',

--- a/bids-validator/src/files/ignore.test.ts
+++ b/bids-validator/src/files/ignore.test.ts
@@ -1,0 +1,26 @@
+import { assertEquals } from '../deps/asserts.ts'
+import { FileIgnoreRulesDeno } from './ignore.ts'
+
+Deno.test('Deno implementation of FileIgnoreRules', async (t) => {
+  await t.step('handles basic .bidsignore rules', () => {
+    const files = [
+      '/sub-01/anat/sub-01_T1w.nii.gz',
+      '/dataset_description.json',
+      '/README',
+      '/CHANGES',
+      '/participants.tsv',
+      '/.git/HEAD',
+      '/sub-01/anat/non-bidsy-file.xyz',
+    ]
+    const rules = ['.git', '**/*.xyz']
+    const ignore = new FileIgnoreRulesDeno(rules)
+    const filtered = files.filter((path) => ignore.test(path))
+    assertEquals(filtered, [
+      '/sub-01/anat/sub-01_T1w.nii.gz',
+      '/dataset_description.json',
+      '/README',
+      '/CHANGES',
+      '/participants.tsv',
+    ])
+  })
+})

--- a/bids-validator/src/files/ignore.ts
+++ b/bids-validator/src/files/ignore.ts
@@ -1,0 +1,19 @@
+import { ignore, Ignore } from '../deps/ignore.ts'
+import { FileIgnoreRules } from '../types/ignore.ts'
+
+/**
+ * Deno implementation of .bidsignore style rules
+ */
+export class FileIgnoreRulesDeno implements FileIgnoreRules {
+  #ignore: Ignore
+
+  constructor(config: string[]) {
+    this.#ignore = ignore({ allowRelativePaths: true })
+    this.#ignore.add(config)
+  }
+
+  /** Test if a dataset relative path should be ignored given configured rules */
+  test(path: string): boolean {
+    return !this.#ignore.ignores(path)
+  }
+}

--- a/bids-validator/src/files/ignore.ts
+++ b/bids-validator/src/files/ignore.ts
@@ -1,5 +1,20 @@
+import { BIDSFile } from '../types/file.ts'
 import { ignore, Ignore } from '../deps/ignore.ts'
 import { FileIgnoreRules } from '../types/ignore.ts'
+
+export async function readBidsIgnore(file: BIDSFile) {
+  const fileStream = await file.stream
+  const reader = fileStream
+    .pipeThrough(new TextDecoderStream('utf-8'))
+    .getReader()
+  const { value } = await reader.read()
+  if (value) {
+    const lines = value.split('\n')
+    return lines
+  } else {
+    return []
+  }
+}
 
 /**
  * Deno implementation of .bidsignore style rules
@@ -12,8 +27,12 @@ export class FileIgnoreRulesDeno implements FileIgnoreRules {
     this.#ignore.add(config)
   }
 
+  add(config: string[]): void {
+    this.#ignore.add(config)
+  }
+
   /** Test if a dataset relative path should be ignored given configured rules */
   test(path: string): boolean {
-    return !this.#ignore.ignores(path)
+    return this.#ignore.ignores(path)
   }
 }

--- a/bids-validator/src/issues/datasetIssues.ts
+++ b/bids-validator/src/issues/datasetIssues.ts
@@ -77,6 +77,13 @@ export class DatasetIssues {
     }
   }
 
+  /**
+   * Proxy to internal issues map
+   */
+  get(key: string): Issue | undefined {
+    return this.issues.get(key)
+  }
+
   // Shorthand to test if an issue has occurred
   hasIssue({ key }: { key: string }): boolean {
     if (this.issues.has(key)) {

--- a/bids-validator/src/issues/index.ts
+++ b/bids-validator/src/issues/index.ts
@@ -1,4 +1,0 @@
-import { DatasetIssues } from './datasetIssues.ts'
-
-/** Singleton for DatasetIssues class for the active validation run */
-export const issues = new DatasetIssues()

--- a/bids-validator/src/issues/list.ts
+++ b/bids-validator/src/issues/list.ts
@@ -24,6 +24,17 @@ export const filenameIssues: IssueDefinitionRecord = {
     reason:
       'The datatype directory does not match datatype of found suffix and extension',
   },
+  NOT_INCLUDED: {
+    severity: 'error',
+    reason:
+      'Files with such naming scheme are not part of BIDS specification. This error is most commonly ' +
+      'caused by typos in file names that make them not BIDS compatible. Please consult the specification and ' +
+      'make sure your files are named correctly. If this is not a file naming issue (for example when including ' +
+      'files not yet covered by the BIDS specification) you should include a ".bidsignore" file in your dataset (see' +
+      ' https://github.com/bids-standard/bids-validator#bidsignore for details). Please ' +
+      'note that derived (processed) data should be placed in /derivatives folder and source data (such as DICOMS ' +
+      'or behavioural logs in proprietary formats) should be placed in the /sourcedata folder.',
+  },
 }
 
 export const nonSchemaIssues = { ...filenameIssues }

--- a/bids-validator/src/main.ts
+++ b/bids-validator/src/main.ts
@@ -3,7 +3,6 @@ import { readFileTree } from './files/deno.ts'
 import { resolve } from './deps/path.ts'
 import { fullTestAdapter } from './compat/fulltest.ts'
 import { validate } from './validators/bids.ts'
-import { issues } from './issues/index.ts'
 
 function inspect(obj: any) {
   console.log(
@@ -20,18 +19,18 @@ async function main() {
   const tree = await readFileTree(absolutePath)
 
   // Run the schema based validator
-  await validate(tree)
+  const schemaResult = await validate(tree)
 
   if (options.schemaOnly) {
-    inspect(issues.issues)
+    inspect(schemaResult.issues.issues)
     // TODO - generate a summary without the old validator
   } else {
-    const output = issues.formatOutput()
-    const result = await fullTestAdapter(tree, options)
-    output.errors.push(...result.issues.errors)
-    output.warnings.push(...result.issues.warnings)
+    const output = schemaResult.issues.formatOutput()
+    const legacyResult = await fullTestAdapter(tree, options)
+    output.errors.push(...legacyResult.issues.errors)
+    output.warnings.push(...legacyResult.issues.warnings)
     inspect(output)
-    inspect(result.summary)
+    inspect(legacyResult.summary)
   }
 }
 

--- a/bids-validator/src/schema/context.ts
+++ b/bids-validator/src/schema/context.ts
@@ -38,8 +38,8 @@ export class BIDSContext implements Context {
     this.entities = bidsEntities.entities
     this.dataset = {} as ContextDataset
     this.subject = {} as ContextSubject
-    this.datatype = 'unimplemented'
-    this.modality = 'unimplemented'
+    this.datatype = ''
+    this.modality = ''
     this.sidecar = {}
     this.associations = {} as ContextAssociations
     this.columns = {}

--- a/bids-validator/src/schema/context.ts
+++ b/bids-validator/src/schema/context.ts
@@ -8,10 +8,12 @@ import {
 import { BIDSFile } from '../types/file.ts'
 import { FileTree } from '../types/filetree.ts'
 import { BIDSEntities, readEntities } from './entities.ts'
+import { DatasetIssues } from '../issues/datasetIssues.ts'
 
 export class BIDSContext implements Context {
   // Internal representation of the file tree
   #fileTree: FileTree
+  issues: DatasetIssues
   file: BIDSFile
   suffix: string
   extension: string
@@ -26,8 +28,9 @@ export class BIDSContext implements Context {
   json: object
   nifti_header: ContextNiftiHeader
 
-  constructor(fileTree: FileTree, file: BIDSFile) {
+  constructor(fileTree: FileTree, file: BIDSFile, issues: DatasetIssues) {
     this.#fileTree = fileTree
+    this.issues = issues
     this.file = file
     const bidsEntities = readEntities(file)
     this.suffix = bidsEntities.suffix

--- a/bids-validator/src/schema/walk.test.ts
+++ b/bids-validator/src/schema/walk.test.ts
@@ -1,6 +1,7 @@
 import { assert, assertEquals } from '../deps/asserts.ts'
 import { BIDSContext } from './context.ts'
 import { walkFileTree } from './walk.ts'
+import { DatasetIssues } from '../issues/datasetIssues.ts'
 import {
   simpleDataset,
   simpleDatasetFileCount,
@@ -8,7 +9,8 @@ import {
 
 Deno.test('file tree walking', async (t) => {
   await t.step('visits each file and creates a BIDSContext', async () => {
-    for await (const context of walkFileTree(simpleDataset)) {
+    const issues = new DatasetIssues()
+    for await (const context of walkFileTree(simpleDataset, issues)) {
       assert(
         context instanceof BIDSContext,
         'walk file tree did not return a BIDSContext',
@@ -16,8 +18,9 @@ Deno.test('file tree walking', async (t) => {
     }
   })
   await t.step('visits every file expected', async () => {
+    const issues = new DatasetIssues()
     let accumulator = 0
-    for await (const context of walkFileTree(simpleDataset)) {
+    for await (const context of walkFileTree(simpleDataset, issues)) {
       assert(
         context instanceof BIDSContext,
         'walk file tree did not return a BIDSContext',

--- a/bids-validator/src/schema/walk.ts
+++ b/bids-validator/src/schema/walk.ts
@@ -1,22 +1,25 @@
 import { BIDSContext } from './context.ts'
 import { FileTree } from '../types/filetree.ts'
+import { DatasetIssues } from '../issues/datasetIssues.ts'
 
 /** Recursive algorithm for visiting each file in the dataset, creating a context */
 export async function* _walkFileTree(
   fileTree: FileTree,
   root: FileTree,
+  issues: DatasetIssues,
 ): AsyncIterable<BIDSContext> {
   for (const file of fileTree.files) {
-    yield new BIDSContext(root, file)
+    yield new BIDSContext(root, file, issues)
   }
   for (const dir of fileTree.directories) {
-    yield* _walkFileTree(dir, root)
+    yield* _walkFileTree(dir, root, issues)
   }
 }
 
 /** Walk all files in the dataset and construct a context for each one */
 export async function* walkFileTree(
   fileTree: FileTree,
+  issues: DatasetIssues,
 ): AsyncIterable<BIDSContext> {
-  yield* _walkFileTree(fileTree, fileTree)
+  yield* _walkFileTree(fileTree, fileTree, issues)
 }

--- a/bids-validator/src/tests/local/common.ts
+++ b/bids-validator/src/tests/local/common.ts
@@ -1,0 +1,23 @@
+import { readFileTree } from '../../files/deno.ts'
+import { FileTree } from '../../types/filetree.ts'
+import { validate } from '../../validators/bids.ts'
+import { ValidationResult } from '../../types/validation-result.ts'
+import { DatasetIssues } from '../../issues/datasetIssues.ts'
+
+export async function validatePath(
+  t: Deno.TestContext,
+  path: string,
+): Promise<{ tree: FileTree; result: ValidationResult }> {
+  let tree: FileTree = new FileTree('', '')
+  let result: ValidationResult = { issues: new DatasetIssues(), summary: {} }
+
+  await t.step('file tree is read', async () => {
+    tree = await readFileTree(path)
+  })
+
+  await t.step('completes validation', async () => {
+    result = await validate(tree)
+  })
+
+  return { tree, result }
+}

--- a/bids-validator/src/tests/local/valid_headers.test.ts
+++ b/bids-validator/src/tests/local/valid_headers.test.ts
@@ -1,0 +1,13 @@
+// Deno runtime tests for tests/data/valid_headers
+import { assert } from '../../deps/asserts.ts'
+import { validatePath } from './common.ts'
+
+const PATH = 'tests/data/valid_headers'
+
+Deno.test('valid_headers dataset', async (t) => {
+  const { tree, result } = await validatePath(t, PATH)
+
+  await t.step('correctly ignores .bidsignore files', () => {
+    assert(result.issues.get('NOT_INCLUDED') === undefined)
+  })
+})

--- a/bids-validator/src/types/filetree.ts
+++ b/bids-validator/src/types/filetree.ts
@@ -2,7 +2,6 @@
  * Abstract FileTree for all environments (Deno, Browser, Python)
  */
 import { BIDSFile } from '../types/file.ts'
-import { FileIgnoreRules } from './ignore.ts'
 
 export class FileTree {
   // Relative path to this FileTree location
@@ -12,20 +11,12 @@ export class FileTree {
   files: BIDSFile[]
   directories: FileTree[]
   parent?: FileTree
-  // Reference to the .bidsignore (or configuration provided) rules
-  ignore?: FileIgnoreRules
 
-  constructor(
-    path: string,
-    name: string,
-    parent?: FileTree,
-    ignore?: FileIgnoreRules,
-  ) {
+  constructor(path: string, name: string, parent?: FileTree) {
     this.path = path
     this.files = []
     this.directories = []
     this.name = name
     this.parent = parent
-    this.ignore = ignore
   }
 }

--- a/bids-validator/src/types/filetree.ts
+++ b/bids-validator/src/types/filetree.ts
@@ -2,6 +2,7 @@
  * Abstract FileTree for all environments (Deno, Browser, Python)
  */
 import { BIDSFile } from '../types/file.ts'
+import { FileIgnoreRules } from './ignore.ts'
 
 export class FileTree {
   // Relative path to this FileTree location
@@ -11,12 +12,20 @@ export class FileTree {
   files: BIDSFile[]
   directories: FileTree[]
   parent?: FileTree
+  // Reference to the .bidsignore (or configuration provided) rules
+  ignore?: FileIgnoreRules
 
-  constructor(path: string, name: string, parent?: FileTree) {
+  constructor(
+    path: string,
+    name: string,
+    parent?: FileTree,
+    ignore?: FileIgnoreRules,
+  ) {
     this.path = path
     this.files = []
     this.directories = []
     this.name = name
     this.parent = parent
+    this.ignore = ignore
   }
 }

--- a/bids-validator/src/types/ignore.ts
+++ b/bids-validator/src/types/ignore.ts
@@ -1,0 +1,6 @@
+/**
+ * Abstract .bidsignore handler
+ */
+export interface FileIgnoreRules {
+  test: (path: string) => boolean
+}

--- a/bids-validator/src/types/ignore.ts
+++ b/bids-validator/src/types/ignore.ts
@@ -2,5 +2,6 @@
  * Abstract .bidsignore handler
  */
 export interface FileIgnoreRules {
+  add: (config: string[]) => void
   test: (path: string) => boolean
 }

--- a/bids-validator/src/types/validation-result.ts
+++ b/bids-validator/src/types/validation-result.ts
@@ -1,0 +1,9 @@
+import { DatasetIssues } from '../issues/datasetIssues.ts'
+
+/**
+ * The output of a validation run
+ */
+export interface ValidationResult {
+  issues: DatasetIssues
+  summary: Record<string, any>
+}

--- a/bids-validator/src/validators/bids.ts
+++ b/bids-validator/src/validators/bids.ts
@@ -9,14 +9,18 @@ import {
   isAtRoot,
   isTopLevel,
 } from './filenames.ts'
+import { DatasetIssues } from '../issues/datasetIssues.ts'
+import { ValidationResult } from '../types/validation-result.ts'
 
 /**
  * Full BIDS schema validation entrypoint
  */
-export async function validate(fileTree: FileTree): Promise<void> {
-  const issues = []
+export async function validate(fileTree: FileTree): Promise<ValidationResult> {
+  const issues = new DatasetIssues()
+  // TODO - summary should be implemented in pure schema mode
+  const summary = {}
   const schema = await loadSchema()
-  for await (const context of walkFileTree(fileTree)) {
+  for await (const context of walkFileTree(fileTree, issues)) {
     if (isAssociatedData(schema, context.file.path)) {
       continue
     }
@@ -25,5 +29,9 @@ export async function validate(fileTree: FileTree): Promise<void> {
       checkLabelFormat(schema, context)
     }
     applyRules(schema, context)
+  }
+  return {
+    issues,
+    summary,
   }
 }

--- a/bids-validator/src/validators/bids.ts
+++ b/bids-validator/src/validators/bids.ts
@@ -21,6 +21,10 @@ export async function validate(fileTree: FileTree): Promise<ValidationResult> {
   const summary = {}
   const schema = await loadSchema()
   for await (const context of walkFileTree(fileTree, issues)) {
+    // TODO - Skip ignored files for now (some tests may reference ignored files)
+    if (context.file.ignored) {
+      continue
+    }
     if (isAssociatedData(schema, context.file.path)) {
       continue
     }

--- a/bids-validator/src/validators/filenames.test.ts
+++ b/bids-validator/src/validators/filenames.test.ts
@@ -8,7 +8,7 @@ import {
 } from './filenames.ts'
 import { loadSchema } from '../setup/loadSchema.ts'
 import { readEntities } from '../schema/entities.ts'
-import { issues } from '../issues/index.ts'
+import { DatasetIssues } from '../issues/datasetIssues.ts'
 
 const schema = await loadSchema()
 
@@ -16,6 +16,7 @@ const newContext = (path: string) => {
   const parts = path.split(SEP)
   const name = parts[parts.length - 1]
   return {
+    issues: new DatasetIssues(),
     file: {
       path: path,
       name: name,
@@ -47,7 +48,7 @@ Deno.test('test checkDatatype', (t) => {
     let context = newContext(test[0])
     context = { ...context, ...readEntities(context.file) }
     checkDatatypes(schema, context)
-    assertEquals(issues.fileInIssues(test[0]), test[1])
+    assertEquals(context.issues.fileInIssues(test[0]), test[1])
   })
 })
 
@@ -61,6 +62,9 @@ Deno.test('test checkLabelFormat', (t) => {
     let context = newContext(test[0])
     context = { ...context, ...readEntities(context.file) }
     checkLabelFormat(schema, context)
-    assertEquals(issues.getFileIssueKeys(test[0]).includes(code), test[1])
+    assertEquals(
+      context.issues.getFileIssueKeys(test[0]).includes(code),
+      test[1],
+    )
   })
 })

--- a/bids-validator/src/validators/filenames.ts
+++ b/bids-validator/src/validators/filenames.ts
@@ -3,7 +3,6 @@ import { SEP } from '../deps/path.ts'
 import { Schema } from '../types/schema.ts'
 import { BIDSContext } from '../schema/context.ts'
 import { lookupModality } from '../schema/modalities.ts'
-import { issues } from '../issues/index.ts'
 
 // This should be defined in the schema
 const sidecarExtensions = ['.json', '.tsv', '.bvec', '.bval']
@@ -67,7 +66,7 @@ export function validateFilenameAgainstRule(
     rule.datatypes &&
     !rule.datatypes.includes(context.datatype)
   ) {
-    issues.addNonSchemaIssue('DATATYPE_MISMATCH', [
+    context.issues.addNonSchemaIssue('DATATYPE_MISMATCH', [
       { ...context.file, evidence: `Datatype rule being applied: ${rule}` },
     ])
   }
@@ -81,7 +80,7 @@ export function validateFilenameAgainstRule(
   )
 
   if (fileNoLabelEntities.length) {
-    issues.addNonSchemaIssue('ENTITY_WITH_NO_LABEL', [
+    context.issues.addNonSchemaIssue('ENTITY_WITH_NO_LABEL', [
       { ...context.file, evidence: fileNoLabelEntities.join(', ') },
     ])
   }
@@ -103,7 +102,7 @@ export function validateFilenameAgainstRule(
     )
 
     if (missingRequired.length) {
-      issues.addNonSchemaIssue('MISSING_REQUIRED_ENTITY', [
+      context.issues.addNonSchemaIssue('MISSING_REQUIRED_ENTITY', [
         { ...context.file, evidence: missingRequired.join(', ') },
       ])
     }
@@ -118,7 +117,7 @@ export function validateFilenameAgainstRule(
   )
 
   if (entityNotInRule.length) {
-    issues.addNonSchemaIssue('ENTITY_NOT_IN_RULE', [
+    context.issues.addNonSchemaIssue('ENTITY_NOT_IN_RULE', [
       { ...context.file, evidence: entityNotInRule.join(', ') },
     ])
   }
@@ -189,7 +188,7 @@ export function checkLabelFormat(schema: Schema, context: BIDSContext) {
       const rePattern = new RegExp(`^${pattern}$`)
       const label = context.entities[fileEntity]
       if (!rePattern.test(label)) {
-        issues.addNonSchemaIssue('INVALID_ENTITY_LABEL', [
+        context.issues.addNonSchemaIssue('INVALID_ENTITY_LABEL', [
           {
             ...context.file,
             evidence: `entity: ${fileEntity} label: ${label} pattern: ${pattern}`,

--- a/bids-validator/src/validators/filenames.ts
+++ b/bids-validator/src/validators/filenames.ts
@@ -23,7 +23,7 @@ export function checkDatatypes(schema: Schema, context: BIDSContext) {
   /* If we can't find a datatype in the directory names, and match a rule
    * for that datatype we might want to see if there are any rules for any
    * datatype that we may be able to match against. Certain suffixes are
-   * used across datatypes so its conievable we could have multiple possible
+   * used across datatypes so its conceivable we could have multiple possible
    * matches. Sidecars at root of dataset also fall into this category.
    */
   if (matchedRule === '') {
@@ -93,7 +93,7 @@ export function validateFilenameAgainstRule(
   // skip required entity checks if file is at root.
   // No requirements for inherited sidecars at this level.
   if (!fileIsAtRoot) {
-    let ruleEntitiesRequired = Object.entries(rule.entities)
+    const ruleEntitiesRequired = Object.entries(rule.entities)
       .filter(([_, v]) => v === 'required')
       .map(([k, _]) => lookupEntityLiteral(k, schema))
 

--- a/bids-validator/src/validators/filenames.ts
+++ b/bids-validator/src/validators/filenames.ts
@@ -40,6 +40,8 @@ export function checkDatatypes(schema: Schema, context: BIDSContext) {
     }
     /**
      * If nothing matches, this is an unrecognizable filename and should throw the general error
+     *
+     * Special case for .bidsignore which is not defined by the specification schema
      */
     if (matchedRule === undefined && context.file.path !== '/.bidsignore') {
       context.issues.addNonSchemaIssue('NOT_INCLUDED', [context.file])

--- a/bids-validator/src/validators/filenames.ts
+++ b/bids-validator/src/validators/filenames.ts
@@ -9,7 +9,7 @@ const sidecarExtensions = ['.json', '.tsv', '.bvec', '.bval']
 
 export function checkDatatypes(schema: Schema, context: BIDSContext) {
   delete schema.rules.datatypes.derivatives
-  let matchedRule = ''
+  let matchedRule
   datatypeFromDirectory(schema, context)
   if (schema.rules.datatypes.hasOwnProperty(context.datatype)) {
     const rules = schema.rules.datatypes[context.datatype]
@@ -26,7 +26,7 @@ export function checkDatatypes(schema: Schema, context: BIDSContext) {
    * used across datatypes so its conceivable we could have multiple possible
    * matches. Sidecars at root of dataset also fall into this category.
    */
-  if (matchedRule === '') {
+  if (matchedRule === undefined) {
     const possibleDatatypes = new Set()
     const datatypes = Object.values(schema.rules.datatypes)
     for (const rules of datatypes) {
@@ -37,6 +37,12 @@ export function checkDatatypes(schema: Schema, context: BIDSContext) {
           break
         }
       }
+    }
+    /**
+     * If nothing matches, this is an unrecognizable filename and should throw the general error
+     */
+    if (matchedRule === undefined && context.file.path !== '/.bidsignore') {
+      context.issues.addNonSchemaIssue('NOT_INCLUDED', [context.file])
     }
   }
 }


### PR DESCRIPTION
Builds on #1475 

This is the start of test coverage for the datasets in tests/data including bids-examples. The one test that's implemented just checks that the valid_headers dataset doesn't crash and that the one .bidsignore file is actually ignored.