### PR TITLE
FIX: Un-define the unspecified Context.data

### DIFF
--- a/bids-validator/src/schema/context.ts
+++ b/bids-validator/src/schema/context.ts
@@ -5,7 +5,6 @@ import {
   ContextSubject,
   ContextAssociations,
   ContextNiftiHeader,
-  ContextData,
 } from '../types/context.ts'
 import { BIDSFile } from '../types/file.ts'
 import { FileTree } from '../types/filetree.ts'
@@ -13,7 +12,6 @@ import { ColumnsMap } from '../types/columns.ts'
 import { BIDSEntities, readEntities } from './entities.ts'
 import { DatasetIssues } from '../issues/datasetIssues.ts'
 import { parseTSV } from '../files/tsv.ts'
-import { parseBval, parseBvec } from '../files/dwi.ts'
 import { loadHeader } from '../files/nifti.ts'
 import { buildAssociations } from './associations.ts'
 import { ValidatorOptions } from '../setup/options.ts'
@@ -68,7 +66,6 @@ export class BIDSContext implements Context {
   columns: ColumnsMap
   associations: ContextAssociations
   nifti_header?: ContextNiftiHeader
-  data?: ContextData
 
   constructor(
     fileTree: FileTree,
@@ -174,27 +171,6 @@ export class BIDSContext implements Context {
     }
   }
 
-  // Currently un-specified bit of context needed for bval/bvec
-  async loadData(): Promise<void> {
-    let parser
-    if (this.file.path.endsWith('.bval')) {
-      parser = parseBval
-    } else if (this.file.path.endsWith('.bvec')) {
-      parser = parseBvec
-    }
-    if (parser) {
-      this.data = await this.file
-        .text()
-        .then(parser as (value: string) => number[][])
-        .then((data) => {
-          return {
-            n_rows: data.length,
-            n_cols: data ? data[0].length : 0,
-          }
-        }).then((ret) => {console.log(ret); return ret})
-    }
-  }
-
   async loadColumns(): Promise<void> {
     if (this.extension !== '.tsv') {
       return
@@ -222,7 +198,6 @@ export class BIDSContext implements Context {
       this.loadSidecar(),
       this.loadColumns(),
       this.loadAssociations(),
-      this.loadData(),
     ])
     this.loadNiftiHeader()
   }

--- a/bids-validator/src/types/context.ts
+++ b/bids-validator/src/types/context.ts
@@ -86,10 +86,6 @@ export interface ContextNiftiHeader {
   qform_code: number
   sform_code: number
 }
-export interface ContextData {
-  n_cols?: number
-  n_rows?: number
-}
 export interface Context {
   dataset: ContextDataset
   subject: ContextSubject
@@ -104,5 +100,4 @@ export interface Context {
   columns: object
   json: object
   nifti_header?: ContextNiftiHeader
-  data?: ContextData
 }


### PR DESCRIPTION
Introduced in #1797, but broken and made unnecessary by #1813 and bids-standard/bids-specification#1622.

This should fix one of the failing CI tests.