### PR TITLE
Bump hed-validator to 3.13.1

### DIFF
--- a/bids-validator/package.json
+++ b/bids-validator/package.json
@@ -45,7 +45,7 @@
     "date-fns": "^2.30.0",
     "events": "^3.3.0",
     "exifreader": "^4.17.0",
-    "hed-validator": "^3.12.0",
+    "hed-validator": "^3.13.1",
     "ignore": "^5.3.0",
     "is-utf8": "^0.2.1",
     "jest": "^29.7.0",

--- a/bids-validator/validators/hed.js
+++ b/bids-validator/validators/hed.js
@@ -102,14 +102,6 @@ function detectHed(tsvData, sidecarData) {
   )
 }
 
-function sidecarValueHasHed(sidecarValue) {
-  return (
-    sidecarValue !== null &&
-    typeof sidecarValue === 'object' &&
-    sidecarValue.HED !== undefined
-  )
-}
-
 function parseHedVersion(jsonContents) {
   const datasetDescription = jsonContents['/dataset_description.json']
 

--- a/bids-validator/validators/hed.js
+++ b/bids-validator/validators/hed.js
@@ -97,12 +97,8 @@ function getSidecarFileObject(sidecarName, jsonFiles) {
 
 function detectHed(tsvData, sidecarData) {
   return (
-    sidecarData.some((sidecarFileData) => {
-      return Object.values(sidecarFileData.sidecarData).some(sidecarValueHasHed)
-    }) ||
-    tsvData.some((tsvFileData) => {
-      return tsvFileData.parsedTsv.headers.indexOf('HED') !== -1
-    })
+    sidecarData.some((sidecarFileData) => sidecarFileData.hasHedData()) ||
+    tsvData.some((tsvFileData) => tsvFileData.hasHedData())
   )
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "date-fns": "^2.30.0",
         "events": "^3.3.0",
         "exifreader": "^4.17.0",
-        "hed-validator": "^3.12.0",
+        "hed-validator": "^3.13.1",
         "ignore": "^5.3.0",
         "is-utf8": "^0.2.1",
         "jest": "^29.7.0",
@@ -85,8 +85,8 @@
       "dependencies": {
         "@babel/runtime": "^7.22.10",
         "bootstrap": "^5.3.2",
-        "eslint-config-next": "14.0.4",
-        "next": "14.0.4",
+        "eslint-config-next": "^14.0.4",
+        "next": "^14.0.0",
         "pluralize": "^8.0.0",
         "react": "^18.2.0",
         "react-bootstrap": "^2.9.1",
@@ -94,7 +94,7 @@
         "sass": "^1.69.5"
       },
       "devDependencies": {
-        "@next/eslint-plugin-next": "14.0.4"
+        "@next/eslint-plugin-next": "^14.0.4"
       }
     },
     "bids-validator/node_modules/yaml": {
@@ -10312,9 +10312,9 @@
       }
     },
     "node_modules/hed-validator": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/hed-validator/-/hed-validator-3.12.0.tgz",
-      "integrity": "sha512-6VDVhc23GGQAtrx6rLSWjwvfHpja1iV8apCmeKKfHvxDOZv23uPkyZ5Tk0dh0nmsm4lPiKYTt2WzKR/6VMCaFQ==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/hed-validator/-/hed-validator-3.13.1.tgz",
+      "integrity": "sha512-082DQQrclVVPeJxM4Dv2NybMpsPKbWqMUhgfyvIoE6NKWjwatY2PppaQ9UUFzRG+iF0i1gxc8dAzU57XfYKpXQ==",
       "dependencies": {
         "buffer": "^6.0.3",
         "date-and-time": "^0.14.2",
@@ -24170,7 +24170,7 @@
         "eslint-plugin-prettier": "^5.0.1",
         "events": "^3.3.0",
         "exifreader": "^4.17.0",
-        "hed-validator": "^3.12.0",
+        "hed-validator": "^3.13.1",
         "husky": "^8.0.3",
         "ignore": "^5.3.0",
         "is-utf8": "^0.2.1",
@@ -24207,10 +24207,10 @@
       "version": "file:bids-validator-web",
       "requires": {
         "@babel/runtime": "^7.22.10",
-        "@next/eslint-plugin-next": "14.0.4",
+        "@next/eslint-plugin-next": "^14.0.4",
         "bootstrap": "^5.3.2",
-        "eslint-config-next": "14.0.4",
-        "next": "14.0.4",
+        "eslint-config-next": "^14.0.4",
+        "next": "^14.0.0",
         "pluralize": "^8.0.0",
         "react": "^18.2.0",
         "react-bootstrap": "^2.9.1",
@@ -26808,9 +26808,9 @@
       }
     },
     "hed-validator": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/hed-validator/-/hed-validator-3.12.0.tgz",
-      "integrity": "sha512-6VDVhc23GGQAtrx6rLSWjwvfHpja1iV8apCmeKKfHvxDOZv23uPkyZ5Tk0dh0nmsm4lPiKYTt2WzKR/6VMCaFQ==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/hed-validator/-/hed-validator-3.13.1.tgz",
+      "integrity": "sha512-082DQQrclVVPeJxM4Dv2NybMpsPKbWqMUhgfyvIoE6NKWjwatY2PppaQ9UUFzRG+iF0i1gxc8dAzU57XfYKpXQ==",
       "requires": {
         "buffer": "^6.0.3",
         "date-and-time": "^0.14.2",


### PR DESCRIPTION
This PR updates the hed-validator dependency to 3.13.1 and resolves the compatibility issue raised in #1867. This should replace that PR.