### PR TITLE
deps: Bump hed-validator to 3.13.3

### DIFF
--- a/bids-validator/package.json
+++ b/bids-validator/package.json
@@ -45,7 +45,7 @@
     "date-fns": "^3.2.0",
     "events": "^3.3.0",
     "exifreader": "^4.20.0",
-    "hed-validator": "^3.13.2",
+    "hed-validator": "^3.13.3",
     "ignore": "^5.3.0",
     "is-utf8": "^0.2.1",
     "jest": "^29.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,15 +34,15 @@
         "bytes": "^3.1.2",
         "colors": "^1.4.0",
         "cross-fetch": "^4.0.0",
-        "date-fns": "3.2.0",
+        "date-fns": "^3.2.0",
         "events": "^3.3.0",
-        "exifreader": "4.20.0",
-        "hed-validator": "3.13.2",
+        "exifreader": "^4.20.0",
+        "hed-validator": "^3.13.3",
         "ignore": "^5.3.0",
         "is-utf8": "^0.2.1",
         "jest": "^29.7.0",
         "jshint": "^2.13.6",
-        "lerna": "8.0.2",
+        "lerna": "^8.0.2",
         "lodash": "^4.17.21",
         "minimatch": "3.0.5",
         "next": "14.0.4",
@@ -65,12 +65,12 @@
       "devDependencies": {
         "adm-zip": "",
         "chai": "",
-        "esbuild": "0.19.11",
+        "esbuild": "^0.19.11",
         "esbuild-plugin-globals": "^0.2.0",
         "esbuild-runner": "^2.2.2",
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^9.1.0",
-        "eslint-plugin-prettier": "5.1.3",
+        "eslint-plugin-prettier": "^5.1.3",
         "husky": "^8.0.3",
         "lockfile": "^1.0.4",
         "sync-request": "6.1.0"
@@ -91,7 +91,7 @@
         "react": "^18.2.0",
         "react-bootstrap": "^2.9.2",
         "react-dom": "^18.2.0",
-        "sass": "1.69.7"
+        "sass": "^1.69.7"
       },
       "devDependencies": {
         "@next/eslint-plugin-next": "^14.0.4"
@@ -10248,9 +10248,9 @@
       }
     },
     "node_modules/hed-validator": {
-      "version": "3.13.2",
-      "resolved": "https://registry.npmjs.org/hed-validator/-/hed-validator-3.13.2.tgz",
-      "integrity": "sha512-7ZgNsPCIS0OcFfC9peATdNdinK+7EwhEDcotepv9z72bbI7tmiHCFpaC2rtnFWKYW03cCR5qyZzAZQhvV4Z1ng==",
+      "version": "3.13.3",
+      "resolved": "https://registry.npmjs.org/hed-validator/-/hed-validator-3.13.3.tgz",
+      "integrity": "sha512-HhWylUmUWpkeAJizXFxnAqR+6VxfslSYo14e16mMNxCA7skhuWJkjZl0/YSMEu+WnYpsBLeDmo2w1xpgFL5bDA==",
       "dependencies": {
         "buffer": "^6.0.3",
         "date-and-time": "^0.14.2",
@@ -24278,22 +24278,22 @@
         "chai": "",
         "colors": "^1.4.0",
         "cross-fetch": "^4.0.0",
-        "date-fns": "3.2.0",
-        "esbuild": "0.19.11",
+        "date-fns": "^3.2.0",
+        "esbuild": "^0.19.11",
         "esbuild-plugin-globals": "^0.2.0",
         "esbuild-runner": "^2.2.2",
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^9.1.0",
-        "eslint-plugin-prettier": "5.1.3",
+        "eslint-plugin-prettier": "^5.1.3",
         "events": "^3.3.0",
-        "exifreader": "4.20.0",
-        "hed-validator": "3.13.2",
+        "exifreader": "^4.20.0",
+        "hed-validator": "^3.13.3",
         "husky": "^8.0.3",
         "ignore": "^5.3.0",
         "is-utf8": "^0.2.1",
         "jest": "^29.7.0",
         "jshint": "^2.13.6",
-        "lerna": "8.0.2",
+        "lerna": "^8.0.2",
         "lockfile": "^1.0.4",
         "lodash": "^4.17.21",
         "minimatch": "3.0.5",
@@ -24337,7 +24337,7 @@
         "react": "^18.2.0",
         "react-bootstrap": "^2.9.2",
         "react-dom": "^18.2.0",
-        "sass": "1.69.7"
+        "sass": "^1.69.7"
       }
     },
     "binary-extensions": {
@@ -26818,9 +26818,9 @@
       }
     },
     "hed-validator": {
-      "version": "3.13.2",
-      "resolved": "https://registry.npmjs.org/hed-validator/-/hed-validator-3.13.2.tgz",
-      "integrity": "sha512-7ZgNsPCIS0OcFfC9peATdNdinK+7EwhEDcotepv9z72bbI7tmiHCFpaC2rtnFWKYW03cCR5qyZzAZQhvV4Z1ng==",
+      "version": "3.13.3",
+      "resolved": "https://registry.npmjs.org/hed-validator/-/hed-validator-3.13.3.tgz",
+      "integrity": "sha512-HhWylUmUWpkeAJizXFxnAqR+6VxfslSYo14e16mMNxCA7skhuWJkjZl0/YSMEu+WnYpsBLeDmo2w1xpgFL5bDA==",
       "requires": {
         "buffer": "^6.0.3",
         "date-and-time": "^0.14.2",


### PR DESCRIPTION
Fix for https://github.com/bids-standard/bids-validator/issues/1868#issuecomment-1896968974.