### PR TITLE
FIX : motion.json typo fix and remove unused fields 

### DIFF
--- a/bids-validator/validators/json/schemas/motion.json
+++ b/bids-validator/validators/json/schemas/motion.json
@@ -27,7 +27,6 @@
     },
     "SubjectArtefactDescription": { "type": "string" },
     "MotionChannelCount": { "type": "number" },
-    "TrackingSystemCount": { "type": "number" },
     "TrackingSystemName": { "type": "string" },
     "DeviceSerialNumber": {
       "$ref": "common_definitions.json#/definitions/DeviceSerialNumber"
@@ -56,7 +55,7 @@
     "GYROChannelCount": { "type": "number" },
     "JNTANGChannelCount": { "type": "number" },
     "MAGNChannelCount": { "type": "number" },
-    "MISChannelCount": { "type": "number" },
+    "MISCChannelCount": { "type": "number" },
     "ORNTChannelCount": { "type": "number" },
     "POSChannelCount": { "type": "number" },
     "VELChannelCount": { "type": "number" },

--- a/bids-validator/validators/json/schemas/motion.json
+++ b/bids-validator/validators/json/schemas/motion.json
@@ -61,16 +61,7 @@
     "POSChannelCount": { "type": "number" },
     "VELChannelCount": { "type": "number" },
     "LATENCYChannelCount": { "type": "number" },
-    "MissingValues": { "type": "string" },
-    "RotationOrder": {
-      "type": "string",
-      "enum": ["XYZ", "XZY", "YXZ", "YZX", "ZXY", "ZYX"]
-    },
-    "RotationRule": {
-      "type": "string",
-      "enum": ["left-hand", "right-hand"]
-    },
-    "SpatialAxes": { "type": "string" }
+    "MissingValues": { "type": "string" }
   },
   "required": ["TaskName", "SamplingFrequency"],
   "additionalProperties": false


### PR DESCRIPTION
- Updated ´motion.json´ field `MISChannelCount` to `MISCChannelCount`
- Bring fields up-to-date with [spec change](https://github.com/bids-standard/bids-specification/pull/1524), removing `SpatialAxes`, `RotationOrder`, `RotationRule`
- Remove unused field `TrackingSystemCount`