### PR TITLE
FIX: Add pattern to allow `/dir-<label>_dwi.json` files

### DIFF
--- a/bids-validator/bids_validator/rules/top_level_rules.json
+++ b/bids-validator/bids_validator/rules/top_level_rules.json
@@ -140,7 +140,7 @@
   },
 
   "dwi_top": {
-    "regexp": "^[\\/\\\\](?:ses-[a-zA-Z0-9]+_)?(?:acq-[a-zA-Z0-9]+_)?(?:rec-[a-zA-Z0-9]+_)?(?:run-[0-9]+_)?(dwi\\.(?:@@@_dwi_top_ext_@@@)|sbref\\.json)$",
+    "regexp": "^[\\/\\\\](?:ses-[a-zA-Z0-9]+_)?(?:acq-[a-zA-Z0-9]+_)?(?:rec-[a-zA-Z0-9]+_)?(?:_dir-[a-zA-Z0-9]+)?(?:run-[0-9]+_)?(dwi\\.(?:@@@_dwi_top_ext_@@@)|sbref\\.json)$",
     "tokens": {
       "@@@_dwi_top_ext_@@@": ["json", "bval", "bvec"]
     }

--- a/bids-validator/bids_validator/rules/top_level_rules.json
+++ b/bids-validator/bids_validator/rules/top_level_rules.json
@@ -140,7 +140,7 @@
   },
 
   "dwi_top": {
-    "regexp": "^[\\/\\\\](?:ses-[a-zA-Z0-9]+_)?(?:acq-[a-zA-Z0-9]+_)?(?:rec-[a-zA-Z0-9]+_)?(?:_dir-[a-zA-Z0-9]+)?(?:run-[0-9]+_)?(dwi\\.(?:@@@_dwi_top_ext_@@@)|sbref\\.json)$",
+    "regexp": "^[\\/\\\\](?:ses-[a-zA-Z0-9]+_)?(?:acq-[a-zA-Z0-9]+_)?(?:rec-[a-zA-Z0-9]+_)?(?:dir-[a-zA-Z0-9]+_)?(?:run-[0-9]+_)?(dwi\\.(?:@@@_dwi_top_ext_@@@)|sbref\\.json)$",
     "tokens": {
       "@@@_dwi_top_ext_@@@": ["json", "bval", "bvec"]
     }

--- a/bids-validator/bids_validator/rules/top_level_rules.json
+++ b/bids-validator/bids_validator/rules/top_level_rules.json
@@ -140,7 +140,7 @@
   },
 
   "dwi_top": {
-    "regexp": "^[\\/\\\\](?:ses-[a-zA-Z0-9]+_)?(?:acq-[a-zA-Z0-9]+_)?(?:rec-[a-zA-Z0-9]+_)?(?:dir-[a-zA-Z0-9]+_)?(?:run-[0-9]+_)?(dwi\\.(?:@@@_dwi_top_ext_@@@)|sbref\\.json)$",
+    "regexp": "^[\\/\\\\](?:ses-[a-zA-Z0-9]+_)?(?:acq-[a-zA-Z0-9]+_)?(?:rec-[a-zA-Z0-9]+_)?(?:dir-[a-zA-Z0-9]+_)?(?:run-[0-9]+_)?(?:part-(mag|phase|real|imag)_)?(?:chunk-[0-9]+_)?(dwi\\.(?:@@@_dwi_top_ext_@@@)|sbref\\.json)$",
     "tokens": {
       "@@@_dwi_top_ext_@@@": ["json", "bval", "bvec"]
     }


### PR DESCRIPTION
Currently, top-level metadata such as `/dir-AP_dwi.json` are deemed invalid.