### PR TITLE
MNT: Configure dependabot to open npm update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,13 @@ updates:
     directory: '/'
     schedule:
       interval: 'monthly'
+
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+
+  - package-ecosystem: 'npm'
+    directory: '/bids-validator-web'
+    schedule:
+      interval: 'daily'


### PR DESCRIPTION
Closed #1422 as requested by dependabot, but it seems it can't open a new one due to our explicit configuration. This adds node packages to our configuration, setting daily for now.

I don't know what I'm doing here, really. I might be opening us up to a bunch of superfluous PRs.