### PR TITLE
[SCHEMA] tests: Add integration tests for summary and empty_files using example datasets

### DIFF
--- a/bids-validator/src/tests/local/empty_files.test.ts
+++ b/bids-validator/src/tests/local/empty_files.test.ts
@@ -1,0 +1,47 @@
+// Deno runtime tests for tests/data/empty_files
+import { assert, assertEquals, assertObjectMatch } from '../../deps/asserts.ts'
+import { validatePath } from './common.ts'
+
+const PATH = 'tests/data/empty_files'
+
+/**
+ * Contains stripped down CTF format dataset: Both, BadChannels and
+ * bad.segments files can be empty and still valid. Everything else must
+ * not be empty.
+ */
+Deno.test('empty_files dataset', async (t) => {
+  const { tree, result } = await validatePath(t, PATH)
+
+  await t.step('correctly ignores .bidsignore files', () => {
+    assert(
+      result.issues.get('NOT_INCLUDED') === undefined,
+      'NOT_INCLUDED error should not be present',
+    )
+  })
+
+  // *.meg4 and BadChannels files are empty. But only *.meg4 is an issue
+  await t.step(
+    'EMPTY_FILES error is thrown for only sub-0001_task-AEF_run-01_meg.meg4',
+    () => {
+      const issue = result.issues.get('EMPTY_FILE')
+      assert(issue, 'EMPTY_FILES was not thrown as expected')
+      assertObjectMatch(issue, {
+        key: 'EMPTY_FILE',
+        severity: 'error',
+      })
+      assert(
+        issue.files.get(
+          'sub-0001/meg/sub-0001_task-AEF_run-01_meg.ds/sub-0001_task-AEF_run-01_meg.meg4',
+        ),
+        'sub-0001_task-AEF_run-01_meg.meg4 is empty but not present in EMPTY_FILE issue',
+      )
+      assertEquals(
+        issue.files.get(
+          'tests/data/empty_files/sub-0001/meg/sub-0001_task-AEF_run-01_meg.ds/BadChannels',
+        ),
+        undefined,
+        'BadChannels should not be included in EMPTY_FILES error',
+      )
+    },
+  )
+})

--- a/bids-validator/src/tests/local/valid_dataset.test.ts
+++ b/bids-validator/src/tests/local/valid_dataset.test.ts
@@ -1,0 +1,16 @@
+// Deno runtime tests for tests/data/valid_dataset
+import { assert, assertEquals } from '../../deps/asserts.ts'
+import { validatePath } from './common.ts'
+
+const PATH = 'tests/data/valid_dataset'
+
+Deno.test('valid_dataset dataset', async (t) => {
+  const { tree, result } = await validatePath(t, PATH)
+
+  await t.step('correctly ignores .bidsignore files', () => {
+    assert(
+      result.issues.get('NOT_INCLUDED') === undefined,
+      'NOT_INCLUDED error should not be present',
+    )
+  })
+})

--- a/bids-validator/src/tests/local/valid_filenames.test.ts
+++ b/bids-validator/src/tests/local/valid_filenames.test.ts
@@ -1,0 +1,16 @@
+// Deno runtime tests for tests/data/valid_filenames
+import { assert, assertEquals } from '../../deps/asserts.ts'
+import { validatePath } from './common.ts'
+
+const PATH = 'tests/data/valid_filenames'
+
+Deno.test('valid_filenames dataset', async (t) => {
+  const { tree, result } = await validatePath(t, PATH)
+
+  await t.step('correctly ignores .bidsignore files', () => {
+    assert(
+      result.issues.get('NOT_INCLUDED') === undefined,
+      'NOT_INCLUDED error should not be present',
+    )
+  })
+})

--- a/bids-validator/src/tests/local/valid_headers.test.ts
+++ b/bids-validator/src/tests/local/valid_headers.test.ts
@@ -1,5 +1,5 @@
 // Deno runtime tests for tests/data/valid_headers
-import { assert } from '../../deps/asserts.ts'
+import { assert, assertEquals } from '../../deps/asserts.ts'
 import { validatePath } from './common.ts'
 
 const PATH = 'tests/data/valid_headers'
@@ -8,6 +8,33 @@ Deno.test('valid_headers dataset', async (t) => {
   const { tree, result } = await validatePath(t, PATH)
 
   await t.step('correctly ignores .bidsignore files', () => {
-    assert(result.issues.get('NOT_INCLUDED') === undefined)
+    assert(
+      result.issues.get('NOT_INCLUDED') === undefined,
+      'NOT_INCLUDED error should not be present',
+    )
+  })
+
+  await t.step('summary has correct tasks', () => {
+    assertEquals(result.summary.tasks, ['rhyme judgment'])
+  })
+
+  await t.step('summary has correct dataProcessed', () => {
+    assertEquals(result.summary.dataProcessed, ['rhyme judgment'])
+  })
+
+  await t.step('summary has correct dataProcessed', () => {
+    assertEquals(result.summary.modalities, ['MRI'])
+  })
+
+  await t.step('summary has correct totalFiles', () => {
+    assertEquals(result.summary.totalFiles, 8)
+  })
+
+  await t.step('summary has correct subjectMetadata', () => {
+    assertEquals(result.summary.subjectMetadata[0], {
+      age: 25,
+      participantId: '01',
+      sex: 'M',
+    })
   })
 })


### PR DESCRIPTION
Most of the new tests here are failing intentionally to provide useful targets for implementation.