### PR TITLE
FIX: Handle webkitRelativePath returning dataset parent directory correctly when loading browser file

### DIFF
--- a/bids-validator/src/files/browser.test.ts
+++ b/bids-validator/src/files/browser.test.ts
@@ -23,9 +23,9 @@ Deno.test('Browser implementation of FileTree', async (t) => {
       new TestFile(
         ['{}'],
         'dataset_description.json',
-        'dataset_description.json',
+        'ds/dataset_description.json',
       ),
-      new TestFile(['flat test dataset'], 'README.md', 'README.md'),
+      new TestFile(['flat test dataset'], 'README.md', 'ds/README.md'),
     ]
     const tree = await fileListToTree(files)
     const expectedTree = new FileTree('', '/', undefined)
@@ -38,18 +38,22 @@ Deno.test('Browser implementation of FileTree', async (t) => {
       new TestFile(
         ['{}'],
         'dataset_description.json',
-        'dataset_description.json',
+        'ds/dataset_description.json',
       ),
       new TestFile(
         ['tsv headers\n', 'column\tdata'],
         'participants.tsv',
-        'participants.tsv',
+        'ds/participants.tsv',
       ),
-      new TestFile(['single subject test dataset'], 'README.md', 'README.md'),
+      new TestFile(
+        ['single subject test dataset'],
+        'README.md',
+        'ds/README.md',
+      ),
       new TestFile(
         ['nifti file goes here'],
         'sub-01_T1w.nii.gz',
-        'sub-01/anat/sub-01_T1w.nii.gz',
+        'ds/sub-01/anat/sub-01_T1w.nii.gz',
       ),
     ]
     const tree = await fileListToTree(files)

--- a/bids-validator/src/files/browser.ts
+++ b/bids-validator/src/files/browser.ts
@@ -21,7 +21,9 @@ export class BIDSFileBrowser implements BIDSFile {
 
   get path(): string {
     // @ts-expect-error webkitRelativePath is defined in the browser
-    return this.#file.webkitRelativePath
+    const relativePath = this.#file.webkitRelativePath
+    const prefixLength = relativePath.indexOf('/')
+    return relativePath.substring(prefixLength)
   }
 
   get size(): number {
@@ -54,11 +56,11 @@ export function fileListToTree(files: File[]): Promise<FileTree> {
   for (const f of files) {
     const file = new BIDSFileBrowser(f, ignore)
     const fPath = parse(file.path)
-    const levels = fPath.dir.split(SEP)
-    if (levels[0] === '') {
+    if (fPath.dir === '/') {
       // Top level file
       tree.files.push(file)
     } else {
+      const levels = fPath.dir.split(SEP).slice(1)
       let currentLevelTree = tree
       for (const level of levels) {
         const exists = currentLevelTree.directories.find(


### PR DESCRIPTION
The tests here incorrectly assumed the parent directory would not be included when uploading a dataset. This fixes the prefix in tests and updates fileListToTree to match the tree shape to the Deno CLI version (where parent directory is not included).