### PR TITLE
[SCHEMA] Implement EMPTY_FILE and reorganize check calls as array

### DIFF
--- a/bids-validator/src/files/deno.ts
+++ b/bids-validator/src/files/deno.ts
@@ -13,7 +13,7 @@ import { readBidsIgnore, FileIgnoreRulesDeno } from './ignore.ts'
 export class UnicodeDecodeError extends Error {
   constructor(message: string) {
     super(message)
-    this.name = "UnicodeDecode"
+    this.name = 'UnicodeDecode'
   }
 }
 
@@ -32,20 +32,15 @@ export class BIDSFileDeno implements BIDSFile {
     this.path = path
     this.name = basename(path)
     this.#ignore = ignore
+    this.#fileInfo = Deno.statSync(this._getPath())
   }
 
   private _getPath(): string {
     return join(this._datasetAbsPath, this.path)
   }
 
-  /**
-   * Deferred stat to get size
-   */
   get size(): number {
-    return (
-      this.#fileInfo?.size ||
-      (this.#fileInfo = Deno.statSync(this._getPath())).size
-    )
+    return this.#fileInfo.size
   }
 
   get stream(): ReadableStream<Uint8Array> {
@@ -70,7 +65,7 @@ export class BIDSFileDeno implements BIDSFile {
       // Read once to check for unicode issues
       const { done, value } = await streamReader.read()
       // Check for UTF-16 BOM
-      if (value && (value.startsWith('\uFFFD'))) {
+      if (value && value.startsWith('\uFFFD')) {
         throw new UnicodeDecodeError('This file appears to be UTF-16')
       }
       if (done) return data

--- a/bids-validator/src/files/deno.ts
+++ b/bids-validator/src/files/deno.ts
@@ -24,7 +24,7 @@ export class BIDSFileDeno implements BIDSFile {
   #ignore: FileIgnoreRulesDeno
   name: string
   path: string
-  #fileInfo: Deno.FileInfo | undefined
+  #fileInfo: Deno.FileInfo
   private _datasetAbsPath: string
 
   constructor(datasetPath: string, path: string, ignore: FileIgnoreRulesDeno) {

--- a/bids-validator/src/issues/list.ts
+++ b/bids-validator/src/issues/list.ts
@@ -65,6 +65,10 @@ export const filenameIssues: IssueDefinitionRecord = {
       'note that derived (processed) data should be placed in /derivatives folder and source data (such as DICOMS ' +
       'or behavioural logs in proprietary formats) should be placed in the /sourcedata folder.',
   },
+  EMPTY_FILE: {
+    severity: 'error',
+    reason: 'Empty files not allowed.',
+  },
 }
 
 export const nonSchemaIssues = { ...filenameIssues }

--- a/bids-validator/src/schema/applyRules.ts
+++ b/bids-validator/src/schema/applyRules.ts
@@ -24,6 +24,7 @@ export function applyRules(schema: GenericSchema, context: BIDSContext) {
       applyRules(schema[key] as GenericSchema, context)
     }
   }
+  return Promise.resolve()
 }
 
 const evalConstructor = (src: string): Function =>

--- a/bids-validator/src/types/check.ts
+++ b/bids-validator/src/types/check.ts
@@ -1,0 +1,8 @@
+import { GenericSchema } from './schema.ts'
+import { BIDSContext } from '../schema/context.ts'
+
+/** Function interface for writing a check */
+export type CheckFunction = (
+  schema: GenericSchema,
+  context: BIDSContext,
+) => Promise<void>

--- a/bids-validator/src/validators/internal/emptyFile.ts
+++ b/bids-validator/src/validators/internal/emptyFile.ts
@@ -1,0 +1,9 @@
+import { CheckFunction } from '../../types/check.ts'
+
+// Non-schema EMPTY_FILE implementation
+export const emptyFile: CheckFunction = (schema, context) => {
+  if (context.file.size === 0) {
+    context.issues.addNonSchemaIssue('EMPTY_FILE', [context.file])
+  }
+  return Promise.resolve()
+}


### PR DESCRIPTION
One other minor change, which is to call the stat at constructor time. The EMPTY_FILE check means we would be doing this anyways and making it immediate simplifies things a bit.