### PR TITLE
[SCHEMA] Load schema using dynamic/static ES imports

### DIFF
--- a/bids-validator/src/deps/yaml.ts
+++ b/bids-validator/src/deps/yaml.ts
@@ -1,1 +1,0 @@
-export { parse, parseAll } from 'https://deno.land/std@0.130.0/encoding/yaml.ts'

--- a/bids-validator/src/setup/loadSchema.ts
+++ b/bids-validator/src/setup/loadSchema.ts
@@ -22,7 +22,10 @@ const yamlBasePath = join(
   'schema',
 )
 
-export async function loadSchema(): Promise<Schema> {
+const defaultSchemaURL =
+  'https://bids-specification.readthedocs.io/en/latest/schema.json'
+
+export async function loadSchemaFromSpecification(): Promise<Schema> {
   await requestReadPermission()
   const schemaObj = {}
   for await (const entry of walk(yamlBasePath, {
@@ -45,5 +48,12 @@ export async function loadSchema(): Promise<Schema> {
       await Deno.readTextFile(entry.path),
     )
   }
+  return schemaObj as Schema
+}
+
+export async function loadSchema(): Promise<Schema> {
+  let schemaObj = {}
+  const jsonResponse = await fetch(defaultSchemaURL)
+  schemaObj = await jsonResponse.json()
   return schemaObj as Schema
 }


### PR DESCRIPTION
Iteration on #1510 

This has a fallback to use a static import so bundlers can provide a copy without network access. A warning message is displayed if the fallback copy is used.