### PR TITLE
[SCHEMA] Logger functions for debug flag

### DIFF
--- a/bids-validator/src/deps/logger.ts
+++ b/bids-validator/src/deps/logger.ts
@@ -10,4 +10,5 @@ export {
   handlers,
   getLogger,
 } from 'https://deno.land/std@0.177.0/log/mod.ts'
+export { LogLevelNames } from 'https://deno.land/std@0.177.0/log/levels.ts'
 export type { LevelName } from 'https://deno.land/std@0.177.0/log/mod.ts'

--- a/bids-validator/src/deps/logger.ts
+++ b/bids-validator/src/deps/logger.ts
@@ -1,0 +1,13 @@
+export {
+  Logger,
+  LogLevels,
+  error,
+  critical,
+  debug,
+  info,
+  setup,
+  warning,
+  handlers,
+  getLogger,
+} from 'https://deno.land/std@0.176.0/log/mod.ts'
+export type { LevelName } from 'https://deno.land/std@0.176.0/log/mod.ts'

--- a/bids-validator/src/deps/logger.ts
+++ b/bids-validator/src/deps/logger.ts
@@ -9,5 +9,5 @@ export {
   warning,
   handlers,
   getLogger,
-} from 'https://deno.land/std@0.176.0/log/mod.ts'
-export type { LevelName } from 'https://deno.land/std@0.176.0/log/mod.ts'
+} from 'https://deno.land/std@0.177.0/log/mod.ts'
+export type { LevelName } from 'https://deno.land/std@0.177.0/log/mod.ts'

--- a/bids-validator/src/main.ts
+++ b/bids-validator/src/main.ts
@@ -5,6 +5,7 @@ import { resolve } from './deps/path.ts'
 import { fullTestAdapter } from './compat/fulltest.ts'
 import { validate } from './validators/bids.ts'
 import { consoleFormat } from './utils/output.ts'
