### PR TITLE
fix(schema): Fix regression in legacy nifti test when run with Deno

### DIFF
--- a/bids-validator/src/compat/adapter-file.ts
+++ b/bids-validator/src/compat/adapter-file.ts
@@ -28,8 +28,9 @@ export class AdapterFile {
     return this.#stream
   }
 
-  slice(start: number, end = 0): Blob {
+  async readBytes(start: number, end = 0): Promise<Blob> {
     const size = end - start
-    return new Blob([this.#file.readBytes(size, start).buffer])
+    const u8array = await this.#file.readBytes(size, start)
+    return new Blob([u8array.buffer])
   }
 }

--- a/bids-validator/src/types/file.ts
+++ b/bids-validator/src/types/file.ts
@@ -16,6 +16,6 @@ export interface BIDSFile {
   stream: ReadableStream<Uint8Array>
   // Resolve stream to decoded utf-8 text
   text: () => Promise<string>
-  // Synchronously read a range of bytes
+  // Read a range of bytes
   readBytes: (size: number, offset?: number) => Promise<Uint8Array>
 }

--- a/bids-validator/utils/files/readNiftiHeader.js
+++ b/bids-validator/utils/files/readNiftiHeader.js
@@ -65,9 +65,16 @@ function extractNiftiFile(file, callback) {
   })
 }
 
-function browserNiftiTest(file, callback) {
+async function browserNiftiTest(file, callback) {
   const bytesRead = 1024
-  const blob = file.slice(0, bytesRead)
+  let blob
+  if ('slice' in file) {
+    // This is a real browser
+    blob = file.slice(0, bytesRead)
+  } else {
+    // Slice is undefined by the Deno adapter, this is likely Deno or a very confused browser
+    blob = await file.readBytes(0, bytesRead)
+  }
   if (file.size == 0) {
     callback({ error: new Issue({ code: 44, file: file }) })
     return


### PR DESCRIPTION
Couldn't come up with a cross compatible way to solve this without special casing it for our adapter but this shouldn't change the behavior with a real browser that defines File.slice().