### PR TITLE
[SCHEMA] tests: Validate BOM handling behavior for UTF-8 JSON files

### DIFF
--- a/bids-validator/src/files/deno.test.ts
+++ b/bids-validator/src/files/deno.test.ts
@@ -14,7 +14,7 @@ const testDir = dirname(testPath)
 const testFilename = basename(testPath)
 const ignore = new FileIgnoreRulesDeno([])
 
-Deno.test('Deno implementation of BIDSFile', async (t) => {
+Deno.test('Deno implementation of BIDSFile', async t => {
   await t.step('implements basic file properties', () => {
     const file = new BIDSFileDeno(testDir, testFilename, ignore)
     assertEquals(join(testDir, file.path), testPath)
@@ -37,4 +37,15 @@ Deno.test('Deno implementation of BIDSFile', async (t) => {
     const text = await file.text()
     assertEquals(await file.size, text.length)
   })
+  await t.step(
+    'strips BOM characters when reading UTF-8 via .text()',
+    async () => {
+      // BOM is invalid in JSON but shows up often from certain tools, so abstract handling it
+      const bomDir = join(testPath, '..', '..', 'tests')
+      const bomFilename = 'bom-utf8.json'
+      const file = new BIDSFileDeno(bomDir, bomFilename, ignore)
+      const text = await file.text()
+      assertEquals(text, '{\n  "example": "JSON for test suite"\n}\n')
+    },
+  )
 })

--- a/bids-validator/src/tests/bom-utf8.json
+++ b/bids-validator/src/tests/bom-utf8.json
@@ -1,0 +1,3 @@
+﻿{
+  "example": "JSON for test suite"
+}


### PR DESCRIPTION
This adds a test for BOM handling in UTF-8 files.

GitHub doesn't display it but the example JSON has the UTF-8 BOM character.