### PR TITLE
Avoid crashing when reporting config file errors

### DIFF
--- a/bids-validator/utils/consoleFormat.js
+++ b/bids-validator/utils/consoleFormat.js
@@ -18,7 +18,7 @@ function formatIssues(issues, options = {}) {
   var errors = issues.errors
   var warnings = issues.warnings
   var output = []
-  if (issues.errors.length === 1 && issues.errors[0].code === '61') {
+  if (errors && errors.length === 1 && errors[0].code === '61') {
     output.push(
       colors.red(
         '[ERR]  The given directory failed an initial Quick Test. This means the basic names and structure of the files and directories do not comply with BIDS specification. For more info go to https://bids.neuroimaging.io/',


### PR DESCRIPTION
When there's a config file error (for example, invalid JSON syntax in `.bids-validator-config.json`), the `issues` only has a `.config` member, and no `.errors` or `.warnings` members. So, we need to check whether `issues.errors` is defined before taking `issues.errors.length`. Otherwise, we get an unhandled rejection traceback, instead of the desired diagnostic output:

```
bids-validator@1.10.0
[ERR]  Invalid Config File
	1: [ERR] Unexpected comma. (code: 27 - JSON_INVALID)
		..bids-validator-config.json

	Please visit https://neurostars.org/search?q=JSON_INVALID for existing conversations about this issue.
```