### PR TITLE
fix(schema): Improve performance with memoization for evalConstructor

### DIFF
--- a/bids-validator/src/schema/applyRules.ts
+++ b/bids-validator/src/schema/applyRules.ts
@@ -8,6 +8,7 @@ import { Severity } from '../types/issues.ts'
 import { BIDSContext } from './context.ts'
 import { expressionFunctions } from './expressionLanguage.ts'
 import { logger } from '../utils/logger.ts'
+import { memoize } from '../utils/memoize.ts'
 
 /**
  * Given a schema and context, evaluate which rules match and test them.
@@ -62,8 +63,10 @@ const safeHas = () => true
 const safeGet = (target: any, prop: any) =>
   prop === Symbol.unscopables ? undefined : target[prop]
 
+const memoizedEvalConstructor = memoize(evalConstructor)
+
 export function evalCheck(src: string, context: BIDSContext) {
-  const test = evalConstructor(src)
+  const test = memoizedEvalConstructor(src)
   const safeContext = new Proxy(context, { has: safeHas, get: safeGet })
   try {
     return test(safeContext)

--- a/bids-validator/src/schema/associations.ts
+++ b/bids-validator/src/schema/associations.ts
@@ -105,7 +105,7 @@ function getPaths(
   targetExtensions: string[],
 ) {
   const validAssociations = fileTree.files.filter((file) => {
-    const { suffix, extension, entities } = readEntities(file)
+    const { suffix, extension, entities } = readEntities(file.name)
     return (
       targetExtensions.includes(extension) &&
       suffix === targetSuffix &&

--- a/bids-validator/src/schema/context.ts
+++ b/bids-validator/src/schema/context.ts
@@ -8,7 +8,7 @@ import {
 } from '../types/context.ts'
 import { BIDSFile } from '../types/file.ts'
 import { FileTree } from '../types/filetree.ts'
-import { readEntities } from './entities.ts'
+import { BIDSEntities, readEntities } from './entities.ts'
 import { DatasetIssues } from '../issues/datasetIssues.ts'
 import { parseTSV } from '../files/tsv.ts'
 import { loadHeader } from '../files/nifti.ts'
@@ -76,7 +76,7 @@ export class BIDSContext implements Context {
     this.filenameRules = []
     this.issues = issues
     this.file = file
-    const bidsEntities = readEntities(file)
+    const bidsEntities = readEntities(file.name)
     this.suffix = bidsEntities.suffix
     this.extension = bidsEntities.extension
     this.entities = bidsEntities.entities

--- a/bids-validator/src/schema/entities.test.ts
+++ b/bids-validator/src/schema/entities.test.ts
@@ -1,9 +1,9 @@
-import { assert, assertEquals } from '../deps/asserts.ts'
-import { BIDSFile } from '../types/file.ts'
+import { assert } from '../deps/asserts.ts'
 import { readEntities } from './entities.ts'
 import { nullReadBytes } from '../tests/nullReadBytes.ts'
+import { generateBIDSFilename } from '../tests/generate-filenames.ts'
 
-Deno.test('test readEntities', async (t) => {
+Deno.test('test readEntities', (t) => {
   const testFile = {
     name: 'task-rhymejudgment_bold.json',
     path: '/task-rhymejudgment_bold.json',
@@ -13,8 +13,29 @@ Deno.test('test readEntities', async (t) => {
     text: () => Promise.resolve(''),
     readBytes: nullReadBytes,
   }
-  const context = readEntities(testFile)
+  const context = readEntities(testFile.name)
   assert(context.suffix === 'bold', 'failed to match suffix')
   assert(context.extension === '.json', 'failed to match extension')
   assert(context.entities.task === 'rhymejudgment', 'failed to match extension')
+})
+
+Deno.test('test readEntities performance', (t) => {
+  const generateStart = performance.now()
+  const testFilenames = []
+  for (let n = 0; n < 200000; n++) {
+    testFilenames.push(generateBIDSFilename(Math.floor(Math.random() * 4)))
+  }
+  const generateEnd = performance.now()
+  const normalizePerf = generateEnd - generateStart
+
+  const start = performance.now()
+  for (const each of testFilenames) {
+    readEntities(each)
+  }
+  const end = performance.now()
+  const readEntitiesTime = end - start
+
+  const perfRatio = readEntitiesTime / normalizePerf + Number.EPSILON
+  console.log(`readEntities() runtime ratio: ${perfRatio.toFixed(2)}`)
+  assert(perfRatio < 2)
 })

--- a/bids-validator/src/schema/entities.ts
+++ b/bids-validator/src/schema/entities.ts
@@ -1,4 +1,4 @@
-import { BIDSFile } from '../types/file.ts'
+import { memoize } from '../utils/memoize.ts'
 
 export interface BIDSEntities {
   suffix: string
@@ -6,19 +6,15 @@ export interface BIDSEntities {
   entities: Record<string, string>
 }
 
-export function readEntities(file: BIDSFile): BIDSEntities {
+export function _readEntities(filename: string): BIDSEntities {
   let suffix = ''
   let extension = ''
-  let entities: Record<string, string> = {}
+  const entities: Record<string, string> = {}
 
-  let parts = file.name.split('_')
+  const parts = filename.split('_')
   for (let i = 0; i < parts.length - 1; i++) {
-    let [entity, label] = parts[i].split('-')
-    if (entity && label) {
-      entities[entity] = label
-    } else {
-      entities[entity] = 'NOENTITY'
-    }
+    const [entity, label] = parts[i].split('-')
+    entities[entity] = label || 'NOENTITY'
   }
 
   const lastPart = parts[parts.length - 1]
@@ -30,5 +26,7 @@ export function readEntities(file: BIDSFile): BIDSEntities {
     extension = lastPart.slice(extStart)
   }
 
-  return { suffix: suffix, extension: extension, entities: entities }
+  return { suffix, extension, entities }
 }
+
+export const readEntities = memoize(_readEntities)

--- a/bids-validator/src/tests/generate-filenames.ts
+++ b/bids-validator/src/tests/generate-filenames.ts
@@ -1,0 +1,26 @@
+function randomString() {
+  return Math.random().toString(36).substring(6)
+}
+
+function randomEntityString(prefix?: string): string {
+  if (prefix) {
+    return `${prefix}-${randomString()}`
+  } else {
+    return `${randomString()}-${randomString()}`
+  }
+}
+
+/**
+ * Generate random filenames not following entity ordering rules if length > 0
+ */
+export function generateBIDSFilename(length = 1, extension = '.json') {
+  const subject = randomEntityString('sub')
+  const session = randomEntityString('ses')
+  const run = randomEntityString('run')
+  const acquisition = randomEntityString('acq')
+  const parts = [subject, session, run, acquisition]
+  for (let n = 0; n < length; n++) {
+    parts.push(randomEntityString())
+  }
+  return parts.join('_') + extension
+}

--- a/bids-validator/src/utils/memoize.ts
+++ b/bids-validator/src/utils/memoize.ts
@@ -1,0 +1,10 @@
+export const memoize = <T = any>(fn: Function<T>) => {
+  const cache = new Map()
+  const cached = function (this: any, val: T) {
+    return cache.has(val)
+      ? cache.get(val)
+      : cache.set(val, fn.call(this, val)) && cache.get(val)
+  }
+  cached.cache = cache
+  return cached
+}

--- a/bids-validator/src/utils/memoize.ts
+++ b/bids-validator/src/utils/memoize.ts
@@ -1,4 +1,6 @@
-export const memoize = <T = any>(fn: Function<T>) => {
+export const memoize = <T>(
+  fn: (...args: any[]) => T,
+): ((...args: any[]) => T) => {
   const cache = new Map()
   const cached = function (this: any, val: T) {
     return cache.has(val)


### PR DESCRIPTION
This saves a decent amount of time constructing the evalConstructor function when the same function has already been parsed.

On a large dataset with 200k files, before:
```
real    4m14.717s
user    4m15.705s
sys     0m6.777s
```

After:
```
real    3m44.549s
user    3m46.593s
sys     0m6.151s
```