### PR TITLE
Disable coverage for Deno tests due to hang

### DIFF
--- a/.github/workflows/deno_tests.yml
+++ b/.github/workflows/deno_tests.yml
@@ -29,4 +29,4 @@ jobs:
         run: |
           git submodule update --init --recursive
           git submodule update --recursive --remote
-      - run: deno test --allow-all --coverage=cov/ src/
+      - run: deno test --allow-all src/


### PR DESCRIPTION
Looks like the tests deadlock with coverage enabled. Likely an upstream Deno bug, disable for now.