### PR TITLE
Bump hed-validator dependency to v3.13.4

### DIFF
--- a/bids-validator/package.json
+++ b/bids-validator/package.json
@@ -45,7 +45,7 @@
     "date-fns": "^3.3.1",
     "events": "^3.3.0",
     "exifreader": "^4.21.0",
-    "hed-validator": "^3.13.3",
+    "hed-validator": "^3.13.4",
     "ignore": "^5.3.1",
     "is-utf8": "^0.2.1",
     "jest": "^29.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "date-fns": "^3.3.1",
         "events": "^3.3.0",
         "exifreader": "^4.21.0",
-        "hed-validator": "^3.13.3",
+        "hed-validator": "^3.13.4",
         "ignore": "^5.3.1",
         "is-utf8": "^0.2.1",
         "jest": "^29.7.0",
@@ -10288,9 +10288,9 @@
       }
     },
     "node_modules/hed-validator": {
-      "version": "3.13.3",
-      "resolved": "https://registry.npmjs.org/hed-validator/-/hed-validator-3.13.3.tgz",
-      "integrity": "sha512-HhWylUmUWpkeAJizXFxnAqR+6VxfslSYo14e16mMNxCA7skhuWJkjZl0/YSMEu+WnYpsBLeDmo2w1xpgFL5bDA==",
+      "version": "3.13.4",
+      "resolved": "https://registry.npmjs.org/hed-validator/-/hed-validator-3.13.4.tgz",
+      "integrity": "sha512-ZElhF2cg2VjbzJgbgbY3IvGogDr4pnuJ1kgwvhF4OFQMkFHZ7mA1biFk27O3vLwGipwjrgh6eGg3tbf0kMtrIA==",
       "dependencies": {
         "buffer": "^6.0.3",
         "date-and-time": "^0.14.2",
@@ -24343,7 +24343,7 @@
         "eslint-plugin-prettier": "^5.1.3",
         "events": "^3.3.0",
         "exifreader": "^4.21.0",
-        "hed-validator": "^3.13.3",
+        "hed-validator": "^3.13.4",
         "husky": "^9.0.11",
         "ignore": "^5.3.1",
         "is-utf8": "^0.2.1",
@@ -26861,9 +26861,9 @@
       }
     },
     "hed-validator": {
-      "version": "3.13.3",
-      "resolved": "https://registry.npmjs.org/hed-validator/-/hed-validator-3.13.3.tgz",
-      "integrity": "sha512-HhWylUmUWpkeAJizXFxnAqR+6VxfslSYo14e16mMNxCA7skhuWJkjZl0/YSMEu+WnYpsBLeDmo2w1xpgFL5bDA==",
+      "version": "3.13.4",
+      "resolved": "https://registry.npmjs.org/hed-validator/-/hed-validator-3.13.4.tgz",
+      "integrity": "sha512-ZElhF2cg2VjbzJgbgbY3IvGogDr4pnuJ1kgwvhF4OFQMkFHZ7mA1biFk27O3vLwGipwjrgh6eGg3tbf0kMtrIA==",
       "requires": {
         "buffer": "^6.0.3",
         "date-and-time": "^0.14.2",


### PR DESCRIPTION
See the release notes at https://github.com/hed-standard/hed-javascript/releases/tag/v3.13.4. The main feature in this release is validating TSV files in a way that respects their `onset` column (merging rows with the same onset into a single event and sorting events by onset).