### PR TITLE
Bundle CLI entrypoint with main() call

### DIFF
--- a/.github/workflows/deno_tests.yml
+++ b/.github/workflows/deno_tests.yml
@@ -74,7 +74,8 @@ jobs:
       - name: Commit to new branch
         run: |
           mv main/main.js .
-          git add main.js
+          mv main/bids-validator.js .
+          git add main.js bids-validator.js
           git commit -m "BLD: $VERSION [skip ci]" || true
       - name: Push
         run: git push origin deno-build

--- a/bids-validator/bids-validator-deno
+++ b/bids-validator/bids-validator-deno
@@ -1,3 +1,3 @@
 #!/bin/env -S deno run --allow-read --allow-write --allow-env --allow-net --allow-run
-import './src/run.ts'
+import './src/bids-validator.ts'
 

--- a/bids-validator/bids-validator-deno
+++ b/bids-validator/bids-validator-deno
@@ -1,4 +1,3 @@
 #!/bin/env -S deno run --allow-read --allow-write --allow-env --allow-net --allow-run
-import { main } from './src/main.ts'
+import './src/run.ts'
 
-await main()

--- a/bids-validator/build.ts
+++ b/bids-validator/build.ts
@@ -8,6 +8,7 @@ import * as esbuild from 'https://deno.land/x/esbuild@v0.17.5/mod.js'
 import { parse } from 'https://deno.land/std@0.175.0/flags/mod.ts'
 
 const MAIN_ENTRY = 'src/main.ts'
+const CLI_ENTRY = 'src/bids-validator.ts'
 
 const httpPlugin = {
   name: 'http',
@@ -43,7 +44,7 @@ const flags = parse(Deno.args, {
 
 const result = await esbuild.build({
   format: 'esm',
-  entryPoints: [MAIN_ENTRY],
+  entryPoints: [MAIN_ENTRY, CLI_ENTRY],
   bundle: true,
   outdir: 'dist/validator',
   minify: flags.minify,

--- a/bids-validator/src/bids-validator.ts
+++ b/bids-validator/src/bids-validator.ts
@@ -1,0 +1,3 @@
+import { main } from './main.ts'
+
+await main()


### PR DESCRIPTION
This adds a new `bids-validator.js` build output that can be run with Deno without any additional code. This avoids the need to inject a caller like `await main()` and lets you run the validator directly from the raw script URL.

I wasn't sure if I should name it bids-validator.js or something more or less descriptive. If you download this file, it's fairly intuitive to run it with this name: `deno run ./bids-validator.js`