### PR TITLE
docs(schema): Add some explanation for how to reload the latest version of the specification JSON

### DIFF
--- a/bids-validator/src/README.md
+++ b/bids-validator/src/README.md
@@ -47,3 +47,9 @@ deno run --allow-env --allow-read src/main.ts --schemaOnly path/to/dataset
 # Run tests:
 deno test --allow-env --allow-read src/
 ```
+
+# Refreshing latest specification
+
+If you are validating with the latest specification instead of a specific version, the validator will hold onto a cached version for up to one year. You can request the newest version by adding the `--reload` argument to obtain the newest specification definition.
+
+`deno run --reload=https://bids-specification.readthedocs.io/en/latest/schema.json src/main.ts`


### PR DESCRIPTION
Ran into this running an older copy of the schema validator and was confused for a bit before I realized it was just a cached copy of a slightly out of date schema.json. The spec JSON file is served with a max-age of 365 days, so you'll use the old version for up to one year before Deno reloads it if you are requesting the `latest` version.

Alternatively we could lower the cache time for this file, it is somewhat useful to have it stick around but also potentially confusing.