### PR TITLE
CI: Continue Windows builds even if chocolatey complains

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -47,6 +47,7 @@ jobs:
         uses: crazy-max/ghaction-chocolatey@v2
         with:
           args: install git-annex --yes --ignore-checksums
+        continue-on-error: true  # This can fail for stupid reasons ¯\_(ツ)_/¯
 
       - name: Install remaining dependencies
         shell: bash -l {0}


### PR DESCRIPTION
Looks like nobody takes particular responsibility for problems with the `git.install` package, but it can fail because the same version already exists on the system. (See https://github.com/chocolatey/choco/issues/1691)

Fixes #1765. I hope.

<!-- Fuck it. Computers are garbage and programmers are worse. -->