### PR TITLE
Reduce bids-validator-web pack size.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ __pycache__/
 dist/
 *.egg-info/
 bids-validator-web/out/
-bids-validator-web/.next/
+.next/
 
 # Only use global yarn.lock
 bids-validator/yarn.lock


### PR DESCRIPTION
npm pack uses gitignore relative to the workspace directory. Removed leading path for .next in gitignore.