### PR TITLE
Add tests against tsv headers to check for duplicate, empty, and 'n/a' values.

### DIFF
--- a/bids-validator/tests/tsv.spec.js
+++ b/bids-validator/tests/tsv.spec.js
@@ -11,14 +11,18 @@ describe('TSV', function() {
   }
 
   it('should not allow empty values saved as empty cells.', function() {
-    var tsv = '1.0\t\t0.2\tresponse 1\t12.32'
+    var tsv =
+      'header-one\theader-two\theader-three\theader-four\theader-five\n' +
+      '1.0\t\t0.2\tresponse 1\t12.32'
     validate.TSV.TSV(file, tsv, [], function(issues) {
       assert(issues.length === 1 && issues[0].code === 23)
     })
   })
 
   it('should not allow missing values that are specified by something other than "n/a".', function() {
-    var tsv = '1.0\tNA\t0.2\tresponse 1\t12.32'
+    var tsv =
+      'header-one\theader-two\theader-three\theader-four\theader-five\n' +
+      'n1.0\tNA\t0.2\tresponse 1\t12.32'
     validate.TSV.TSV(file, tsv, [], function(issues) {
       assert(issues.length === 1 && issues[0].code === 24)
     })

--- a/bids-validator/utils/issues/list.js
+++ b/bids-validator/utils/issues/list.js
@@ -1125,4 +1125,16 @@ export default {
     reason:
       'A BIDS dataset MUST NOT contain more than one `README` file (with or without extension) at its root directory.',
   },
+  229: {
+    key: 'TSV_COLUMN_HEADER_DUPLICATE',
+    severity: 'error',
+    reason:
+      'Two elements in the first row of a TSV are the same. Each column header must be unique.',
+  },
+  230: {
+    key: 'TSV_COLUMN_HEADER_NA',
+    severity: 'error',
+    reason:
+      'An element in a tsv header is "n/a". A different header name should be chosen.',
+  },
 }

--- a/bids-validator/utils/issues/list.js
+++ b/bids-validator/utils/issues/list.js
@@ -1137,4 +1137,16 @@ export default {
     reason:
       "The column names of the EEG channels file must be in the following order ['name', 'type', 'units']",
   },
+  231: {
+    key: 'TSV_COLUMN_HEADER_DUPLICATE',
+    severity: 'error',
+    reason:
+      'Two elements in the first row of a TSV are the same. Each column header must be unique.',
+  },
+  232: {
+    key: 'TSV_COLUMN_HEADER_NA',
+    severity: 'error',
+    reason:
+      'An element in a tsv header is "n/a". A different header name should be chosen.',
+  },
 }

--- a/bids-validator/validators/tsv/__tests__/checkHeaders.spec.js
+++ b/bids-validator/validators/tsv/__tests__/checkHeaders.spec.js
@@ -1,0 +1,35 @@
+import checkHeaders from '../checkHeaders'
+
+describe('checkHeaders()', () => {
+  it('generates issue on duplicate', () => {
+    const issues = []
+    const headers = ['hdr1', 'hdr2', 'hdr1']
+    const mockFile = {}
+    checkHeaders(headers, mockFile, issues)
+    expect(issues).toHaveLength(1)
+    expect(issues[0].code).toBe(231)
+  })
+  it('No issue for unique headers array', () => {
+    const issues = []
+    const headers = ['hdr1', 'hdr2', 'hdr3']
+    const mockFile = {}
+    checkHeaders(headers, mockFile, issues)
+    expect(issues).toHaveLength(0)
+  })
+  it('generates issue on n/a', () => {
+    const issues = []
+    const headers = ['n/a']
+    const mockFile = {}
+    checkHeaders(headers, mockFile, issues)
+    expect(issues).toHaveLength(1)
+    expect(issues[0].code).toBe(232)
+  })
+  it('generates issue on empty header', () => {
+    const issues = []
+    const headers = ['normal', '   ', 'fine']
+    const mockFile = {}
+    checkHeaders(headers, mockFile, issues)
+    expect(issues).toHaveLength(1)
+    expect(issues[0].code).toBe(23)
+  })
+})

--- a/bids-validator/validators/tsv/__tests__/checkHeaders.spec.js
+++ b/bids-validator/validators/tsv/__tests__/checkHeaders.spec.js
@@ -1,0 +1,35 @@
+import checkHeaders from '../checkHeaders'
+
+describe('checkHeaders()', () => {
+  it('generates issue on duplicate', () => {
+    const issues = []
+    const headers = ['hdr1', 'hdr2', 'hdr1']
+    const mockFile = {}
+    checkHeaders(headers, mockFile, issues)
+    expect(issues).toHaveLength(1)
+    expect(issues[0].code).toBe(229)
+  })
+  it('No issue for unique headers array', () => {
+    const issues = []
+    const headers = ['hdr1', 'hdr2', 'hdr3']
+    const mockFile = {}
+    checkHeaders(headers, mockFile, issues)
+    expect(issues).toHaveLength(0)
+  })
+  it('generates issue on n/a', () => {
+    const issues = []
+    const headers = ['n/a']
+    const mockFile = {}
+    checkHeaders(headers, mockFile, issues)
+    expect(issues).toHaveLength(1)
+    expect(issues[0].code).toBe(230)
+  })
+  it('generates issue on empty header', () => {
+    const issues = []
+    const headers = ['normal', '   ', 'fine']
+    const mockFile = {}
+    checkHeaders(headers, mockFile, issues)
+    expect(issues).toHaveLength(1)
+    expect(issues[0].code).toBe(23)
+  })
+})

--- a/bids-validator/validators/tsv/checkHeaders.js
+++ b/bids-validator/validators/tsv/checkHeaders.js
@@ -1,0 +1,42 @@
+import Issue from '../../utils/issues/issue'
+import { headersEvidence } from './tsv'
+
+const checkHeaders = (headers, file, issues) => {
+  headers.map((header, i) => {
+    if (i !== headers.findIndex(x => x === header)) {
+      issues.push(
+        new Issue({
+          file: file,
+          evidence: headersEvidence(headers),
+          line: 1,
+          reason: 'Duplicate value at column #' + (i + 1),
+          code: 231,
+        }),
+      )
+    }
+    if (/^\s*$/.test(header)) {
+      issues.push(
+        new Issue({
+          file: file,
+          evidence: headersEvidence(headers),
+          line: 1,
+          reason: 'Missing value at column # ' + (i + 1),
+          code: 23,
+        }),
+      )
+    }
+    if (header === 'n/a') {
+      issues.push(
+        new Issue({
+          file: file,
+          evidence: headersEvidence(headers),
+          line: 1,
+          reason: 'n/a value in header at column #' + (i + 1),
+          code: 232,
+        }),
+      )
+    }
+  })
+}
+
+export default checkHeaders

--- a/bids-validator/validators/tsv/checkHeaders.js
+++ b/bids-validator/validators/tsv/checkHeaders.js
@@ -1,0 +1,42 @@
+import Issue from '../../utils/issues/issue'
+import { headersEvidence } from './tsv'
+
+const checkHeaders = (headers, file, issues) => {
+  headers.map((header, i) => {
+    if (i !== headers.findIndex(x => x === header)) {
+      issues.push(
+        new Issue({
+          file: file,
+          evidence: headersEvidence(headers),
+          line: 1,
+          reason: 'Duplicate value at column #' + (i + 1),
+          code: 229,
+        }),
+      )
+    }
+    if (/^\s*$/.test(header)) {
+      issues.push(
+        new Issue({
+          file: file,
+          evidence: headersEvidence(headers),
+          line: 1,
+          reason: 'Missing value at column # ' + (i + 1),
+          code: 23,
+        }),
+      )
+    }
+    if (header === 'n/a') {
+      issues.push(
+        new Issue({
+          file: file,
+          evidence: headersEvidence(headers),
+          line: 1,
+          reason: 'n/a value in header at column #' + (i + 1),
+          code: 230,
+        }),
+      )
+    }
+  })
+}
+
+export default checkHeaders

--- a/bids-validator/validators/tsv/tsv.js
+++ b/bids-validator/validators/tsv/tsv.js
@@ -1,6 +1,7 @@
 import Issue from '../../utils/issues/issue'
 import checkAcqTimeFormat from './checkAcqTimeFormat'
 import checkAge89 from './checkAge89'
+import checkHeaders from './checkHeaders'
 import checkStatusCol from './checkStatusCol'
 import checkTypecol from './checkTypeCol'
 import parseTSV from './tsvParser'
@@ -11,7 +12,8 @@ var path = require('path')
  * @param {Array[string]} headers
  * @returns {string}
  */
-const headersEvidence = headers => `Column headers: ${headers.join(', ')}`
+export const headersEvidence = headers =>
+  `Column headers: ${headers.join(', ')}`
 
 /**
  * Format TSV filename for evidence string
@@ -51,6 +53,8 @@ const TSV = (file, contents, fileList, callback) => {
   let columnMismatch = false
   let emptyCells = false
   let NACells = false
+
+  checkHeaders(headers, file, issues)
 
   for (let i = 0; i < rows.length; i++) {
     const values = rows[i]

--- a/bids-validator/validators/tsv/tsv.js
+++ b/bids-validator/validators/tsv/tsv.js
@@ -56,7 +56,7 @@ const TSV = (file, contents, fileList, callback) => {
 
   checkHeaders(headers, file, issues)
 
-  for (let i = 0; i < rows.length; i++) {
+  for (let i = 1; i < rows.length; i++) {
     const values = rows[i]
     const evidence = `row ${i}: ${values.join('\t')}`
     if (values.length === 1 && /^\s*$/.test(values[0])) continue


### PR DESCRIPTION
Fixes #1465