### PR TITLE
Add cli option to specify schema url or file.

### DIFF
--- a/bids-validator/src/setup/loadSchema.ts
+++ b/bids-validator/src/setup/loadSchema.ts
@@ -8,7 +8,11 @@ import * as schemaDefault from 'https://bids-specification.readthedocs.io/en/lat
  * version is ignored when the network cannot be accessed
  */
 export async function loadSchema(version = 'latest'): Promise<Schema> {
-  const schemaUrl = `https://bids-specification.readthedocs.io/en/${version}/schema.json`
+  const versionRegex = /v\d/
+  let schemaUrl = version
+  if (version === 'latest' || versionRegex.test(version)) {
+    schemaUrl = `https://bids-specification.readthedocs.io/en/${version}/schema.json`
+  }
   try {
     const schemaModule = await import(schemaUrl, {
       assert: { type: 'json' },

--- a/bids-validator/src/setup/loadSchema.ts
+++ b/bids-validator/src/setup/loadSchema.ts
@@ -8,7 +8,7 @@ import * as schemaDefault from 'https://bids-specification.readthedocs.io/en/lat
  * version is ignored when the network cannot be accessed
  */
 export async function loadSchema(version = 'latest'): Promise<Schema> {
-  const versionRegex = /v\d/
+  const versionRegex = /^v\d/
   let schemaUrl = version
   if (version === 'latest' || versionRegex.test(version)) {
     schemaUrl = `https://bids-specification.readthedocs.io/en/${version}/schema.json`
@@ -21,11 +21,15 @@ export async function loadSchema(version = 'latest'): Promise<Schema> {
       schemaModule.default as object,
       objectPathHandler,
     ) as Schema
-  } catch {
+  } catch (error) {
     // No network access or other errors
+    console.error(error)
     console.error(
       `Warning, could not load schema from ${schemaUrl}, falling back to internal version`,
     )
-    return new Proxy(schemaDefault as object, objectPathHandler) as Schema
+    return new Proxy(
+      schemaDefault.default as object,
+      objectPathHandler,
+    ) as Schema
   }
 }

--- a/bids-validator/src/setup/options.ts
+++ b/bids-validator/src/setup/options.ts
@@ -77,6 +77,10 @@ export function parseOptions(
       'A less accurate check that reads filenames one per line from stdin.',
     )
     .hide('filenames')
+    .option('schema', {
+      alias: 's',
+      describe: 'Schema Version or Path or URL to schema json file.',
+    })
     .boolean('schemaOnly')
     .default('schemaOnly', false)
     .describe('schemaOnly', 'Run only schema based validation.')

--- a/bids-validator/src/summary/summary.ts
+++ b/bids-validator/src/summary/summary.ts
@@ -67,6 +67,7 @@ export class Summary {
   modalitiesCount: Record<string, number>
   secondaryModalitiesCount: Record<string, number>
   datatypes: Set<string>
+  schemaVersion: string
   constructor() {
     this.dataProcessed = false
     this.totalFiles = -1
@@ -95,6 +96,7 @@ export class Summary {
       iEEG_ECoG: 0,
       iEEG_SEEG: 0,
     }
+    this.schemaVersion = ''
   }
   get modalities() {
     return computeModalities(this.modalitiesCount)
@@ -161,6 +163,7 @@ export class Summary {
       dataProcessed: this.dataProcessed,
       pet: this.pet,
       datatypes: Array.from(this.datatypes),
+      schemaVersion: this.schemaVersion,
     }
   }
 }

--- a/bids-validator/src/types/schema.ts
+++ b/bids-validator/src/types/schema.ts
@@ -32,6 +32,7 @@ export interface SchemaFiles {
 export interface Schema {
   objects: SchemaObjects
   rules: SchemaRules
+  schema_version: string
 }
 
 export interface SchemaIssue {

--- a/bids-validator/src/types/validation-result.ts
+++ b/bids-validator/src/types/validation-result.ts
@@ -26,6 +26,7 @@ export interface SummaryOutput {
   dataProcessed: boolean
   pet: Record<string, any>
   datatypes: string[]
+  schemaVersion: string
 }
 
 /**

--- a/bids-validator/src/validators/bids.ts
+++ b/bids-validator/src/validators/bids.ts
@@ -34,7 +34,8 @@ export async function validate(
 ): Promise<ValidationResult> {
   const issues = new DatasetIssues()
   const summary = new Summary()
-  const schema = await loadSchema()
+  const schema = await loadSchema(options.schema)
+  summary.schemaVersion = schema.schema_version
 
   /* There should be a dataset_description in root, this will tell us if we
    * are dealing with a derivative dataset


### PR DESCRIPTION
Currently failure to load schema passed as a cli option just prints error message and continues with default schema. Should this failure should be more aggressive for new option.

If a string starting wtih `v` and then a digit is passed we try and use that as the _bids-specification_ version to load schema.json from readthedocs.