### PR TITLE
[SCHEMA] feat: Add .text() method to BIDSFileDeno for quickly accessing full text

### DIFF
--- a/bids-validator/src/files/deno.test.ts
+++ b/bids-validator/src/files/deno.test.ts
@@ -26,10 +26,15 @@ Deno.test('Deno implementation of BIDSFile', async (t) => {
   })
   await t.step('can be read as ReadableStream', async () => {
     const file = new BIDSFileDeno(testDir, testFilename, ignore)
-    const stream = await file.stream
+    const stream = file.stream
     const streamReader = stream.getReader()
     const denoReader = readerFromStreamReader(streamReader)
     const fileBuffer = await readAll(denoReader)
     assertEquals(await file.size, fileBuffer.length)
+  })
+  await t.step('can be read with .text() method', async () => {
+    const file = new BIDSFileDeno(testDir, testFilename, ignore)
+    const text = await file.text()
+    assertEquals(await file.size, text.length)
   })
 })

--- a/bids-validator/src/files/ignore.ts
+++ b/bids-validator/src/files/ignore.ts
@@ -3,11 +3,7 @@ import { ignore, Ignore } from '../deps/ignore.ts'
 import { FileIgnoreRules } from '../types/ignore.ts'
 
 export async function readBidsIgnore(file: BIDSFile) {
-  const fileStream = await file.stream
-  const reader = fileStream
-    .pipeThrough(new TextDecoderStream('utf-8'))
-    .getReader()
-  const { value } = await reader.read()
+  const value = await file.text()
   if (value) {
     const lines = value.split('\n')
     return lines

--- a/bids-validator/src/issues/datasetIssues.test.ts
+++ b/bids-validator/src/issues/datasetIssues.test.ts
@@ -16,20 +16,23 @@ Deno.test('DatasetIssues management class', async (t) => {
     // This mostly tests the issueFile mapping function
     const issues = new DatasetIssues()
     const testStream = new ReadableStream()
+    const text = () => Promise.resolve('')
     const files = [
       {
+        text,
         name: 'dataset_description.json',
         path: '/dataset_description.json',
-        size: Promise.resolve(500),
+        size: 500,
         ignored: false,
-        stream: Promise.resolve(testStream),
+        stream: testStream,
       } as BIDSFile,
       {
+        text,
         name: 'README',
         path: '/README',
-        size: Promise.resolve(500),
+        size: 500,
         ignored: false,
-        stream: Promise.resolve(testStream),
+        stream: testStream,
         line: 1,
         character: 5,
         severity: 'warning',

--- a/bids-validator/src/schema/entities.test.ts
+++ b/bids-validator/src/schema/entities.test.ts
@@ -6,9 +6,10 @@ Deno.test('test readEntities', async (t) => {
   const testFile = {
     name: 'task-rhymejudgment_bold.json',
     path: '/task-rhymejudgment_bold.json',
-    size: null as unknown as Promise<number>,
+    size: null as unknown as number,
     ignored: false,
-    stream: null as unknown as Promise<ReadableStream<Uint8Array>>,
+    stream: null as unknown as ReadableStream<Uint8Array>,
+    text: () => Promise.resolve(''),
   }
   const context = readEntities(testFile)
   assert(context.suffix === 'bold', 'failed to match suffix')

--- a/bids-validator/src/tests/simple-dataset.ts
+++ b/bids-validator/src/tests/simple-dataset.ts
@@ -1,48 +1,55 @@
 import { FileTree } from '../types/filetree.ts'
 
+const text = () => Promise.resolve('')
+
 // Very basic dataset modeled for tests
 const rootFileTree = new FileTree('/', '')
 const subjectFileTree = new FileTree('/sub-01', 'sub-01', rootFileTree)
 const anatFileTree = new FileTree('/sub-01/anat', 'anat', subjectFileTree)
 anatFileTree.files = [
   {
+    text,
     path: '/sub-01/anat/sub-01_T1w.nii.gz',
     name: 'sub-01_T1w.nii.gz',
-    size: Promise.resolve(311112),
+    size: 311112,
     ignored: false,
-    stream: Promise.resolve(new ReadableStream()),
+    stream: new ReadableStream<Uint8Array>(),
   },
 ]
 subjectFileTree.files = []
 subjectFileTree.directories = [anatFileTree]
 rootFileTree.files = [
   {
+    text,
     path: '/dataset_description.json',
     name: 'dataset_description.json',
-    size: Promise.resolve(240),
+    size: 240,
     ignored: false,
-    stream: Promise.resolve(new ReadableStream()),
+    stream: new ReadableStream(),
   },
   {
+    text,
     path: '/README',
     name: 'README',
-    size: Promise.resolve(709),
+    size: 709,
     ignored: false,
-    stream: Promise.resolve(new ReadableStream()),
+    stream: new ReadableStream(),
   },
   {
+    text,
     path: '/CHANGES',
     name: 'CHANGES',
-    size: Promise.resolve(39),
+    size: 39,
     ignored: false,
-    stream: Promise.resolve(new ReadableStream()),
+    stream: new ReadableStream(),
   },
   {
+    text,
     path: '/participants.tsv',
     name: 'participants.tsv',
-    size: Promise.resolve(36),
+    size: 36,
     ignored: false,
-    stream: Promise.resolve(new ReadableStream()),
+    stream: new ReadableStream(),
   },
 ]
 rootFileTree.directories = [subjectFileTree]

--- a/bids-validator/src/types/file.ts
+++ b/bids-validator/src/types/file.ts
@@ -9,9 +9,11 @@ export interface BIDSFile {
   // Dataset relative path for the file
   path: string
   // File size in bytes
-  size: Promise<number>
+  size: number
   // BIDS ignore status of the file
   ignored: boolean
   // ReadableStream to file raw contents
-  stream: Promise<ReadableStream<Uint8Array>>
+  stream: ReadableStream<Uint8Array>
+  // Resolve stream to decoded utf-8 text
+  text: () => Promise<string>
 }


### PR DESCRIPTION
Simplifies the main file class to return size/stream as lazy immediate getters and implements a .text() method similar to the fetch API to allow to quickly read in the file as utf-8 text.