### PR TITLE
Skip checkheader for motion.tsv in legacy validator

### DIFF
--- a/bids-validator/validators/tsv/tsv.js
+++ b/bids-validator/validators/tsv/tsv.js
@@ -55,7 +55,10 @@ const TSV = (file, contents, fileList, callback) => {
   let emptyCells = false
   let NACells = false
 
-  checkHeaders(headers, file, issues)
+  // motion tsvs don't have headers
+  if (!file.name.endsWith('_motion.tsv')) {
+    checkHeaders(headers, file, issues)
+  }
 
   for (let i = 1; i < rows.length; i++) {
     const values = rows[i]


### PR DESCRIPTION
fixes #1889 