### PR TITLE
add PartialFourier to schema

### DIFF
--- a/bids-validator/validators/json/schemas/bold.json
+++ b/bids-validator/validators/json/schemas/bold.json
@@ -44,6 +44,9 @@
         "type": "number",
         "minimum": 0
       }
+    },
+    "PartialFourier": {
+      "type": "number"
     }
   }
 }


### PR DESCRIPTION
closes #1534 

1 minute fix ...

I am aware that a _proper_ enhancement would involve a pass over all metadata currently missing from all possible MRI json files (not just bold), but I'd be fine with this.