### PR TITLE
schema: Fixes for web builds

### DIFF
--- a/bids-validator/src/setup/loadSchema.ts
+++ b/bids-validator/src/setup/loadSchema.ts
@@ -18,7 +18,7 @@ export async function loadSchema(version = 'latest'): Promise<Schema> {
     schemaUrl = `https://bids-specification.readthedocs.io/en/${version}/schema.json`
   }
   try {
-    const schemaModule = await import(schemaUrl, {
+    const schemaModule = await import(/* @vite-ignore */ schemaUrl, {
       assert: { type: 'json' },
     })
     return new Proxy(


### PR DESCRIPTION
Improves compatibility with common bundlers (vite/rollup) and supports all of Deno's import URL schemes for builds targeting the browser.