+import { setupLogging } from './utils/logger.ts'
 
 function inspect(obj: any) {
   console.log(
@@ -17,6 +18,7 @@ function inspect(obj: any) {
 
 export async function main() {
   const options = await parseOptions(Deno.args)
+  setupLogging(options.debug)
   const absolutePath = resolve(options.datasetPath)
   const tree = await readFileTree(absolutePath)
 

--- a/bids-validator/src/schema/context.ts
+++ b/bids-validator/src/schema/context.ts
@@ -164,10 +164,10 @@ export class BIDSContext implements Context {
       .text()
       .then((text) => parseTSV(text))
       .catch((error) => {
-        logger.warn(
+        logger.warning(
           `tsv file could not be opened by loadColumns '${this.file.path}'`,
         )
-        logger.error(error)
+        logger.debug(error)
         return {}
       })
     return

--- a/bids-validator/src/schema/context.ts
+++ b/bids-validator/src/schema/context.ts
@@ -8,12 +8,13 @@ import {
 } from '../types/context.ts'
 import { BIDSFile } from '../types/file.ts'
 import { FileTree } from '../types/filetree.ts'
-import { BIDSEntities, readEntities } from './entities.ts'
+import { readEntities } from './entities.ts'
 import { DatasetIssues } from '../issues/datasetIssues.ts'
 import { parseTSV } from '../files/tsv.ts'
 import { loadHeader } from '../files/nifti.ts'
 import { buildAssociations } from './associations.ts'
 import { ValidatorOptions } from '../setup/options.ts'
+import { logger } from '../utils/logger.ts'
 
 export class BIDSContextDataset implements ContextDataset {
   dataset_description: Record<string, unknown>
@@ -163,7 +164,10 @@ export class BIDSContext implements Context {
       .text()
       .then((text) => parseTSV(text))
       .catch((error) => {
-        console.log(error)
+        logger.warn(
+          `tsv file could not be opened by loadColumns '${this.file.path}'`,
+        )
+        logger.error(error)
         return {}
       })
     return

--- a/bids-validator/src/setup/options.test.ts
+++ b/bids-validator/src/setup/options.test.ts
@@ -6,7 +6,7 @@ Deno.test('options parsing', async (t) => {
     const options = await parseOptions(['my_dataset', '--json'])
     assertEquals(options, {
       datasetPath: 'my_dataset',
-      debug: 'error',
+      debug: 'ERROR',
       json: true,
       schema: 'latest',
     })

--- a/bids-validator/src/setup/options.ts
+++ b/bids-validator/src/setup/options.ts
@@ -1,6 +1,5 @@
+import { LevelName, LogLevels } from '../deps/logger.ts'
 import { Command, EnumType } from '../deps/cliffy.ts'
-
-export type DebugLevels = 'debug' | 'info' | 'warning' | 'error' | 'critical'
 
 export type ValidatorOptions = {
   datasetPath: string
@@ -10,7 +9,7 @@ export type ValidatorOptions = {
   verbose?: boolean
   ignoreNiftiHeaders?: boolean
   filenameMode?: boolean
-  debug: string
+  debug: LevelName
 }
 
 /**
@@ -22,10 +21,7 @@ export async function parseOptions(
 ): Promise<ValidatorOptions> {
   const { args, options } = await new Command()
     .name('bids-validator')
-    .type(
-      'debugLevel',
-      new EnumType(['debug', 'info', 'warning', 'error', 'critical']),
-    )
+    .type('debugLevel', new EnumType(Object.keys(LogLevels)))
     .description(
       'This tool checks if a dataset in a given directory is compatible with the Brain Imaging Data Structure specification. To learn more about Brain Imaging Data Structure visit http://bids.neuroimaging.io',
     )
@@ -46,7 +42,7 @@ export async function parseOptions(
       'Disregard NIfTI header content during validation',
     )
     .option('--debug <type:debugLevel>', 'Enable debug output', {
-      default: 'error',
+      default: 'ERROR',
       hidden: true,
     })
     .option(
@@ -57,5 +53,6 @@ export async function parseOptions(
   return {
     datasetPath: args[0],
     ...options,
+    debug: options.debug as LevelName,
   }
 }

--- a/bids-validator/src/setup/options.ts
+++ b/bids-validator/src/setup/options.ts
@@ -1,4 +1,4 @@
-import { LevelName, LogLevels } from '../deps/logger.ts'
+import { LevelName, LogLevelNames } from '../deps/logger.ts'
 import { Command, EnumType } from '../deps/cliffy.ts'
 
 export type ValidatorOptions = {
@@ -21,7 +21,7 @@ export async function parseOptions(
 ): Promise<ValidatorOptions> {
   const { args, options } = await new Command()
     .name('bids-validator')
-    .type('debugLevel', new EnumType(Object.keys(LogLevels)))
+    .type('debugLevel', new EnumType(LogLevelNames))
     .description(
       'This tool checks if a dataset in a given directory is compatible with the Brain Imaging Data Structure specification. To learn more about Brain Imaging Data Structure visit http://bids.neuroimaging.io',
     )
@@ -43,7 +43,6 @@ export async function parseOptions(
     )
     .option('--debug <type:debugLevel>', 'Enable debug output', {
       default: 'ERROR',
-      hidden: true,
     })
     .option(
       '--filenameMode',

--- a/bids-validator/src/utils/logger.ts
+++ b/bids-validator/src/utils/logger.ts
@@ -25,6 +25,7 @@ export function setupLogging(level: LevelName) {
 }
 
 const loggerProxyHandler = {
+  // deno-lint-ignore no-explicit-any
   get: function (_: any, prop: keyof Logger) {
     const logger = getLogger('@bids/validator')
     const stack = new Error().stack

--- a/bids-validator/src/utils/logger.ts
+++ b/bids-validator/src/utils/logger.ts
@@ -1,4 +1,10 @@
-import { setup, handlers, LevelName, getLogger } from '../deps/logger.ts'
+import {
+  setup,
+  handlers,
+  LevelName,
+  getLogger,
+  Logger,
+} from '../deps/logger.ts'
 
 /**
  * Setup a console logger used with the --debug flag
@@ -18,6 +24,19 @@ export function setupLogging(level: LevelName) {
   })
 }
 
-const logger = getLogger('@bids/validator')
+const loggerProxyHandler = {
+  get: function (_: void, prop: keyof Logger) {
+    const logger = getLogger('@bids/validator')
+    const stack = new Error().stack
+    if (stack) {
+      const callerLocation = stack.split('\n')[2].trim().split(' ')[1]
+      logger.debug(`Logger invoked at "${callerLocation}"`)
+    }
+    const logFunc = logger[prop] as typeof logger.warning
+    return logFunc.bind(logger)
+  },
+}
+
+const logger = new Proxy(getLogger('@bids/validator'), loggerProxyHandler)
 
 export { logger }

--- a/bids-validator/src/utils/logger.ts
+++ b/bids-validator/src/utils/logger.ts
@@ -25,7 +25,7 @@ export function setupLogging(level: LevelName) {
 }
 
 const loggerProxyHandler = {
-  get: function (_: void, prop: keyof Logger) {
+  get: function (_: any, prop: keyof Logger) {
     const logger = getLogger('@bids/validator')
     const stack = new Error().stack
     if (stack) {

--- a/bids-validator/src/utils/logger.ts
+++ b/bids-validator/src/utils/logger.ts
@@ -1,0 +1,23 @@
+import { setup, handlers, LevelName, getLogger } from '../deps/logger.ts'
+
+/**
+ * Setup a console logger used with the --debug flag
+ */
+export function setupLogging(level: LevelName) {
+  setup({
+    handlers: {
+      console: new handlers.ConsoleHandler(level),
+    },
+
+    loggers: {
+      '@bids/validator': {
+        level,
+        handlers: ['console'],
+      },
+    },
+  })
+}
+
+const logger = getLogger('@bids/validator')
+
+export { logger }


### PR DESCRIPTION
This adds some helpers for easily logging info. Logs everything to a channel named '@bids/validator' and `--debug DEBUG` to show all logs. Default is `--debug ERROR` but maybe it should be WARNING?