### PR TITLE
schema: Disable import map for Deno validator

### DIFF
--- a/bids-validator/deno.json
+++ b/bids-validator/deno.json
@@ -1,7 +1,4 @@
 {
-  "imports": {
-    "std/": "https://deno.land/std@0.217.0/"
-  },
   "tasks": {
     "test": "deno test -A src/tests/"
   },

--- a/bids-validator/src/deps/asserts.ts
+++ b/bids-validator/src/deps/asserts.ts
@@ -4,4 +4,4 @@ export {
   assertObjectMatch,
   assertExists,
   assertRejects,
-} from 'std/testing/asserts.ts'
+} from 'https://deno.land/std@0.217.0/testing/asserts.ts'

--- a/bids-validator/src/deps/fmt.ts
+++ b/bids-validator/src/deps/fmt.ts
@@ -1,1 +1,1 @@
-export * as colors from 'std/fmt/colors.ts'
+export * as colors from 'https://deno.land/std@0.217.0/fmt/colors.ts'

--- a/bids-validator/src/deps/fs.ts
+++ b/bids-validator/src/deps/fs.ts
@@ -1,1 +1,1 @@
-export { walk } from 'std/fs/walk.ts'
+export { walk } from 'https://deno.land/std@0.217.0/fs/walk.ts'

--- a/bids-validator/src/deps/logger.ts
+++ b/bids-validator/src/deps/logger.ts
@@ -10,5 +10,5 @@ export {
   LogLevels,
   setup,
   warn,
-} from "std/log/mod.ts"
-export type { LevelName } from "std/log/mod.ts"
+} from "https://deno.land/std@0.217.0/log/mod.ts"
+export type { LevelName } from "https://deno.land/std@0.217.0/log/mod.ts"

--- a/bids-validator/src/deps/path.ts
+++ b/bids-validator/src/deps/path.ts
@@ -8,4 +8,4 @@ export {
   fromFileUrl,
   parse,
   SEPARATOR,
-} from 'std/path/mod.ts'
+} from 'https://deno.land/std@0.217.0/path/mod.ts'

--- a/bids-validator/src/deps/stream.ts
+++ b/bids-validator/src/deps/stream.ts
@@ -1,4 +1,4 @@
 export {
   readAll,
   readerFromStreamReader,
-} from 'std/io/mod.ts'
+} from 'https://deno.land/std@0.217.0/io/mod.ts'


### PR DESCRIPTION
The import map turns out to cause issues for downstream applications (OpenNeuro, web app). Import maps like this are [recommended only for applications](https://docs.deno.com/runtime/manual/basics/import_maps#import-maps-are-for-applications) but bids-validator is more of a hybrid case.