### PR TITLE
FIX: Close NIfTI files after read, before parsing headers

### DIFF
--- a/bids-validator/tests/events.spec.js
+++ b/bids-validator/tests/events.spec.js
@@ -310,7 +310,7 @@ describe('Events', function () {
           },
         },
         '/dataset_description.json': {
-          HEDVersion: ['8.0.0', 'ts:testlib_1.0.2', 'sc:score_0.0.1'],
+          HEDVersion: ['8.0.0', 'ts:testlib_1.0.2', 'sc:score_1.0.0'],
         },
       }
 

--- a/bids-validator/utils/files/readNiftiHeader.js
+++ b/bids-validator/utils/files/readNiftiHeader.js
@@ -50,16 +50,18 @@ function extractNiftiFile(file, callback) {
       return
     } else {
       fs.read(fd, buffer, 0, bytesRead, 0, function () {
-        if (file.name.endsWith('.nii')) {
-          callback(parseNIfTIHeader(buffer, file))
-        } else {
-          try {
-            const data = pako.inflate(buffer)
-            callback(parseNIfTIHeader(data, file))
-          } catch (err) {
-            callback(handleGunzipError(buffer, file))
+        fs.close(fd, function () {
+          if (file.name.endsWith('.nii')) {
+            callback(parseNIfTIHeader(buffer, file))
+          } else {
+            try {
+              const data = pako.inflate(buffer)
+              callback(parseNIfTIHeader(data, file))
+            } catch (err) {
+              callback(handleGunzipError(buffer, file))
+            }
           }
-        }
+        })
       })
     }
   })


### PR DESCRIPTION
Replacement of #1583, revival of #691. Could close #675 if driven by open NIfTI files and not other open files.

Opening a separate PR to let CI do its magic and tell me if this is dumb.