### PR TITLE
Updated deno_tests.yaml to not fail fast

### DIFF
--- a/.github/workflows/deno_tests.yml
+++ b/.github/workflows/deno_tests.yml
@@ -17,6 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, macos-12, windows-2022]
+      fail-fast: false
     defaults:
       run:
         working-directory: ./bids-validator


### PR DESCRIPTION
Noticed fun new errors on osx, changed fail fast so they get noticed in CI. Ubuntu actions VM builds faster and causes windows and mac jobs to be cancelled before they can begin.

See issue #1645 