### PR TITLE
ENH: Check for empty or whitespace-only dataset names

### DIFF
--- a/bids-validator/utils/issues/list.js
+++ b/bids-validator/utils/issues/list.js
@@ -622,6 +622,12 @@ export default {
     reason:
       'This dataset contains remote files. If you would like to validate with remote files, use the --remoteFiles option.',
   },
+  115: {
+    key: 'EMPTY_DATASET_NAME',
+    severity: 'warning',
+    reason:
+      'The Name field of dataset_description.json is present but empty of visible characters.',
+  },
   123: {
     key: 'INVALID JSON ENCODING',
     severity: 'error',

--- a/bids-validator/validators/bids/__tests__/checkDatasetDescription.spec.js
+++ b/bids-validator/validators/bids/__tests__/checkDatasetDescription.spec.js
@@ -2,16 +2,55 @@ import { assert } from 'chai'
 import checkDatasetDescription from '../checkDatasetDescription'
 
 describe('checkDatasetDescription', () => {
-  describe('checkAuthorField', () => {
-    it('returns no issues with valid Authors field', () => {
+  describe('checkNameAndAuthorsFields', () => {
+    it('returns no issues with valid Name and Authors field', () => {
       const validJsonContentsDict = {
         '/dataset_description.json': {
+          Name: 'Electric Boots',
           Authors: ['Benny', 'the Jets'],
         },
       }
       const issues = checkDatasetDescription(validJsonContentsDict)
       assert.lengthOf(issues, 0)
     })
+  })
+  describe('checkNameField', () => {
+    it('returns code 115 when Name is empty', () => {
+      const invalidJsonContentsDict = {
+        '/dataset_description.json': {
+          Name: '',
+        },
+      }
+      const issues = checkDatasetDescription(invalidJsonContentsDict)
+      assert(
+        issues.findIndex((issue) => issue.code === 115) > -1,
+        'issues include a code 115',
+      )
+    })
+    it('returns code 115 when name only contains whitespace', () => {
+      const invalidJsonContentsDict = {
+        '/dataset_description.json': {
+          Name: ' \t\r\n\f\v\u2003',
+        },
+      }
+      const issues = checkDatasetDescription(invalidJsonContentsDict)
+      assert(
+        issues.findIndex((issue) => issue.code === 115) > -1,
+        'issues include a code 115',
+      )
+    })
+    it('returns no issues with one non-whitespace character', () => {
+      const validJsonContentsDict = {
+        '/dataset_description.json': {
+          Name: '     \u2708     ',
+          Authors: ['Benny', 'the Jets'],
+        },
+      }
+      const issues = checkDatasetDescription(validJsonContentsDict)
+      assert.lengthOf(issues, 0)
+    })
+  })
+  describe('checkAuthorField', () => {
     it('returns code 102 when there is only one author present', () => {
       const invalidJsonContentsDict = {
         '/dataset_description.json': {

--- a/bids-validator/validators/bids/checkDatasetDescription.js
+++ b/bids-validator/validators/bids/checkDatasetDescription.js
@@ -37,7 +37,7 @@ const checkDatasetDescription = (jsonContentsDict) => {
 const checkNameField = (name) => {
   const issues = []
   // missing name will be caught by validation (later)
-  if (name !== null) {
+  if (name !== undefined) {
     const nonws = /\S/
     if (!name.match(nonws)) {
       issues.push(new Issue({ code: 115 }))

--- a/bids-validator/validators/bids/checkDatasetDescription.js
+++ b/bids-validator/validators/bids/checkDatasetDescription.js
@@ -15,8 +15,9 @@ const checkDatasetDescription = (jsonContentsDict) => {
   } else {
     const datasetDescription = jsonContentsDict['/dataset_description.json']
 
-    // check to ensure that the dataset description Authors are
+    // check to ensure that the dataset description fields are
     // properly formatted
+    issues = issues.concat(checkNameField(datasetDescription.Name))
     issues = issues.concat(checkAuthorField(datasetDescription.Authors))
 
     // if genetic info json present ensure mandatory GeneticDataset present
@@ -28,6 +29,18 @@ const checkDatasetDescription = (jsonContentsDict) => {
       )
     ) {
       issues.push(new Issue({ code: 128 }))
+    }
+  }
+  return issues
+}
+
+const checkNameField = (name) => {
+  const issues = []
+  // missing name will be caught by validation (later)
+  if (name !== null) {
+    const nonws = /\S/
+    if (!name.match(nonws)) {
+      issues.push(new Issue({ code: 115 }))
     }
   }
   return issues


### PR DESCRIPTION
This is a rare case but the schema does not verify that `dataset_description.Name` contains non-whitespace characters. On OpenNeuro it led to UI issues where the dataset links were not rendered. It seems like an obviously bad practice to warn the user about, and OpenNeuro can turn it into an error if it's a validator issue.

xref openneuroorg/openneuro#2595