### PR TITLE
CI: Disable dependabot for NPM

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,13 +11,12 @@ updates:
     directory: '/'
     schedule:
       interval: 'monthly'
-
-  - package-ecosystem: 'npm'
-    directory: '/'
-    schedule:
-      interval: 'weekly'
-
-  - package-ecosystem: 'npm'
-    directory: '/bids-validator-web'
-    schedule:
-      interval: 'weekly'
+#   - package-ecosystem: 'npm'
+#     directory: '/'
+#     schedule:
+#       interval: 'weekly'
+#
+#   - package-ecosystem: 'npm'
+#     directory: '/bids-validator-web'
+#     schedule:
+#       interval: 'weekly'


### PR DESCRIPTION
Commenting out, so reenabling will be easy if desired.

Closes #1757.