### PR TITLE
[SCHEMA]: Add slice support for AdapterFile

### DIFF
--- a/bids-validator/src/compat/adapter-file.ts
+++ b/bids-validator/src/compat/adapter-file.ts
@@ -6,14 +6,16 @@ import { BIDSFile } from '../types/file.ts'
  * implementing only what the validator currently uses.
  */
 export class AdapterFile {
-  private _stream: ReadableStream // File contents stream
+  #file: BIDSFile
+  #stream: ReadableStream // File contents stream
   name: string // Filename
   path: string // Absolute path
   relativePath: string // Dataset relative path (prefixed /)
   webkitRelativePath: string // Duplicate name for relativePath
 
   constructor(rootPath: string, file: BIDSFile, stream: ReadableStream) {
-    this._stream = stream
+    this.#file = file
+    this.#stream = stream
     this.name = file.name
     // JS validator expects dataset-dir/contents filenames
     const relativePath = relative(rootPath, file.path)
@@ -23,6 +25,11 @@ export class AdapterFile {
   }
 
   stream(): ReadableStream {
-    return this._stream
+    return this.#stream
+  }
+
+  slice(start: number, end = 0): Blob {
+    const size = end - start
+    return new Blob([this.#file.readBytes(size, start).buffer])
   }
 }

--- a/bids-validator/src/types/file.ts
+++ b/bids-validator/src/types/file.ts
@@ -16,4 +16,6 @@ export interface BIDSFile {
   stream: ReadableStream<Uint8Array>
   // Resolve stream to decoded utf-8 text
   text: () => Promise<string>
+  // Synchronously read a range of bytes
+  readBytes: (size: number, offset?: number) => Uint8Array
 }

--- a/bids-validator/utils/files/readNiftiHeader.js
+++ b/bids-validator/utils/files/readNiftiHeader.js
@@ -66,6 +66,8 @@ function extractNiftiFile(file, callback) {
 }
 
 function browserNiftiTest(file, callback) {
+  const bytesRead = 1024
+  const blob = file.slice(0, bytesRead)
   if (file.size == 0) {
     callback({ error: new Issue({ code: 44, file: file }) })
     return
@@ -77,7 +79,7 @@ function browserNiftiTest(file, callback) {
     return
   }
   const fileReader = constructBrowserFileReader(file, callback)
-  fileReader.readAsArrayBuffer(file)
+  fileReader.readAsArrayBuffer(blob)
 }
 
 function constructBrowserFileReader(file, callback) {


### PR DESCRIPTION
This restores the initial slice call for browsers and Deno when running the backcompat mode. This should avoid memory issues like #1537 