### PR TITLE
Schema/web build fixes

### DIFF
--- a/bids-validator/build.ts
+++ b/bids-validator/build.ts
@@ -9,6 +9,33 @@ import { parse } from 'https://deno.land/std@0.175.0/flags/mod.ts'
 
 const MAIN_ENTRY = 'src/main.ts'
 
+const httpPlugin = {
+  name: 'http',
+  setup(build: esbuild.PluginBuild) {
+    build.onResolve({ filter: /^https?:\/\// }, (args) => ({
+      path: args.path,
+      namespace: 'http-url',
+    }))
+
+    build.onResolve({ filter: /.*/, namespace: 'http-url' }, (args) => ({
+      path: new URL(args.path, args.importer).toString(),
+      namespace: 'http-url',
+    }))
+
+    build.onLoad({ filter: /.*/, namespace: 'http-url' }, async (args) => {
+      const request = await fetch(args.path)
+      const contents = await request.text()
+      if (args.path.endsWith('.ts')) {
+        return { contents, loader: 'ts' }
+      } else if (args.path.endsWith('.json')) {
+        return { contents, loader: 'json' }
+      } else {
+        return { contents, loader: 'js' }
+      }
+    })
+  },
+}
+
 const flags = parse(Deno.args, {
   boolean: ['minify'],
   default: { minify: false },
@@ -20,6 +47,9 @@ const result = await esbuild.build({
   bundle: true,
   outdir: 'dist/validator',
   minify: flags.minify,
+  target: ['chrome109', 'firefox109', 'safari16'],
+  plugins: [httpPlugin],
+  allowOverwrite: true,
 })
 
 if (result.warnings.length > 0) {

--- a/bids-validator/src/deps/node.ts
+++ b/bids-validator/src/deps/node.ts
@@ -1,1 +1,0 @@
-export { createRequire } from 'https://deno.land/std@0.177.0/node/module.ts'


### PR DESCRIPTION
This forces inline bundling of the HTTP/HTTPS imports and passes them to the appropriate esbuild loader. Fixes all the import issues with this in Chrome except for a Deno reference in yargs, which is blocked by #1608 (or stubbing the Deno namespace for the browser).