### PR TITLE
FIX: Guard Deno reference in loadSchema to allow for browser usage

### DIFF
--- a/bids-validator/src/setup/loadSchema.ts
+++ b/bids-validator/src/setup/loadSchema.ts
@@ -10,7 +10,7 @@ import * as schemaDefault from 'https://bids-specification.readthedocs.io/en/lat
 export async function loadSchema(version = 'latest'): Promise<Schema> {
   const versionRegex = /^v\d/
   let schemaUrl = version
-  const bidsSchema = Deno.env.get('BIDS_SCHEMA')
+  const bidsSchema = typeof Deno !== 'undefined' && Deno.env.get('BIDS_SCHEMA')
   if (bidsSchema !== undefined) {
     schemaUrl = bidsSchema
   } else if (version === 'latest' || versionRegex.test(version)) {


### PR DESCRIPTION
Without this, loadSchema will fail in the browser because of the undefined reference to Deno.