### PR TITLE
FIX: Bump required Node.js to 18.0.0 (current LTS)

### DIFF
--- a/bids-validator/README.md
+++ b/bids-validator/README.md
@@ -38,7 +38,7 @@
       couple of minutes please open [developer tools ](https://developer.chrome.com/devtools)
       and report the error at [https://github.com/bids-standard/bids-validator/issues](https://github.com/bids-standard/bids-validator/issues).
 1. Command line version:
-   1. Install [Node.js](https://nodejs.org) (at least version 14.0.0)
+   1. Install [Node.js](https://nodejs.org) (at least version 18.0.0)
    1. Update `npm` to be at least version 7 (`npm install --global npm@^7`)
    1. From a terminal run `npm install -g bids-validator`
    1. Run `bids-validator` to start validating datasets.

--- a/bids-validator/esbuild.mjs
+++ b/bids-validator/esbuild.mjs
@@ -10,7 +10,7 @@ await esbuild.build({
     path.join(process.cwd(), 'utils', 'consoleFormat.js'),
   ],
   outdir: path.join(process.cwd(), 'dist', 'commonjs'),
-  target: 'node14',
+  target: 'node18',
   bundle: true,
   sourcemap: true,
   platform: 'node',

--- a/bids-validator/package.json
+++ b/bids-validator/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/bids-standard/bids-validator.git"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=18.0.0"
   },
   "bin": {
     "bids-validator": "bin/bids-validator"


### PR DESCRIPTION
Node 18 is the current LTS and Node 14 (our previous requirement) has reached end of life and is being dropped by dependencies.

Fixes #1711