### PR TITLE
[SCHEMA] Browser file API support

### DIFF
--- a/bids-validator/src/deps/asserts.ts
+++ b/bids-validator/src/deps/asserts.ts
@@ -4,4 +4,4 @@ export {
   assertObjectMatch,
   assertExists,
   assertRejects,
-} from 'https://deno.land/std@0.130.0/testing/asserts.ts'
+} from 'https://deno.land/std@0.177.0/testing/asserts.ts'

--- a/bids-validator/src/files/browser.test.ts
+++ b/bids-validator/src/files/browser.test.ts
@@ -1,0 +1,68 @@
+import { FileIgnoreRules } from './ignore.ts'
+import { FileTree } from '../types/filetree.ts'
+import { assertEquals } from '../deps/asserts.ts'
+import { BIDSFileBrowser, fileListToTree } from './browser.ts'
+
+class TestFile extends File {
+  webkitRelativePath: string
+  constructor(
+    fileBits: BlobPart[],
+    fileName: string,
+    webkitRelativePath: string,
+    options?: FilePropertyBag | undefined,
+  ) {
+    super(fileBits, fileName, options)
+    this.webkitRelativePath = webkitRelativePath
+  }
+}
+
+Deno.test('Browser implementation of FileTree', async (t) => {
+  await t.step('converts a basic FileList', async () => {
+    const ignore = new FileIgnoreRules([])
+    const files = [
+      new TestFile(
+        ['{}'],
+        'dataset_description.json',
+        'dataset_description.json',
+      ),
+      new TestFile(['flat test dataset'], 'README.md', 'README.md'),
+    ]
+    const tree = await fileListToTree(files)
+    const expectedTree = new FileTree('', '/', undefined)
+    expectedTree.files = files.map((f) => new BIDSFileBrowser(f, ignore))
+    assertEquals(tree, expectedTree)
+  })
+  await t.step('converts a simple FileList with several levels', async () => {
+    const ignore = new FileIgnoreRules([])
+    const files = [
+      new TestFile(
+        ['{}'],
+        'dataset_description.json',
+        'dataset_description.json',
+      ),
+      new TestFile(
+        ['tsv headers\n', 'column\tdata'],
+        'participants.tsv',
+        'participants.tsv',
+      ),
+      new TestFile(['single subject test dataset'], 'README.md', 'README.md'),
+      new TestFile(
+        ['nifti file goes here'],
+        'sub-01_T1w.nii.gz',
+        'sub-01/anat/sub-01_T1w.nii.gz',
+      ),
+    ]
+    const tree = await fileListToTree(files)
+    const expectedTree = new FileTree('', '/', undefined)
+    const sub01Tree = new FileTree('sub-01', 'sub-01', expectedTree)
+    const anatTree = new FileTree('sub-01/anat', 'anat', sub01Tree)
+    expectedTree.files = files
+      .slice(0, 3)
+      .map((f) => new BIDSFileBrowser(f, ignore))
+    expectedTree.directories.push(sub01Tree)
+    anatTree.files = [new BIDSFileBrowser(files[3], ignore)]
+    sub01Tree.directories.push(anatTree)
+    // TODO - Stack size exceeded
+    assertEquals(tree, expectedTree)
+  })
+})

--- a/bids-validator/src/files/browser.test.ts
+++ b/bids-validator/src/files/browser.test.ts
@@ -62,7 +62,6 @@ Deno.test('Browser implementation of FileTree', async (t) => {
     expectedTree.directories.push(sub01Tree)
     anatTree.files = [new BIDSFileBrowser(files[3], ignore)]
     sub01Tree.directories.push(anatTree)
-    // TODO - Stack size exceeded
     assertEquals(tree, expectedTree)
   })
 })

--- a/bids-validator/src/files/browser.ts
+++ b/bids-validator/src/files/browser.ts
@@ -40,10 +40,8 @@ export class BIDSFileBrowser implements BIDSFile {
     return this.#file.text()
   }
 
