### PR TITLE
fix(deno): Disable lockfile due to schema URL not being versioned

### DIFF
--- a/bids-validator/deno.json
+++ b/bids-validator/deno.json
@@ -4,5 +4,8 @@
   },
   "tasks": {
     "test": "deno test -A src/tests/"
+  },
+  {
+    "lock": false
   }
 }


### PR DESCRIPTION
This disables checking the lockfile at runtime automatically. It can still be checked manually but the schema will usually fail this until we have a versioned URL for it.