### PR TITLE
Update Python library docs

### DIFF
--- a/bids-validator/README.md
+++ b/bids-validator/README.md
@@ -56,7 +56,9 @@
       [Conda package](https://anaconda.org/conda-forge/bids-validator).
    1. Open a Python terminal and type: `python`
    1. Import the BIDS Validator package `from bids_validator import BIDSValidator`
-   1. Check if a file is BIDS compatible `BIDSValidator().is_bids('path/to/a/bids/file')`
+   1. Check if a file is BIDS compatible `BIDSValidator().is_bids('/relative/path/to/a/bids/file')`
+   1. Note, the file path must be relative to the root of the BIDS dataset, and
+      a leading forward slash `/` must be added to the file path.
 
 ## Support
 
@@ -404,6 +406,9 @@ filepaths = ["/sub-01/anat/sub-01_rec-CSD_T1w.nii.gz", "/sub-01/anat/sub-01_acq-
 for filepath in filepaths:
     print(validator.is_bids(filepath))  # will print True, and then False
 ```
+
+Note, the file path must be relative to the root of the BIDS dataset, and a 
+leading forward slash `/` must be added to the file path.
 
 ## Development
 

--- a/bids-validator/bids_validator/bids_validator.py
+++ b/bids-validator/bids_validator/bids_validator.py
@@ -30,14 +30,14 @@ class BIDSValidator():
     def is_bids(self, path):
         """Check if file path adheres to BIDS.
 
-        Main method of the validator. uses other class methods for checking
+        Main method of the validator. Uses other class methods for checking
         different aspects of the file path.
 
         Parameters
         ----------
         path : str
             Path of a file to be checked. Must be relative to root of a BIDS
-            dataset.
+            dataset, and must include a leading forward slash `/`.
 
         Notes
         -----
@@ -45,7 +45,7 @@ class BIDSValidator():
         root of the BIDS dataset the file is part of. That is, as soon as the
         file path contains parts outside of the BIDS dataset, the validation
         will fail. For example "home/username/my_dataset/participants.tsv" will
-        fail, although "participants.tsv" is a valid BIDS file.
+        fail, although "/participants.tsv" is a valid BIDS file.
 
         Examples
         --------


### PR DESCRIPTION
## Description
Add a note that for the Python library the file path must be relative to the root of the BIDS dataset, and a leading forward slash `/` must be added to the file path.

## Changes
- [x] Update readme
- [x] Update `is_bids` docstring