### PR TITLE
feat: Add an export for validateCommand to allow other tools to reuse the validator's argument parsing

### DIFF
--- a/bids-validator/src/setup/options.ts
+++ b/bids-validator/src/setup/options.ts
@@ -12,6 +12,35 @@ export type ValidatorOptions = {
   debug: LevelName
 }
 
+export const validateCommand = new Command()
+  .name('bids-validator')
+  .type('debugLevel', new EnumType(LogLevelNames))
+  .description(
+    'This tool checks if a dataset in a given directory is compatible with the Brain Imaging Data Structure specification. To learn more about Brain Imaging Data Structure visit http://bids.neuroimaging.io',
+  )
+  .arguments('<dataset_directory>')
+  .version('alpha')
+  .option('--json', 'Output machine readable JSON')
+  .option(
+    '-s, --schema <type:string>',
+    'Specify a schema version to use for validation',
+    {
+      default: 'latest',
+    },
+  )
+  .option('-v, --verbose', 'Log more extensive information about issues')
+  .option(
+    '--ignoreNiftiHeaders',
+    'Disregard NIfTI header content during validation',
+  )
+  .option('--debug <type:debugLevel>', 'Enable debug output', {
+    default: 'ERROR',
+  })
+  .option(
+    '--filenameMode',
+    'Enable filename checks for newline separated filenames read from stdin',
+  )
+
 /**
  * Parse command line options and return a ValidatorOptions config
  * @param argumentOverride Override the arguments instead of using Deno.args
@@ -19,35 +48,7 @@ export type ValidatorOptions = {
 export async function parseOptions(
   argumentOverride: string[] = Deno.args,
 ): Promise<ValidatorOptions> {
-  const { args, options } = await new Command()
-    .name('bids-validator')
-    .type('debugLevel', new EnumType(LogLevelNames))
-    .description(
-      'This tool checks if a dataset in a given directory is compatible with the Brain Imaging Data Structure specification. To learn more about Brain Imaging Data Structure visit http://bids.neuroimaging.io',
-    )
-    .arguments('<dataset_directory>')
-    .version('alpha')
-    .option('--json', 'Output machine readable JSON')
-    .option(
-      '-s, --schema <type:string>',
-      'Specify a schema version to use for validation',
-      {
-        default: 'latest',
-      },
-    )
-    .option('-v, --verbose', 'Log more extensive information about issues')
-    .option(
-      '--ignoreNiftiHeaders',
-      'Disregard NIfTI header content during validation',
-    )
-    .option('--debug <type:debugLevel>', 'Enable debug output', {
-      default: 'ERROR',
-    })
-    .option(
-      '--filenameMode',
-      'Enable filename checks for newline separated filenames read from stdin',
-    )
-    .parse(argumentOverride)
+  const { args, options } = await validateCommand.parse(argumentOverride)
   return {
     datasetPath: args[0],
     ...options,


### PR DESCRIPTION
Exporting validateCommand lets OpenNeuro provide the validator arguments for any commands that requires validation (upload) without needing to duplicate the command parsing.