### PR TITLE
Bump hed-validator dep to v3.11.0

### DIFF
--- a/bids-validator/package.json
+++ b/bids-validator/package.json
@@ -45,7 +45,7 @@
     "date-fns": "^2.30.0",
     "events": "^3.3.0",
     "exifreader": "^4.12.1",
-    "hed-validator": "^3.10.0",
+    "hed-validator": "^3.11.0",
     "ignore": "^5.2.4",
     "is-utf8": "^0.2.1",
     "jest": "^29.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "date-fns": "^2.30.0",
         "events": "^3.3.0",
         "exifreader": "^4.12.1",
-        "hed-validator": "^3.10.0",
+        "hed-validator": "^3.11.0",
         "ignore": "^5.2.4",
         "is-utf8": "^0.2.1",
         "jest": "^29.5.0",
@@ -9993,9 +9993,9 @@
       "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
     },
     "node_modules/hed-validator": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/hed-validator/-/hed-validator-3.10.0.tgz",
-      "integrity": "sha512-n2AojmXlFc1/AtGBcUH+lTDpgqZBzd01tFOAvb2RIikkpp8b2gygDS5ETx6L6i65vH7TemBsaWEfOJWKhXNVUA==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/hed-validator/-/hed-validator-3.11.0.tgz",
+      "integrity": "sha512-si07/AG0kriyvMhdCd8j1kD5r2Kdhr6KKy4LYvoPTYqMoP9GJP5JZ1DeXKyTs5OSnL+JmXYAhZEzdh/CkXeDDQ==",
       "dependencies": {
         "buffer": "^6.0.3",
         "date-and-time": "^0.14.2",
@@ -23299,7 +23299,7 @@
         "eslint-plugin-prettier": "^4.2.1",
         "events": "^3.3.0",
         "exifreader": "^4.12.1",
-        "hed-validator": "^3.10.0",
+        "hed-validator": "^3.11.0",
         "husky": "^8.0.3",
         "ignore": "^5.2.4",
         "is-utf8": "^0.2.1",
@@ -25841,9 +25841,9 @@
       "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
     },
     "hed-validator": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/hed-validator/-/hed-validator-3.10.0.tgz",
-      "integrity": "sha512-n2AojmXlFc1/AtGBcUH+lTDpgqZBzd01tFOAvb2RIikkpp8b2gygDS5ETx6L6i65vH7TemBsaWEfOJWKhXNVUA==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/hed-validator/-/hed-validator-3.11.0.tgz",
+      "integrity": "sha512-si07/AG0kriyvMhdCd8j1kD5r2Kdhr6KKy4LYvoPTYqMoP9GJP5JZ1DeXKyTs5OSnL+JmXYAhZEzdh/CkXeDDQ==",
       "requires": {
         "buffer": "^6.0.3",
         "date-and-time": "^0.14.2",


### PR DESCRIPTION
See the release notes at https://github.com/hed-standard/hed-javascript/releases/tag/v3.11.0.