### PR TITLE
Fix context.columns typescript issues

### DIFF
--- a/bids-validator/src/files/tsv.ts
+++ b/bids-validator/src/files/tsv.ts
@@ -2,13 +2,15 @@
  * TSV
  * Module for parsing TSV
  */
+import { ColumnsMap } from '../types/columns.ts'
+
 const normalizeEOL = (str: string): string =>
   str.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
 // Typescript resolved `row && !/^\s*$/.test(row)` as `string | boolean`
 const isContentfulRow = (row: string): boolean => !!(row && !/^\s*$/.test(row))
 
 export function parseTSV(contents: string) {
-  const columns: Map<string, string[]> = new Map<string, string[]>()
+  const columns = new ColumnsMap()
   const rows: string[][] = normalizeEOL(contents)
     .split('\n')
     .filter(isContentfulRow)
@@ -16,15 +18,13 @@ export function parseTSV(contents: string) {
   const headers = rows.length ? rows[0] : []
 
   headers.map((x) => {
-    columns.set(x, [])
+    columns[x] = []
   })
   for (let i = 1; i < rows.length; i++) {
     for (let j = 0; j < headers.length; j++) {
-      columns.get(headers[j])?.push(rows[i][j])
+      const col = columns[headers[j]] as string[]
+      col.push(rows[i][j])
     }
-  }
-  for (const [key, value] of columns) {
-    columns.set(key, value)
   }
   return columns
 }

--- a/bids-validator/src/files/tsv.ts
+++ b/bids-validator/src/files/tsv.ts
@@ -8,7 +8,7 @@ const normalizeEOL = (str: string): string =>
 const isContentfulRow = (row: string): boolean => !!(row && !/^\s*$/.test(row))
 
 export function parseTSV(contents: string) {
-  const columns: Record<string, string[]> = new Map()
+  const columns: Map<string, string[]> = new Map<string, string[]>()
   const rows: string[][] = normalizeEOL(contents)
     .split('\n')
     .filter(isContentfulRow)
@@ -20,11 +20,11 @@ export function parseTSV(contents: string) {
   })
   for (let i = 1; i < rows.length; i++) {
     for (let j = 0; j < headers.length; j++) {
-      columns.get(headers[j]).push(rows[i][j])
+      columns.get(headers[j])?.push(rows[i][j])
     }
   }
-  for (let [key, value] of columns) {
-    columns[key] = value
+  for (const [key, value] of columns) {
+    columns.set(key, value)
   }
   return columns
 }

--- a/bids-validator/src/schema/applyRules.ts
+++ b/bids-validator/src/schema/applyRules.ts
@@ -211,7 +211,7 @@ function evalColumns(
       ])
     }
     if (headers.includes(name)) {
-      for (const value of context.columns[name]) {
+      for (const value of context.columns.get(name) as string[]) {
         if (
           !schemaObjectTypeCheck(columnObject as SchemaTypeLike, value, schema)
         ) {
@@ -316,11 +316,11 @@ function evalIndexColumns(
     ])
     return
   }
-  const rowCount = context.columns[index_columns[0]].length
+  const rowCount = context.columns.get(index_columns[0])?.length || 0
   for (let i = 0; i < rowCount; i++) {
     let indexValue = ''
     index_columns.map((col: string) => {
-      indexValue = indexValue.concat(context.columns[col][i])
+      indexValue = indexValue.concat(context.columns.get(col)?.[i] || '')
     })
     if (uniqueIndexValues.has(indexValue)) {
       context.issues.addNonSchemaIssue('TSV_INDEX_VALUE_NOT_UNIQUE', [

--- a/bids-validator/src/schema/applyRules.ts
+++ b/bids-validator/src/schema/applyRules.ts
@@ -197,7 +197,7 @@ function evalColumns(
   schemaPath: string,
 ): void {
   if (!rule.columns || context.extension !== '.tsv') return
-  const headers = [...Object.keys(context.columns)]
+  const headers = [...Map.prototype.keys.bind(context.columns)()]
   for (const [ruleHeader, requirement] of Object.entries(rule.columns)) {
     // @ts-expect-error
     const columnObject = schema.objects.columns[ruleHeader]
@@ -240,7 +240,7 @@ function evalInitialColumns(
 ): void {
   if (!rule?.columns || !rule?.initial_columns || context.extension !== '.tsv')
     return
-  const headers = [...Object.keys(context.columns)]
+  const headers = [...Map.prototype.keys.bind(context.columns)()]
   rule.initial_columns.map((ruleHeader: string, ruleIndex: number) => {
     // @ts-expect-error
     const ruleHeaderName = schema.objects.columns[ruleHeader].name

--- a/bids-validator/src/schema/applyRules.ts
+++ b/bids-validator/src/schema/applyRules.ts
@@ -197,7 +197,7 @@ function evalColumns(
   schemaPath: string,
 ): void {
   if (!rule.columns || context.extension !== '.tsv') return
-  const headers = [...Map.prototype.keys.bind(context.columns)()]
+  const headers = [...Object.keys(context.columns)]
   for (const [ruleHeader, requirement] of Object.entries(rule.columns)) {
     // @ts-expect-error
     const columnObject = schema.objects.columns[ruleHeader]
@@ -240,7 +240,7 @@ function evalInitialColumns(
 ): void {
   if (!rule?.columns || !rule?.initial_columns || context.extension !== '.tsv')
     return
-  const headers = [...Map.prototype.keys.bind(context.columns)()]
+  const headers = [...Object.keys(context.columns)]
   rule.initial_columns.map((ruleHeader: string, ruleIndex: number) => {
     // @ts-expect-error
     const ruleHeaderName = schema.objects.columns[ruleHeader].name

--- a/bids-validator/src/schema/applyRules.ts
+++ b/bids-validator/src/schema/applyRules.ts
@@ -197,7 +197,7 @@ function evalColumns(
   schemaPath: string,
 ): void {
   if (!rule.columns || context.extension !== '.tsv') return
-  const headers = [...context.columns.keys()]
+  const headers = [...Object.keys(context.columns)]
   for (const [ruleHeader, requirement] of Object.entries(rule.columns)) {
     // @ts-expect-error
     const columnObject = schema.objects.columns[ruleHeader]
@@ -211,7 +211,7 @@ function evalColumns(
       ])
     }
     if (headers.includes(name)) {
-      for (const value of context.columns.get(name) as string[]) {
+      for (const value of context.columns[name] as string[]) {
         if (
           !schemaObjectTypeCheck(columnObject as SchemaTypeLike, value, schema)
         ) {
@@ -240,7 +240,7 @@ function evalInitialColumns(
 ): void {
   if (!rule?.columns || !rule?.initial_columns || context.extension !== '.tsv')
     return
-  const headers = [...context.columns.keys()]
+  const headers = [...Object.keys(context.columns)]
   rule.initial_columns.map((ruleHeader: string, ruleIndex: number) => {
     // @ts-expect-error
     const ruleHeaderName = schema.objects.columns[ruleHeader].name
@@ -316,11 +316,13 @@ function evalIndexColumns(
     ])
     return
   }
-  const rowCount = context.columns.get(index_columns[0])?.length || 0
+  const rowCount = (context.columns[index_columns[0]] as string[])?.length || 0
   for (let i = 0; i < rowCount; i++) {
     let indexValue = ''
     index_columns.map((col: string) => {
-      indexValue = indexValue.concat(context.columns.get(col)?.[i] || '')
+      indexValue = indexValue.concat(
+        (context.columns[col] as string[])?.[i] || '',
+      )
     })
     if (uniqueIndexValues.has(indexValue)) {
       context.issues.addNonSchemaIssue('TSV_INDEX_VALUE_NOT_UNIQUE', [

--- a/bids-validator/src/schema/associations.ts
+++ b/bids-validator/src/schema/associations.ts
@@ -1,4 +1,7 @@
-import { ContextAssociations } from '../types/context.ts'
+import {
+  ContextAssociations,
+  ContextAssociationsEvents,
+} from '../types/context.ts'
 import { BIDSFile } from '../types/file.ts'
 import { FileTree } from '../types/filetree.ts'
 import { BIDSContext } from './context.ts'
@@ -23,7 +26,9 @@ const associationLookup = {
     extensions: ['.tsv'],
     inherit: true,
     load: (file: BIDSFile): Promise<ContextAssociations['events']> => {
-      return file.text().then((text) => parseTSV(text))
+      return file
+        .text()
+        .then((text) => parseTSV(text) as ContextAssociationsEvents)
     },
   },
   aslcontext: {
@@ -72,7 +77,9 @@ const associationLookup = {
     extensions: ['.tsv'],
     inherit: true,
     load: (file: BIDSFile): Promise<ContextAssociations['events']> => {
-      return file.text().then((text) => parseTSV(text))
+      return file
+        .text()
+        .then((text) => parseTSV(text) as ContextAssociationsEvents)
     },
   },
 }

--- a/bids-validator/src/schema/context.ts
+++ b/bids-validator/src/schema/context.ts
@@ -62,7 +62,7 @@ export class BIDSContext implements Context {
   datatype: string
   modality: string
   sidecar: object
-  columns: Record<string, string[]>
+  columns: Map<string, string[]>
   associations: ContextAssociations
   nifti_header?: ContextNiftiHeader
 
@@ -131,12 +131,17 @@ export class BIDSContext implements Context {
     })
 
     if (validSidecars.length > 1) {
-      const exactMatch = validSidecars.find(sidecar => sidecar.path == this.file.path.replace(this.extension, ".json"));
+      const exactMatch = validSidecars.find(
+        (sidecar) =>
+          sidecar.path == this.file.path.replace(this.extension, '.json'),
+      )
       if (exactMatch) {
-        validSidecars.splice(1);
-        validSidecars[0] = exactMatch;
+        validSidecars.splice(1)
+        validSidecars[0] = exactMatch
       } else {
-        logger.warning(`Multiple sidecar files detected for '${this.file.path}'`)
+        logger.warning(
+          `Multiple sidecar files detected for '${this.file.path}'`,
+        )
       }
     }
 

--- a/bids-validator/src/schema/context.ts
+++ b/bids-validator/src/schema/context.ts
@@ -8,6 +8,7 @@ import {
 } from '../types/context.ts'
 import { BIDSFile } from '../types/file.ts'
 import { FileTree } from '../types/filetree.ts'
+import { ColumnsMap } from '../types/columns.ts'
 import { BIDSEntities, readEntities } from './entities.ts'
 import { DatasetIssues } from '../issues/datasetIssues.ts'
 import { parseTSV } from '../files/tsv.ts'
@@ -62,7 +63,7 @@ export class BIDSContext implements Context {
   datatype: string
   modality: string
   sidecar: object
-  columns: Map<string, string[]>
+  columns: ColumnsMap
   associations: ContextAssociations
   nifti_header?: ContextNiftiHeader
 
@@ -85,7 +86,7 @@ export class BIDSContext implements Context {
     this.datatype = ''
     this.modality = ''
     this.sidecar = {}
-    this.columns = {}
+    this.columns = new ColumnsMap()
     this.associations = {} as ContextAssociations
   }
 
@@ -182,7 +183,7 @@ export class BIDSContext implements Context {
           `tsv file could not be opened by loadColumns '${this.file.path}'`,
         )
         logger.debug(error)
-        return {}
+        return new Map<string, string[]>() as ColumnsMap
       })
     return
   }

--- a/bids-validator/src/types/columns.test.ts
+++ b/bids-validator/src/types/columns.test.ts
@@ -17,10 +17,4 @@ Deno.test('ColumnsMap', async (t) => {
     }
     assertEquals(columns.a, ['0'])
   })
-  await t.step('allows access to the keys function on the map', () => {
-    const columns = new ColumnsMap()
-    columns['a'] = ['0']
-    columns['b'] = ['1']
-    assertEquals(Array.from(columns.keys()), ['a', 'b'])
-  })
 })

--- a/bids-validator/src/types/columns.test.ts
+++ b/bids-validator/src/types/columns.test.ts
@@ -1,0 +1,19 @@
+import { assertEquals } from '../deps/asserts.ts'
+import { ColumnsMap } from './columns.ts'
+
+Deno.test('ColumnsMap', async (t) => {
+  await t.step('preserves insertion order with property access', () => {
+    const columns = new ColumnsMap()
+    columns['a'] = ['0']
+    columns[2] = ['1']
+    columns[1] = ['2']
+    columns['b'] = ['3']
+
+    // Check that the order is still correct with iteration
+    let iteration = 0
+    for (const [_, val] of columns) {
+      assertEquals(val, [iteration.toString()])
+      iteration += 1
+    }
+  })
+})

--- a/bids-validator/src/types/columns.test.ts
+++ b/bids-validator/src/types/columns.test.ts
@@ -17,4 +17,10 @@ Deno.test('ColumnsMap', async (t) => {
     }
     assertEquals(columns.a, ['0'])
   })
+  await t.step('allows access to the keys function on the map', () => {
+    const columns = new ColumnsMap()
+    columns['a'] = ['0']
+    columns['b'] = ['1']
+    assertEquals(Array.from(columns.keys()), ['a', 'b'])
+  })
 })

--- a/bids-validator/src/types/columns.test.ts
+++ b/bids-validator/src/types/columns.test.ts
@@ -15,5 +15,6 @@ Deno.test('ColumnsMap', async (t) => {
       assertEquals(val, [iteration.toString()])
       iteration += 1
     }
+    assertEquals(columns.a, ['0'])
   })
 })

--- a/bids-validator/src/types/columns.test.ts
+++ b/bids-validator/src/types/columns.test.ts
@@ -21,6 +21,7 @@ Deno.test('ColumnsMap', async (t) => {
       iteration += 1
     }
     assertEquals(columns.a, ['0'])
+    assertEquals(Object.keys(columns)[0], 'a')
   })
   await t.step('keys are accessible with Object.keys', () => {
     const columns = new ColumnsMap()

--- a/bids-validator/src/types/columns.test.ts
+++ b/bids-validator/src/types/columns.test.ts
@@ -2,6 +2,11 @@ import { assertEquals } from '../deps/asserts.ts'
 import { ColumnsMap } from './columns.ts'
 
 Deno.test('ColumnsMap', async (t) => {
+  await t.step('get is accessible with square bracket notation', () => {
+    const columns = new ColumnsMap()
+    columns['a'] = ['0']
+    assertEquals(columns['a'], ['0'])
+  })
   await t.step('preserves insertion order with property access', () => {
     const columns = new ColumnsMap()
     columns['a'] = ['0']
@@ -16,5 +21,11 @@ Deno.test('ColumnsMap', async (t) => {
       iteration += 1
     }
     assertEquals(columns.a, ['0'])
+  })
+  await t.step('keys are accessible with Object.keys', () => {
+    const columns = new ColumnsMap()
+    columns['a'] = ['0']
+    columns['b'] = ['1']
+    assertEquals(Object.keys(columns), ['a', 'b'])
   })
 })

--- a/bids-validator/src/types/columns.test.ts
+++ b/bids-validator/src/types/columns.test.ts
@@ -21,12 +21,13 @@ Deno.test('ColumnsMap', async (t) => {
       iteration += 1
     }
     assertEquals(columns.a, ['0'])
-    assertEquals(Object.keys(columns)[0], 'a')
   })
   await t.step('keys are accessible with Object.keys', () => {
     const columns = new ColumnsMap()
     columns['a'] = ['0']
     columns['b'] = ['1']
-    assertEquals(Object.keys(columns), ['a', 'b'])
+    columns[0] = ['2']
+    assertEquals(Object.keys(columns), ['a', 'b', '0'])
+    assertEquals(Object.getOwnPropertyNames(columns), ['a', 'b', '0'])
   })
 })

--- a/bids-validator/src/types/columns.ts
+++ b/bids-validator/src/types/columns.ts
@@ -8,7 +8,7 @@ export class ColumnsMap extends Map<string, string[]> {
   }
 }
 
-// Proxy handler to implement ColumnsMapType
+// Proxy handler to implement ColumnsMap type
 export const columnMapAccessorProxy = {
   get: function (
     target: ColumnsMap,

--- a/bids-validator/src/types/columns.ts
+++ b/bids-validator/src/types/columns.ts
@@ -13,8 +13,6 @@ export const columnMapAccessorProxy = {
   get: function (target: ColumnsMap, prop: any) {
     if (prop === Symbol.iterator) {
       return target[Symbol.iterator].bind(target)
-    } else if (prop === 'keys') {
-      return target.keys.bind(target)
     } else {
       return target.get(prop)
     }

--- a/bids-validator/src/types/columns.ts
+++ b/bids-validator/src/types/columns.ts
@@ -1,3 +1,5 @@
+import { PropertyComparer } from 'https://deno.land/x/ts_morph@14.0.0/common/ts_morph_common.js'
+
 // Allow ColumnsMap to be accessed as an object too
 export class ColumnsMap extends Map<string, string[]> {
   [key: string]: Map<string, string[]>[keyof Map<string, string[]>] | string[]
@@ -10,15 +12,21 @@ export class ColumnsMap extends Map<string, string[]> {
 
 // Proxy handler to implement ColumnsMapType
 export const columnMapAccessorProxy = {
-  get: function (target: ColumnsMap, prop: any) {
+  get: function (
+    target: ColumnsMap,
+    prop: symbol | string,
+    receiver: ColumnsMap,
+  ) {
     if (prop === Symbol.iterator) {
       return target[Symbol.iterator].bind(target)
     } else {
-      return target.get(prop)
+      return Reflect.get(target, prop, receiver)
     }
   },
   set: function (target: ColumnsMap, prop: string, value: string[]) {
-    target.set(prop, value)
-    return true
+    return Reflect.set(target, prop, value)
+  },
+  ownKeys: function (target: ColumnsMap) {
+    return Reflect.ownKeys(target)
   },
 }

--- a/bids-validator/src/types/columns.ts
+++ b/bids-validator/src/types/columns.ts
@@ -10,9 +10,9 @@ export class ColumnsMap extends Map<string, string[]> {
 
 // Proxy handler to implement ColumnsMapType
 export const columnMapAccessorProxy = {
-  get: function (target: ColumnsMap, prop: any, receiver: ColumnsMap) {
+  get: function (target: ColumnsMap, prop: any) {
     if (prop === Symbol.iterator) return target[Symbol.iterator].bind(target)
-    else return Reflect.get(target, prop, receiver)
+    else return target.get(prop)
   },
   set: function (target: ColumnsMap, prop: string, value: string[]) {
     target.set(prop, value)

--- a/bids-validator/src/types/columns.ts
+++ b/bids-validator/src/types/columns.ts
@@ -11,8 +11,13 @@ export class ColumnsMap extends Map<string, string[]> {
 // Proxy handler to implement ColumnsMapType
 export const columnMapAccessorProxy = {
   get: function (target: ColumnsMap, prop: any) {
-    if (prop === Symbol.iterator) return target[Symbol.iterator].bind(target)
-    else return target.get(prop)
+    if (prop === Symbol.iterator) {
+      return target[Symbol.iterator].bind(target)
+    } else if (prop === 'keys') {
+      return target.keys.bind(target)
+    } else {
+      return target.get(prop)
+    }
   },
   set: function (target: ColumnsMap, prop: string, value: string[]) {
     target.set(prop, value)

--- a/bids-validator/src/types/columns.ts
+++ b/bids-validator/src/types/columns.ts
@@ -1,0 +1,21 @@
+// Allow ColumnsMap to be accessed as an object too
+export class ColumnsMap extends Map<string, string[]> {
+  [key: string]: Map<string, string[]>[keyof Map<string, string[]>] | string[]
+  constructor() {
+    super()
+    const columns = new Map<string, string[]>() as ColumnsMap
+    return new Proxy<ColumnsMap>(columns, columnMapAccessorProxy)
+  }
+}
+
+// Proxy handler to implement ColumnsMapType
+export const columnMapAccessorProxy = {
+  get: function (target: ColumnsMap, prop: any, receiver: ColumnsMap) {
+    if (prop === Symbol.iterator) return target[Symbol.iterator].bind(target)
+    else return Reflect.get(target, prop, receiver)
+  },
+  set: function (target: ColumnsMap, prop: string, value: string[]) {
+    target.set(prop, value)
+    return true
+  },
+}


### PR DESCRIPTION
Implement ColumnsMap class for preserving ordered keys when creating a parseTSV object. ColumnsMap can be constructed to return a proxy which allows the underlying map to be accessed with a property accessor (`map[key]`) like it is a regular object. A limitation of the proxy is that it only allows key access and iteration, other methods on the underlying map are not passed through and some object functions will not work.