### PR TITLE
FIX/FEAT: Use specific schema version

### DIFF
--- a/bids-validator/validators/options.js
+++ b/bids-validator/validators/options.js
@@ -69,9 +69,9 @@ export function parseOptions(argumentOverride) {
     .option('schema', {
       alias: 's',
       describe:
-        'BIDS specification schema version to use for validation, e.g. "v1.7.0" (beta)',
+        'BIDS specification schema version to use for validation, e.g. "v1.6.0" (beta)',
       default: 'disable',
-      choices: ['disable', 'v1.7.0', 'master'],
+      choices: ['disable', 'v1.6.0', 'v1.7.0', 'master'],
     })
     .epilogue(
       'This tool checks if a dataset in a given directory is \

--- a/bids-validator/validators/options.js
+++ b/bids-validator/validators/options.js
@@ -69,9 +69,9 @@ export function parseOptions(argumentOverride) {
     .option('schema', {
       alias: 's',
       describe:
-        'BIDS specification schema version to use for validation, e.g. "v1.6.0" (beta)',
+        'BIDS specification schema version to use for validation, e.g. "v1.7.0" (beta)',
       default: 'disable',
-      choices: ['disable', 'v1.6.0', 'master'],
+      choices: ['disable', 'v1.7.0', 'master'],
     })
     .epilogue(
       'This tool checks if a dataset in a given directory is \

--- a/bids-validator/validators/schemaTypes.js
+++ b/bids-validator/validators/schemaTypes.js
@@ -136,12 +136,7 @@ export async function generateRegex(schema, pythonRegex = false) {
           if (entity === 'subject' || entity === 'session') {
             continue
           }
-          let entityKey = undefined
-          if (entityDefinion.hasOwnProperty('entity')) {
-            entityKey = entityDefinion.entity // v1.6.0 and v1.7.0
-          } else {
-            entityKey = entityDefinion.name // v1.8.0
-          }
+          const entityKey = entityDefinion.entity
           const format = regex[schema.entities[entity].format]
           if (format) {
             // Limitation here is that if format is missing an essential entity may be skipped

--- a/bids-validator/validators/schemaTypes.js
+++ b/bids-validator/validators/schemaTypes.js
@@ -52,21 +52,28 @@ async function loadYaml(base, path, local) {
  * @param {boolean} local Avoid any network access
  */
 async function loadSchema(base, local = false) {
-  const top = 'rules/top_level_files.yaml'
-  const entities = 'rules/entities.yaml'
+  // Define path prefix depending on the BIDS schema version
+  const prefix_objects = base.includes('v1.6.0') ? '' : 'objects/'
+  const prefix_rules = base.includes('v1.6.0') ? '' : 'rules/'
+  const prefix_datatypes = prefix_rules + 'datatypes/'
+
+  // Define schema files for top level files and entities
+  const top = prefix_rules + 'top_level_files.yaml'
+  const entities = prefix_objects + 'entities.yaml'
+
   return {
     top_level_files: await loadYaml(base, top, local),
     entities: await loadYaml(base, entities, local),
     datatypes: {
-      anat: await loadYaml(base, `rules/datatypes/anat.yaml`, local),
-      beh: await loadYaml(base, `rules/datatypes/beh.yaml`, local),
-      dwi: await loadYaml(base, `rules/datatypes/dwi.yaml`, local),
-      eeg: await loadYaml(base, `rules/datatypes/eeg.yaml`, local),
-      fmap: await loadYaml(base, `rules/datatypes/fmap.yaml`, local),
-      func: await loadYaml(base, `rules/datatypes/func.yaml`, local),
-      ieeg: await loadYaml(base, 'rules/datatypes/ieeg.yaml', local),
-      meg: await loadYaml(base, 'rules/datatypes/meg.yaml', local),
-      pet: await loadYaml(base, 'rules/datatypes/pet.yaml', local),
+      anat: await loadYaml(base, prefix_datatypes + 'anat.yaml', local),
+      beh: await loadYaml(base, prefix_datatypes + 'beh.yaml', local),
+      dwi: await loadYaml(base, prefix_datatypes + 'dwi.yaml', local),
+      eeg: await loadYaml(base, prefix_datatypes + 'eeg.yaml', local),
+      fmap: await loadYaml(base, prefix_datatypes + 'fmap.yaml', local),
+      func: await loadYaml(base, prefix_datatypes + 'func.yaml', local),
+      ieeg: await loadYaml(base, prefix_datatypes + 'ieeg.yaml', local),
+      meg: await loadYaml(base, prefix_datatypes + 'meg.yaml', local),
+      pet: await loadYaml(base, prefix_datatypes + 'pet.yaml', local),
     },
   }
 }


### PR DESCRIPTION
This PR addresses the following issue:
- #1579

I took the initiative to go to the option solution 2 (make the `--schema` option working for `v1.6.0` and `v1.7.0`).

It integrates the following changes:

- [x] FIX: Correct prefix paths to schema files for version `v1.6.0` as the `rules/` folder has been introduced in `v1.7.0`.
- [x] FEAT/REF: Handle schema files for version `v1.7.0` where entities in the `entities.yaml` have been re-ordered alphabetically.
- [x] FEAT: Add the option choices both `v1.6.0` and `v1.7.0`.

*Note:* I made an attempt to support `v1.8.0` as well  but this was involving quite some refactoring in `generateRegex()` as it introduced new schema files specific to `channels`, `nirs`, `task`, and `photo`. I guess this would deserve its own specific PR. What do you think?