### PR TITLE
Use generic TSV file class from hed-validator package

### DIFF
--- a/bids-validator/validators/hed.js
+++ b/bids-validator/validators/hed.js
@@ -52,18 +52,12 @@ function constructTsvData(tsvFiles, jsonContents) {
       potentialSidecars,
       jsonContents,
     )
-    let TsvFileClass
-    if (tsvFile.file.relativePath.endsWith('_events.tsv')) {
-      TsvFileClass = hedValidator.bids.BidsEventFile
-    } else {
-      TsvFileClass = hedValidator.bids.BidsTabularFile
-    }
-    return new TsvFileClass(
+    return new hedValidator.bids.BidsTsvFile(
       tsvFile.path,
-      potentialSidecars,
-      mergedDictionary,
       tsvFile.contents,
       tsvFile.file,
+      potentialSidecars,
+      mergedDictionary,
     )
   })
 }


### PR DESCRIPTION
The previously used classes, `BidsEventFile` and `BidsTabularFile`, have been deprecated. The parameter order is slightly different between the respective constructors, so that has been tweaked.

Fixes #1868