### PR TITLE
Add bids-examples test to schema based validator.

### DIFF
--- a/bids-validator/src/deps/asserts.ts
+++ b/bids-validator/src/deps/asserts.ts
@@ -4,4 +4,4 @@ export {
   assertObjectMatch,
   assertExists,
   assertRejects,
-} from 'https://deno.land/std@0.130.0/testing/asserts.ts'
+} from 'https://deno.land/std@0.176.0/testing/asserts.ts'

--- a/bids-validator/src/deps/cliffy.ts
+++ b/bids-validator/src/deps/cliffy.ts
@@ -1,1 +1,5 @@
-export { Table } from 'https://deno.land/x/cliffy@v0.25.7/table/mod.ts'
+export {
+  Cell,
+  Row,
+  Table,
+} from 'https://deno.land/x/cliffy@v0.25.7/table/mod.ts'

--- a/bids-validator/src/issues/list.ts
+++ b/bids-validator/src/issues/list.ts
@@ -54,7 +54,7 @@ export const filenameIssues: IssueDefinitionRecord = {
     severity: 'error',
     reason: 'Some TSV columns are in the incorrect order',
   },
-  TSV_ADDITONAL_COLUMNS_NOT_ALLOWED: {
+  TSV_ADDITIONAL_COLUMNS_NOT_ALLOWED: {
     severity: 'error',
     reason:
       'A TSV file has extra columns which are not allowed for its file type',

--- a/bids-validator/src/schema/applyRules.ts
+++ b/bids-validator/src/schema/applyRules.ts
@@ -183,12 +183,12 @@ function evalInitialColumns(
   rule.initial_columns.map((ruleHeader: string, ruleIndex: number) => {
     const contextIndex = headers.findIndex((x) => x === ruleHeader)
     if (contextIndex === -1) {
-      const evidence = `Column with header ${ruleHeader} not found, indexed from 0 it should appear in column ${contextIndex}`
+      const evidence = `Column with header ${ruleHeader} not found, indexed from 0 it should appear in column ${ruleIndex}`
       context.issues.addNonSchemaIssue('TSV_COLUMN_MISSING', [
         { ...context.file, evidence: evidence },
       ])
     } else if (ruleIndex !== contextIndex) {
-      const evidence = `Column with header ${ruleHeader} found at index ${ruleIndex} while rule specifies, indexed form 0 it should be in column ${contextIndex}`
+      const evidence = `Column with header ${ruleHeader} found at index ${contextIndex} while rule specifies, indexed form 0 it should be in column ${ruleIndex}`
       context.issues.addNonSchemaIssue('TSV_COLUMN_ORDER_INCORRECT', [
         { ...context.file, evidence: evidence },
       ])

--- a/bids-validator/src/schema/applyRules.ts
+++ b/bids-validator/src/schema/applyRules.ts
@@ -18,9 +18,13 @@ export function applyRules(
   schema: GenericSchema,
   context: BIDSContext,
   rootSchema?: GenericSchema,
+  schemaPath?: string,
 ) {
   if (!rootSchema) {
     rootSchema = schema
+  }
+  if (!schemaPath) {
+    schemaPath = 'schema'
   }
   Object.assign(context, expressionFunctions)
   for (const key in schema) {
@@ -28,9 +32,19 @@ export function applyRules(
       continue
     }
     if ('selectors' in schema[key]) {
-      evalRule(schema[key] as GenericRule, context, rootSchema)
+      evalRule(
+        schema[key] as GenericRule,
+        context,
+        rootSchema,
+        `${schemaPath}.${key}`,
+      )
     } else if (schema[key].constructor === Object) {
-      applyRules(schema[key] as GenericSchema, context, rootSchema)
+      applyRules(
+        schema[key] as GenericSchema,
+        context,
+        rootSchema,
+        `${schemaPath}.${key}`,
+      )
     }
   }
   return Promise.resolve()
@@ -64,6 +78,7 @@ const evalMap: Record<
     rule: GenericRule,
     context: BIDSContext,
     schema: GenericSchema,
+    schemaPath: string,
   ) => boolean | void
 > = {
   checks: evalRuleChecks,
@@ -84,6 +99,7 @@ function evalRule(
   rule: GenericRule,
   context: BIDSContext,
   schema: GenericSchema,
+  schemaPath: string,
 ) {
   if (rule.selectors && !mapEvalCheck(rule.selectors, context)) {
     return
@@ -92,7 +108,7 @@ function evalRule(
     .filter((key) => key in evalMap)
     .map((key) => {
       // @ts-expect-error
-      evalMap[key](rule, context, schema)
+      evalMap[key](rule, context, schema, schemaPath)
     })
 }
 
@@ -108,18 +124,19 @@ function evalRuleChecks(
   rule: GenericRule,
   context: BIDSContext,
   schema: GenericSchema,
+  schemaPath: string,
 ): boolean {
   if (rule.checks && !mapEvalCheck(rule.checks, context)) {
     if (rule.issue?.code && rule.issue?.message) {
       context.issues.add({
         key: rule.issue.code,
         reason: rule.issue.message,
-        files: [{ ...context.file }],
+        files: [{ ...context.file, evidence: schemaPath }],
         severity: rule.issue.level as Severity,
       })
     } else {
       context.issues.addNonSchemaIssue('CHECK_ERROR', [
-        { ...context.file, evidence: JSON.stringify(rule) },
+        { ...context.file, evidence: schemaPath },
       ])
     }
   }
@@ -135,6 +152,7 @@ function evalColumns(
   rule: GenericRule,
   context: BIDSContext,
   schema: GenericSchema,
+  schemaPath: string,
 ): void {
   if (!rule.columns || context.extension !== '.tsv') return
   const headers = Object.keys(context.columns)
@@ -157,6 +175,7 @@ function evalInitialColumns(
   rule: GenericRule,
   context: BIDSContext,
   schema: GenericSchema,
+  schemaPath: string,
 ): void {
   if (!rule?.columns || !rule?.initial_columns || context.extension !== '.tsv')
     return
@@ -181,6 +200,7 @@ function evalAdditionalColumns(
   rule: GenericRule,
   context: BIDSContext,
   schema: GenericSchema,
+  schemaPath: string,
 ): void {
   if (context.extension !== '.tsv') return
   const headers = Object.keys(context?.columns)
@@ -201,6 +221,7 @@ function evalIndexColumns(
   rule: GenericRule,
   context: BIDSContext,
   schema: GenericSchema,
+  schemaPath: string,
 ): void {
   if (
     !rule?.columns ||
@@ -252,6 +273,7 @@ function evalJsonCheck(
   rule: GenericRule,
   context: BIDSContext,
   schema: GenericSchema,
+  schemaPath: string,
 ): void {
   for (const [key, requirement] of Object.entries(rule.fields)) {
     const severity = getFieldSeverity(requirement, context)
@@ -265,7 +287,7 @@ function evalJsonCheck(
         })
       } else {
         context.issues.addNonSchemaIssue('JSON_KEY_REQUIRED', [
-          { ...context.file, evidence: `missing ${key}` },
+          { ...context.file, evidence: `missing ${key} as per ${schemaPath}` },
         ])
       }
     }

--- a/bids-validator/src/schema/expressionLanguage.ts
+++ b/bids-validator/src/schema/expressionLanguage.ts
@@ -24,4 +24,7 @@ export const expressionFunctions = {
   count: <T>(list: T[], val: T): number => {
     return list.filter((x) => x === val).length
   },
+  exists: <T>(list: T[], val: T): boolean => {
+    return true
+  },
 }

--- a/bids-validator/src/setup/loadSchema.ts
+++ b/bids-validator/src/setup/loadSchema.ts
@@ -28,6 +28,7 @@ export async function loadSchema(version = 'latest'): Promise<Schema> {
       `Warning, could not load schema from ${schemaUrl}, falling back to internal version`,
     )
     return new Proxy(
+      // @ts-expect-error
       schemaDefault.default as object,
       objectPathHandler,
     ) as Schema

--- a/bids-validator/src/tests/local/bids_examples.ts
+++ b/bids-validator/src/tests/local/bids_examples.ts
@@ -1,0 +1,26 @@
+// Deno runtime tests for tests/data/valid_dataset
+import { IssueOutput } from '../../types/issues.ts'
+import { assert, assertEquals } from '../../deps/asserts.ts'
+import { validatePath, formatAssertIssue } from './common.ts'
+
+const options = { ignoreNiftiHeaders: true }
+
+function formatBEIssue(issue: IssueOutput) {
+  return `${issue.key}: ${issue.files[0].evidence} ${issue.files[0].file.name}`
+}
+
+Deno.test('validate bids-examples', async (t) => {
+  const prefix = 'tests/data/bids-examples'
+  for (const dirEntry of Deno.readDirSync(prefix)) {
+    if (!dirEntry.isDirectory) {
+      continue
+    }
+    const path = `${prefix}/${dirEntry.name}`
+    const { tree, result } = await validatePath(t, path, options)
+    const output = result.issues.formatOutput()
+    const errorMessages = output.errors.map((x) => formatBEIssue(x))
+    await t.step(`${path} has no issues`, () => {
+      assertEquals(output.errors.length, 0, Deno.inspect(errorMessages))
+    })
+  }
+})

--- a/bids-validator/src/tests/local/bids_examples.ts
+++ b/bids-validator/src/tests/local/bids_examples.ts
@@ -5,8 +5,20 @@ import { validatePath, formatAssertIssue } from './common.ts'
 
 const options = { ignoreNiftiHeaders: true }
 
-function formatBEIssue(issue: IssueOutput) {
-  return `${issue.key}: ${issue.files[0].evidence} ${issue.files[0].file.name}`
+function useIssue(issue: IssueOutput): boolean {
+  return (
+    'schema.rules.checks.general.DuplicateFiles' !== issue.files[0].evidence &&
+    issue.key !== 'EMPTY_FILE'
+  )
+}
+
+const errors: string[] = ['dataset\tissueKey\tschemaPath\tfileName\n']
+function formatBEIssue(issue: IssueOutput, dsPath: string) {
+  if (useIssue(issue)) {
+    errors.push(
+      `${dsPath}\t${issue.key}\t${issue.files[0].evidence}\t${issue.files[0].file.name}\n`,
+    )
+  }
 }
 
 Deno.test('validate bids-examples', async (t) => {
@@ -18,9 +30,11 @@ Deno.test('validate bids-examples', async (t) => {
     const path = `${prefix}/${dirEntry.name}`
     const { tree, result } = await validatePath(t, path, options)
     const output = result.issues.formatOutput()
-    const errorMessages = output.errors.map((x) => formatBEIssue(x))
+    output.errors = output.errors.filter((x) => useIssue(x))
+    output.errors.map((x) => formatBEIssue(x, dirEntry.name))
     await t.step(`${path} has no issues`, () => {
-      assertEquals(output.errors.length, 0, Deno.inspect(errorMessages))
+      assertEquals(output.errors.length, 0)
     })
   }
+  Deno.writeTextFile('./bids_examples_issues.tsv', errors.join(''))
 })

--- a/bids-validator/src/tests/local/bids_examples.ts
+++ b/bids-validator/src/tests/local/bids_examples.ts
@@ -5,8 +5,18 @@ import { validatePath, formatAssertIssue } from './common.ts'
 
 const options = { ignoreNiftiHeaders: true }
 
-function formatBEIssue(issue: IssueOutput) {
-  return `${issue.key}: ${issue.files[0].evidence} ${issue.files[0].file.name}`
+function useIssue(issue: IssueOutput): boolean {
+  return (
+    'schema.rules.checks.general.DuplicateFiles' !== issue.files[0].evidence &&
+    issue.key !== 'EMPTY_FILE'
+  )
+}
+
+const errors: string[] = ['dataset\tissueKey\tschemaPath\tfileName\n']
+function formatBEIssue(issue: IssueOutput, dsPath: string) {
+  errors.push(
+    `${dsPath}\t${issue.key}\t${issue.files[0].evidence}\t${issue.files[0].file.name}\n`,
+  )
 }
 
 Deno.test('validate bids-examples', async (t) => {
@@ -18,9 +28,11 @@ Deno.test('validate bids-examples', async (t) => {
     const path = `${prefix}/${dirEntry.name}`
     const { tree, result } = await validatePath(t, path, options)
     const output = result.issues.formatOutput()
-    const errorMessages = output.errors.map((x) => formatBEIssue(x))
+    output.errors = output.errors.filter((x) => useIssue(x))
+    output.errors.map((x) => formatBEIssue(x, dirEntry.name))
     await t.step(`${path} has no issues`, () => {
-      assertEquals(output.errors.length, 0, Deno.inspect(errorMessages))
+      assertEquals(output.errors.length, 0)
     })
   }
+  Deno.writeTextFile('./bids_examples_issues.tsv', errors.join(''))
 })

--- a/bids-validator/src/tests/local/bids_examples.ts
+++ b/bids-validator/src/tests/local/bids_examples.ts
@@ -22,7 +22,7 @@ function formatBEIssue(issue: IssueOutput, dsPath: string) {
 Deno.test('validate bids-examples', async (t) => {
   const prefix = 'tests/data/bids-examples'
   for (const dirEntry of Deno.readDirSync(prefix)) {
-    if (!dirEntry.isDirectory) {
+    if (!dirEntry.isDirectory || dirEntry.name.startsWith('.')) {
       continue
     }
     const path = `${prefix}/${dirEntry.name}`

--- a/bids-validator/src/tests/local/bids_examples.ts
+++ b/bids-validator/src/tests/local/bids_examples.ts
@@ -1,10 +1,13 @@
 // Deno runtime tests for tests/data/valid_dataset
-import { IssueOutput } from '../../types/issues.ts'
 import { assert, assertEquals } from '../../deps/asserts.ts'
+import { Cell, Row, Table } from '../../deps/cliffy.ts'
+import { colors } from '../../deps/fmt.ts'
+import { IssueOutput } from '../../types/issues.ts'
 import { validatePath, formatAssertIssue } from './common.ts'
 
 const options = { ignoreNiftiHeaders: true }
 
+// Stand in for old validator config that could ignore issues
 function useIssue(issue: IssueOutput): boolean {
   return (
     'schema.rules.checks.general.DuplicateFiles' !== issue.files[0].evidence &&
@@ -12,15 +15,23 @@ function useIssue(issue: IssueOutput): boolean {
   )
 }
 
-const errors: string[] = ['dataset\tissueKey\tschemaPath\tfileName\n']
+let header: string[] = ['issue key', 'filename', 'schema path']
+header = header.map((x) => colors.magenta(x))
+
+const errors: Row[] = []
 function formatBEIssue(issue: IssueOutput, dsPath: string) {
   errors.push(
-    `${dsPath}\t${issue.key}\t${issue.files[0].evidence}\t${issue.files[0].file.name}\n`,
+    Row.from([
+      colors.red(issue.key),
+      issue.files[0].file.name,
+      issue.files[0].evidence,
+    ]),
   )
 }
 
 Deno.test('validate bids-examples', async (t) => {
   const prefix = 'tests/data/bids-examples'
+
   for (const dirEntry of Deno.readDirSync(prefix)) {
     if (!dirEntry.isDirectory || dirEntry.name.startsWith('.')) {
       continue
@@ -29,10 +40,30 @@ Deno.test('validate bids-examples', async (t) => {
     const { tree, result } = await validatePath(t, path, options)
     const output = result.issues.formatOutput()
     output.errors = output.errors.filter((x) => useIssue(x))
-    output.errors.map((x) => formatBEIssue(x, dirEntry.name))
     await t.step(`${path} has no issues`, () => {
       assertEquals(output.errors.length, 0)
     })
+    if (output.errors.length === 0) {
+      continue
+    }
+
+    errors.push(
+      Row.from([
+        new Cell(colors.cyan(dirEntry.name)).colSpan(4),
+        undefined,
+        undefined,
+        undefined,
+      ]).border(true),
+    )
+    output.errors.map((x) => formatBEIssue(x, dirEntry.name))
   }
-  Deno.writeTextFile('./bids_examples_issues.tsv', errors.join(''))
+  const table = new Table()
+    .header(header)
+    .body(errors)
+    .border(false)
+    .padding(1)
+    .indent(2)
+    .maxColWidth(40)
+    .toString()
+  console.log(table)
 })

--- a/bids-validator/src/tests/local/common.ts
+++ b/bids-validator/src/tests/local/common.ts
@@ -5,11 +5,12 @@ import { ValidationResult } from '../../types/validation-result.ts'
 import { Issue } from '../../types/issues.ts'
 import { DatasetIssues } from '../../issues/datasetIssues.ts'
 import { Summary } from '../../summary/summary.ts'
-import { parseOptions } from '../../setup/options.ts'
+import { parseOptions, ValidatorOptions } from '../../setup/options.ts'
 
 export async function validatePath(
   t: Deno.TestContext,
   path: string,
+  options: Partial<ValidatorOptions> = {},
 ): Promise<{ tree: FileTree; result: ValidationResult }> {
   let tree: FileTree = new FileTree('', '')
   let summary = new Summary()
@@ -23,7 +24,7 @@ export async function validatePath(
   })
 
   await t.step('completes validation', async () => {
-    result = await validate(tree, parseOptions([path]))
+    result = await validate(tree, { ...parseOptions([path]), ...options })
   })
 
   return { tree, result }


### PR DESCRIPTION
To run from bids-validator/bids-validator:
`deno test --allow-write --allow-env --allow-read src/tests/local/bids_examples.ts`

generates a file called `bids_examples_issues.tsv` in calling directory.