### PR TITLE
RF: Parse bval/bvec files uniformly, add n_rows attribute to associations

### DIFF
--- a/bids-validator/src/files/dwi.ts
+++ b/bids-validator/src/files/dwi.ts
@@ -5,18 +5,11 @@
 const normalizeEOL = (str: string): string =>
   str.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
 
-export function parseBval(contents: string): number[][] {
-  // BVAL files are a single row of numbers, and may contain
-  // trailing whitespace
-  return [contents
-    .split(/\s+/)
-    .filter((x) => x !== '')
-    .map((x) => Number(x))]
-}
-
-export function parseBvec(contents: string): number[][] {
+export function parseBvalBvec(contents: string): number[][] {
   // BVEC files are a matrix of numbers, with each row being
   // a different axis
+  // BVAL files are a single row of numbers, and may contain
+  // trailing whitespace
   return normalizeEOL(contents)
     .split(/\s*\n/)
     .filter((x) => x !== '')

--- a/bids-validator/src/schema/associations.ts
+++ b/bids-validator/src/schema/associations.ts
@@ -7,7 +7,7 @@ import { FileTree } from '../types/filetree.ts'
 import { BIDSContext } from './context.ts'
 import { readEntities } from './entities.ts'
 import { parseTSV } from '../files/tsv.ts'
-import { parseBval, parseBvec } from '../files/dwi.ts'
+import { parseBvalBvec } from '../files/dwi.ts'
 
 // type AssociationsLookup = Record<keyof ContextAssociations, { extensions: string[], inherit: boolean, load: ... }
 
@@ -82,10 +82,11 @@ const associationLookup = {
     inherit: true,
     load: async (file: BIDSFile): Promise<ContextAssociations['bval']> => {
       const contents = await file.text()
-      const columns = parseBval(contents)
+      const columns = parseBvalBvec(contents)
       return {
         path: file.path,
         n_cols: columns ? columns[0].length : 0,
+        n_rows: columns ? columns.length : 0,
       }
     },
   },
@@ -95,10 +96,11 @@ const associationLookup = {
     inherit: true,
     load: async (file: BIDSFile): Promise<ContextAssociations['bvec']> => {
       const contents = await file.text()
-      const columns = parseBvec(contents)
+      const columns = parseBvalBvec(contents)
       return {
         path: file.path,
         n_cols: columns ? columns[0].length : 0,
+        n_rows: columns ? columns.length : 0,
       }
     },
   },

--- a/bids-validator/src/types/context.ts
+++ b/bids-validator/src/types/context.ts
@@ -43,10 +43,12 @@ export interface ContextAssociationsMagnitude1 {
 export interface ContextAssociationsBval {
   path: string
   n_cols: number
+  n_rows: number
 }
 export interface ContextAssociationsBvec {
   path: string
   n_cols: number
+  n_rows: number
 }
 export interface ContextAssociationsChannels {
   path?: string


### PR DESCRIPTION
This PR is paired with https://github.com/bids-standard/bids-specification/pull/1622, which proposes augmenting the bval/bvec associations in the context.

This simplifies things a bit by using the same code to parse bvals and bvecs, ensuring that bugs found and fixed in one will work for the other.