### PR TITLE
ENH: Local testing conveniences

### DIFF
--- a/bids-validator/src/setup/loadSchema.ts
+++ b/bids-validator/src/setup/loadSchema.ts
@@ -10,7 +10,10 @@ import * as schemaDefault from 'https://bids-specification.readthedocs.io/en/lat
 export async function loadSchema(version = 'latest'): Promise<Schema> {
   const versionRegex = /^v\d/
   let schemaUrl = version
-  if (version === 'latest' || versionRegex.test(version)) {
+  const bidsSchema = Deno.env.get('BIDS_SCHEMA')
+  if (bidsSchema !== undefined) {
+    schemaUrl = bidsSchema
+  } else if (version === 'latest' || versionRegex.test(version)) {
     schemaUrl = `https://bids-specification.readthedocs.io/en/${version}/schema.json`
   }
   try {

--- a/bids-validator/src/tests/local/bids_examples.test.ts
+++ b/bids-validator/src/tests/local/bids_examples.test.ts
@@ -31,8 +31,11 @@ function formatBEIssue(issue: IssueOutput, dsPath: string) {
 
 Deno.test('validate bids-examples', async (t) => {
   const prefix = 'tests/data/bids-examples'
+  const dirEntries = Array.from(Deno.readDirSync(prefix))
 
-  for (const dirEntry of Deno.readDirSync(prefix)) {
+  for (const dirEntry of dirEntries.sort((a, b) =>
+    a.name.localeCompare(b.name),
+  )) {
     if (!dirEntry.isDirectory || dirEntry.name.startsWith('.')) {
       continue
     }


### PR DESCRIPTION
Saving Nell's time by bugging ChatGPT instead.

This PR does two things:

1) Makes it possible to set the schema URL with the environment variable `BIDS_SCHEMA`
2) Sorts BIDS-examples directories to result in reproducible test ordering.