### PR TITLE
[SCHEMA] Build Deno validator bundle for web apps

### DIFF
--- a/bids-validator/src/build/README.md
+++ b/bids-validator/src/build/README.md
@@ -1,0 +1,6 @@
+Build tooling for browsers and other targets besides Deno native.
+
+```shell
+# Builds web compatible bundle and writes to dist/web
+deno run --allow-read --allow-env --allow-run src/build/web.ts
+```

--- a/bids-validator/src/build/web.ts
+++ b/bids-validator/src/build/web.ts
@@ -1,0 +1,19 @@
+/** Bundle for browsers */
+import { join, fromFileUrl, dirname } from '../deps/path.ts'
+import * as esbuild from 'https://deno.land/x/esbuild@v0.15.3/mod.js'
+
+const srcPath = dirname(dirname(fromFileUrl(import.meta.url)))
+const entryPointPath = join(srcPath, 'main.ts')
+const outdirPath = join(dirname(srcPath), 'dist', 'web')
+
+await esbuild.build({
+  entryPoints: [entryPointPath],
+  target: ['chrome96', 'firefox103', 'safari15'],
+  bundle: true,
+  sourcemap: true,
+  outdir: outdirPath,
+  format: 'esm',
+})
+
+// Don't wait for changes
+esbuild.stop()


### PR DESCRIPTION
This uses esbuild to bundle the schema validator for the web. The resulting module is valid but doesn't actually work in the browser yet because of calls to the Deno namespace.

Limited this to ESM output so we can use top level await and current LTS browser versions (same as OpenNeuro's full feature support list).