### PR TITLE
Return 1 on most failures in cli try/except

### DIFF
--- a/bids-validator/bin/bids-validator
+++ b/bids-validator/bin/bids-validator
@@ -19,5 +19,6 @@ try {
     entry(cli)
   } else {
     console.log(err)
+    process.exitCode = 1
   }
 }


### PR DESCRIPTION
bids-examples run_tests.sh was returning 0 when using an old version of node was causing validator to crash.