### PR TITLE
FIX: Shadow size property of columns object, so it acts as a column

### DIFF
--- a/bids-validator/src/types/columns.test.ts
+++ b/bids-validator/src/types/columns.test.ts
@@ -30,4 +30,17 @@ Deno.test('ColumnsMap', async (t) => {
     assertEquals(Object.keys(columns), ['a', 'b', '0'])
     assertEquals(Object.getOwnPropertyNames(columns), ['a', 'b', '0'])
   })
+  await t.step('size columns are permissible', () => {
+    const columns = new ColumnsMap()
+    // @ts-expect-error
+    columns['size'] = ['0']
+    // @ts-expect-error
+    assertEquals(columns.size, ['0'])
+  })
+  await t.step('missing columns are undefined', () => {
+    const columns = new ColumnsMap()
+    columns['a'] = ['0']
+    assertEquals(columns.b, undefined)
+    assertEquals(columns.size, undefined)
+  })
 })

--- a/bids-validator/src/types/columns.ts
+++ b/bids-validator/src/types/columns.ts
@@ -15,6 +15,8 @@ export const columnMapAccessorProxy = {
     prop: symbol | string,
     receiver: ColumnsMap,
   ) {
+    // Map.size exists, so we need to shadow it with the column contents
+    if (prop === 'size') return target.get('size')
     const value = Reflect.get(target, prop, receiver)
     if (typeof value === 'function') return value.bind(target)
     if (prop === Symbol.iterator) return target[Symbol.iterator].bind(target)


### PR DESCRIPTION
Fixes #1824. This is a narrow fix for the size column. I believe the other things that could potentially be shadowed are:

* length
* entries
* keys
* hasOwnProperty
* constructor
* prototype
* toString

`length` is the only one that seems plausible to eventually have as a header, but it is not defined in BIDS, so I'm inclined to leave it alone for now.

I add a test that `size` is permissible and returns a column if present and returns `undefined` like other absent columns if absent.