### PR TITLE
wrap non array args to intersects in square brackets

### DIFF
--- a/bids-validator/src/schema/expressionLanguage.ts
+++ b/bids-validator/src/schema/expressionLanguage.ts
@@ -31,6 +31,12 @@ export const expressionFunctions = {
     return index != -1 ? index : null
   },
   intersects: <T>(a: T[], b: T[]): boolean => {
+    if (!Array.isArray(a)) {
+      a = [a]
+    }
+    if (!Array.isArray(b)) {
+      b = [b]
+    }
     return a.some((x) => b.includes(x))
   },
   match: (target: string, regex: string): boolean => {


### PR DESCRIPTION
fixes #1779 
pet002 in bids-examples uses `ReconFilterType`