### PR TITLE
FIX: Permit electrodes.tsv in meg directories

### DIFF
--- a/bids-validator/bids_validator/rules/file_level_rules.json
+++ b/bids-validator/bids_validator/rules/file_level_rules.json
@@ -488,6 +488,8 @@
         "_events\\.tsv",
         "_channels\\.json",
         "_channels\\.tsv",
+        "_electrodes\\.json",
+        "_electrodes\\.tsv",
         "_meg\\.json",
         "_coordsystem\\.json",
         "_photo\\.jpg",


### PR DESCRIPTION
Implements https://github.com/bids-standard/bids-specification/pull/1555 for the legacy validator. RECOMMENDED status can wait on the schema.