### PR TITLE
ENH: Enable structured Level descriptions for TSV columns

### DIFF
--- a/bids-validator/validators/json/schemas/data_dictionary.json
+++ b/bids-validator/validators/json/schemas/data_dictionary.json
@@ -27,7 +27,21 @@
           "description": "For  categorical variables: a dictionary of possible values (keys) and their descriptions (values).",
           "patternProperties": {
             "^.+$": {
-              "type": "string"
+              "anyOf": [
+                { "type": "string" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Description": { "type": "string" },
+                    "TermURL": {
+                      "title": "TermURL",
+                      "description": "URL pointing to a formal definition in an ontology available on the web.",
+                      "type": "string",
+                      "format": "uri"
+                    }
+                  }
+                }
+              ]
             }
           }
         },

--- a/bids-validator/validators/json/schemas/events.json
+++ b/bids-validator/validators/json/schemas/events.json
@@ -27,7 +27,21 @@
           "description": "For categorical variables: a dictionary of possible values (keys) and their descriptions (values).",
           "patternProperties": {
             "^.+$": {
-              "type": "string"
+              "anyOf": [
+                { "type": "string" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Description": { "type": "string" },
+                    "TermURL": {
+                      "title": "TermURL",
+                      "description": "URL pointing to a formal definition in an ontology available on the web.",
+                      "type": "string",
+                      "format": "uri"
+                    }
+                  }
+                }
+              ]
             }
           }
         },


### PR DESCRIPTION
Follow-up to bids-standard/bids-specification#1603. Adds support for levels in legacy validator.

xref https://github.com/bids-standard/bids-examples/pull/413