### PR TITLE
CI: Reenable coverage for Deno tests due to hang

### DIFF
--- a/.github/workflows/deno_tests.yml
+++ b/.github/workflows/deno_tests.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           git submodule update --init --recursive
           git submodule update --recursive --remote
-      - run: deno test --allow-all src/
+      - run: deno test --allow-all --coverage=cov/ src/
 
   deploy:
     needs: [build]

--- a/.github/workflows/deno_tests.yml
+++ b/.github/workflows/deno_tests.yml
@@ -29,6 +29,7 @@ jobs:
 
   test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
     strategy:
       matrix:
         os: [ubuntu-22.04, macos-12, windows-2022]

--- a/.github/workflows/deno_tests.yml
+++ b/.github/workflows/deno_tests.yml
@@ -48,6 +48,13 @@ jobs:
           git submodule update --init --recursive
           git submodule update --recursive --remote
       - run: deno test --allow-all --coverage=cov/ src/
+      - name: Collect coverage
+        run: deno coverage cov/ --lcov --output=coverage.lcov
+        if: ${{ always() }}
+      - uses: codecov/codecov-action@v3
+        if: ${{ always() }}
+        with:
+          files: coverage.lcov
 
   deploy:
     needs: [build]


### PR DESCRIPTION
Tracking whether we can restore coverage without hanging. We should probably bump this ~weekly with a comment.

~~I believe this depends on https://github.com/denoland/deno/pull/16959 being merged.~~

Reverts bids-standard/bids-validator#1643.