### PR TITLE
Schema/fix tsv val type check

### DIFF
--- a/bids-validator/src/files/ignore.ts
+++ b/bids-validator/src/files/ignore.ts
@@ -20,6 +20,7 @@ const defaultIgnores = [
   'stimuli/',
   'log/',
   '**/meg/*.ds/**',
+  '**/micr/*.zarr/**',
 ]
 
 /**

--- a/bids-validator/src/schema/applyRules.ts
+++ b/bids-validator/src/schema/applyRules.ts
@@ -162,6 +162,10 @@ function schemaObjectTypeCheck(
   value: string,
   schema: GenericSchema,
 ): boolean {
+  // always allow n/a?
+  if (value === 'n/a') {
+    return true
+  }
   if ('anyOf' in schemaObject) {
     return schemaObject.anyOf.some((x) =>
       schemaObjectTypeCheck(x, value, schema),
@@ -169,10 +173,6 @@ function schemaObjectTypeCheck(
   }
   if ('enum' in schemaObject && schemaObject.enum) {
     return schemaObject.enum.some((x) => x === value)
-  }
-  // always allow n/a?
-  if (value === 'n/a') {
-    return true
   }
   // @ts-expect-error
   const format = schema.objects.formats[schemaObject.type]

--- a/bids-validator/src/tests/local/bids_examples.test.ts
+++ b/bids-validator/src/tests/local/bids_examples.test.ts
@@ -4,8 +4,10 @@ import { Cell, Row, Table } from '../../deps/cliffy.ts'
 import { colors } from '../../deps/fmt.ts'
 import { IssueOutput } from '../../types/issues.ts'
 import { validatePath, formatAssertIssue } from './common.ts'
+import { parseOptions } from '../../setup/options.ts'
 
-const options = { ignoreNiftiHeaders: true }
+const options = await parseOptions(['fake_dataset_arg', ...Deno.args])
+options.ignoreNiftiHeaders = true
 
 // Stand in for old validator config that could ignore issues
 function useIssue(issue: IssueOutput): boolean {


### PR DESCRIPTION
Also ignores contents of zarr directories, and adds parsing of cli options when running deno test on bids-examples.ts.