-  readBytes(size: number, offset = 0): Uint8Array {
-    // TODO - Promise or FileReaderSync?
-    // @ts-ignore obviously
-    return this.#file.slice(offset, size)
+  async readBytes(size: number, offset = 0): Promise<Uint8Array> {
+    return new Uint8Array(await this.#file.slice(offset, size).arrayBuffer())
   }
 }
 

--- a/bids-validator/src/files/browser.ts
+++ b/bids-validator/src/files/browser.ts
@@ -1,0 +1,88 @@
+import { BIDSFile } from '../types/file.ts'
+import { FileTree } from '../types/filetree.ts'
+import { FileIgnoreRules } from './ignore.ts'
+import { parse, join, SEP } from '../deps/path.ts'
+
+/**
+ * Browser implement of BIDSFile wrapping native File/FileList types
+ */
+export class BIDSFileBrowser implements BIDSFile {
+  #ignore: FileIgnoreRules
+  #file: File
+
+  constructor(file: File, ignore: FileIgnoreRules) {
+    this.#file = file
+    this.#ignore = ignore
+  }
+
+  get name(): string {
+    return this.#file.name
+  }
+
+  get path(): string {
+    // @ts-expect-error webkitRelativePath is defined in the browser
+    return this.#file.webkitRelativePath
+  }
+
+  get size(): number {
+    return this.#file.size
+  }
+
+  get stream(): ReadableStream<Uint8Array> {
+    return this.#file.stream()
+  }
+
+  get ignored(): boolean {
+    return this.#ignore.test(this.path)
+  }
+
+  text(): Promise<string> {
+    return this.#file.text()
+  }
+
+  readBytes(size: number, offset = 0): Uint8Array {
+    // TODO - Promise or FileReaderSync?
+    // @ts-ignore obviously
+    return this.#file.slice(offset, size)
+  }
+}
+
+/**
+ * Convert from FileList (created with webkitDirectory: true) to FileTree for validator use
+ */
+export function fileListToTree(files: File[]): Promise<FileTree> {
+  const ignore = new FileIgnoreRules([])
+  const tree = new FileTree('', '/', undefined)
+  for (const f of files) {
+    const file = new BIDSFileBrowser(f, ignore)
+    const fPath = parse(file.path)
+    const levels = fPath.dir.split(SEP)
+    if (levels[0] === '') {
+      // Top level file
+      tree.files.push(file)
+    } else {
+      let currentLevelTree = tree
+      for (const level of levels) {
+        const exists = currentLevelTree.directories.find(
+          (d) => d.name === level,
+        )
+        // If this level exists, set it and descend once
+        if (exists) {
+          currentLevelTree = exists
+        } else {
+          // Otherwise make a new level and continue if needed
+          const newTree = new FileTree(
+            join(currentLevelTree.path, level),
+            level,
+            currentLevelTree,
+          )
+          currentLevelTree.directories.push(newTree)
+          currentLevelTree = newTree
+        }
+      }
+      // At the terminal leaf, add files
+      currentLevelTree.files.push(file)
+    }
+  }
+  return Promise.resolve(tree)
+}

--- a/bids-validator/src/files/deno.ts
+++ b/bids-validator/src/files/deno.ts
@@ -6,7 +6,6 @@ import { BIDSFile } from '../types/file.ts'
 import { FileTree } from '../types/filetree.ts'
 import { requestReadPermission } from '../setup/requestPermissions.ts'
 import { readBidsIgnore, FileIgnoreRules } from './ignore.ts'
-import { assert } from 'https://deno.land/std@0.130.0/_util/assert.ts'
 
 /**
  * Thrown when a text file is decoded as UTF-8 but contains UTF-16 characters
@@ -109,29 +108,15 @@ export class BIDSFileDeno implements BIDSFile {
   }
 }
 
-export class FileTreeDeno extends FileTree {
-  // System specific dataset path
-  private _datasetRootPath?: string
-  constructor(
-    path: string,
-    name: string,
-    parent?: FileTree,
-    rootPath?: string,
-  ) {
-    super(path, name, parent)
-    this._datasetRootPath = rootPath
-  }
-}
-
 export async function _readFileTree(
   rootPath: string,
   relativePath: string,
   ignore: FileIgnoreRules,
-  parent?: FileTreeDeno,
+  parent?: FileTree,
 ): Promise<FileTree> {
   await requestReadPermission()
   const name = basename(relativePath)
-  const tree = new FileTreeDeno(relativePath, name, parent, rootPath)
+  const tree = new FileTree(relativePath, name, parent)
 
   for await (const dirEntry of Deno.readDir(join(rootPath, relativePath))) {
     if (dirEntry.isFile || dirEntry.isSymlink) {

--- a/bids-validator/src/files/deno.ts
+++ b/bids-validator/src/files/deno.ts
@@ -89,11 +89,11 @@ export class BIDSFileDeno implements BIDSFile {
   /**
    * Read bytes in a range efficiently from a given file
    */
-  readBytes(size: number, offset = 0): Uint8Array {
+  async readBytes(size: number, offset = 0): Promise<Uint8Array> {
     const handle = this.#openHandle()
     const buf = new Uint8Array(size)
-    handle.seekSync(offset, Deno.SeekMode.Start)
-    handle.readSync(buf)
+    await handle.seek(offset, Deno.SeekMode.Start)
+    await handle.read(buf)
     Deno.close(handle.rid)
     return buf
   }

--- a/bids-validator/src/files/nifti.ts
+++ b/bids-validator/src/files/nifti.ts
@@ -1,8 +1,8 @@
 import 'https://raw.githubusercontent.com/rii-mango/NIFTI-Reader-JS/master/release/current/nifti-reader-min.js'
 import { BIDSFile } from '../types/file.ts'
 
-export function loadHeader(file: BIDSFile) {
-  const buf = file.readBytes(1024)
+export async function loadHeader(file: BIDSFile) {
+  const buf = await file.readBytes(1024)
   // @ts-expect-error
   const header = globalThis.nifti.readHeader(buf.buffer)
   // normalize between nifti-reader and spec schema

--- a/bids-validator/src/main.ts
+++ b/bids-validator/src/main.ts
@@ -1,5 +1,6 @@
 import { parseOptions } from './setup/options.ts'
 import { readFileTree } from './files/deno.ts'
+import { fileListToTree } from './files/browser.ts'
 import { resolve } from './deps/path.ts'
 import { fullTestAdapter } from './compat/fulltest.ts'
 import { validate } from './validators/bids.ts'
@@ -38,4 +39,4 @@ export async function main() {
   }
 }
 
-export { validate }
+export { validate, fileListToTree }

--- a/bids-validator/src/schema/context.ts
+++ b/bids-validator/src/schema/context.ts
@@ -146,15 +146,14 @@ export class BIDSContext implements Context {
     }
   }
 
-  loadNiftiHeader(): Promise<void> {
+  async loadNiftiHeader(): Promise<void> {
     if (
       this.extension.startsWith('.nii') &&
       this.dataset.options &&
       !this.dataset.options.ignoreNiftiHeaders
     ) {
-      this.nifti_header = loadHeader(this.file)
+      this.nifti_header = await loadHeader(this.file)
     }
-    return Promise.resolve()
   }
 
   async loadColumns(): Promise<void> {

--- a/bids-validator/src/tests/nullReadBytes.ts
+++ b/bids-validator/src/tests/nullReadBytes.ts
@@ -1,3 +1,3 @@
 export const nullReadBytes = (size: number, offset = 1024) => {
-  return new Uint8Array()
+  return Promise.resolve(new Uint8Array())
 }

--- a/bids-validator/src/types/file.ts
+++ b/bids-validator/src/types/file.ts
@@ -17,5 +17,5 @@ export interface BIDSFile {
   // Resolve stream to decoded utf-8 text
   text: () => Promise<string>
   // Synchronously read a range of bytes
-  readBytes: (size: number, offset?: number) => Uint8Array
+  readBytes: (size: number, offset?: number) => Promise<Uint8Array>
 }

--- a/bids-validator/src/types/validation-result.ts
+++ b/bids-validator/src/types/validation-result.ts
@@ -1,10 +1,9 @@
 import { DatasetIssues } from '../issues/datasetIssues.ts'
 
 export interface SubjectMetadata {
-  PARTICIPANT_ID: string
+  participantId: string
   age: number
   sex: string
-  group: string
 }
 /*
     BodyPart: {},

--- a/bids-validator/src/validators/filenameIdentify.test.ts
+++ b/bids-validator/src/validators/filenameIdentify.test.ts
@@ -5,14 +5,15 @@ import {
   datatypeFromDirectory,
   hasMatch,
 } from './filenameIdentify.ts'
-import { BIDSFileDeno, FileTreeDeno } from '../files/deno.ts'
+import { BIDSFileDeno } from '../files/deno.ts'
+import { FileTree } from '../types/filetree.ts'
 import { DatasetIssues } from '../issues/datasetIssues.ts'
 import { FileIgnoreRules } from '../files/ignore.ts'
 import { loadSchema } from '../setup/loadSchema.ts'
 
 const PATH = 'tests/data/valid_dataset'
 const schema = await loadSchema()
-const fileTree = new FileTreeDeno(PATH, '/')
+const fileTree = new FileTree(PATH, '/')
 const issues = new DatasetIssues()
 const ignore = new FileIgnoreRules([])
 

--- a/bids-validator/src/validators/filenameValidate.test.ts
+++ b/bids-validator/src/validators/filenameValidate.test.ts
@@ -1,14 +1,15 @@
+import { FileTree } from '../types/filetree.ts'
 import { GenericSchema } from '../types/schema.ts'
 import { assertEquals } from '../deps/asserts.ts'
 import { BIDSContext } from '../schema/context.ts'
 import { missingLabel, atRoot, entityLabelCheck } from './filenameValidate.ts'
-import { BIDSFileDeno, FileTreeDeno } from '../files/deno.ts'
+import { BIDSFileDeno } from '../files/deno.ts'
 import { DatasetIssues } from '../issues/datasetIssues.ts'
 import { FileIgnoreRules } from '../files/ignore.ts'
 import { loadSchema } from '../setup/loadSchema.ts'
 
 const schema = (await loadSchema()) as unknown as GenericSchema
-const fileTree = new FileTreeDeno('/tmp', '/')
+const fileTree = new FileTree('/tmp', '/')
 const issues = new DatasetIssues()
 const ignore = new FileIgnoreRules([])
 


### PR DESCRIPTION
Adds an entrypoint for browser apps to run the validator.

```typescript
// Given a const fileList = FileList from <input type="file" webkitdirectory />
const options = {
  ignoreNiftiHeaders: true
}
const tree = fileListToTree(fileList)
const results: ValidationResult = await validate(tree, options)
...
```

I ended up using the async version of readBytes, that seems simpler but maybe there's limitations around how this is consumed later in the context? @rwblair What do you think of this version?