### PR TITLE
Ignore files in _scans.tsv that correspond to entries in .bidsignore (#1366)

### DIFF
--- a/bids-validator/tests/bids.spec.js
+++ b/bids-validator/tests/bids.spec.js
@@ -9,6 +9,13 @@ import path from 'path'
 import { createFileList } from './env/FileList.js'
 import isNode from '../utils/isNode.js'
 
+// Mock sessionStorage
+global.sessionStorage = {
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  clear: jest.fn()
+};
+
 function getDirectories(srcpath) {
   return fs.readdirSync(srcpath).filter(function (file) {
     return (

--- a/bids-validator/tests/bids.spec.js
+++ b/bids-validator/tests/bids.spec.js
@@ -9,13 +9,6 @@ import path from 'path'
 import { createFileList } from './env/FileList.js'
 import isNode from '../utils/isNode.js'
 
-// Mock sessionStorage
-global.sessionStorage = {
-  getItem: jest.fn(),
-  setItem: jest.fn(),
-  clear: jest.fn()
-};
-
 function getDirectories(srcpath) {
   return fs.readdirSync(srcpath).filter(function (file) {
     return (

--- a/bids-validator/tests/setupTests.js
+++ b/bids-validator/tests/setupTests.js
@@ -1,7 +1,13 @@
 // Mock sessionStorage
 global.sessionStorage = {
-  getItem: key => sessionStorage[key],
-  setItem: (key, value) => { sessionStorage[key] = value; },
-  removeItem: key => { delete sessionStorage[key]; },
-  clear: () => { sessionStorage = {}; },
-};
+  getItem: (key) => sessionStorage[key],
+  setItem: (key, value) => {
+    sessionStorage[key] = value
+  },
+  removeItem: (key) => {
+    delete sessionStorage[key]
+  },
+  clear: () => {
+    Object.keys(sessionStorage).forEach((key) => sessionStorage.removeItem(key))
+  },
+}

--- a/bids-validator/tests/setupTests.js
+++ b/bids-validator/tests/setupTests.js
@@ -1,0 +1,6 @@
+// Mock sessionStorage
+global.sessionStorage = {
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  clear: jest.fn()
+};

--- a/bids-validator/tests/setupTests.js
+++ b/bids-validator/tests/setupTests.js
@@ -1,13 +1,3 @@
 // Mock sessionStorage
-global.sessionStorage = {
-  getItem: (key) => sessionStorage[key],
-  setItem: (key, value) => {
-    sessionStorage[key] = value
-  },
-  removeItem: (key) => {
-    delete sessionStorage[key]
-  },
-  clear: () => {
-    Object.keys(sessionStorage).forEach((key) => sessionStorage.removeItem(key))
-  },
-}
+import getSessionStorage from '../utils/getSessionStorage'
+global.sessionStorage = getSessionStorage()

--- a/bids-validator/tests/setupTests.js
+++ b/bids-validator/tests/setupTests.js
@@ -1,6 +1,7 @@
 // Mock sessionStorage
 global.sessionStorage = {
-  getItem: jest.fn(),
-  setItem: jest.fn(),
-  clear: jest.fn()
+  getItem: key => sessionStorage[key],
+  setItem: (key, value) => { sessionStorage[key] = value; },
+  removeItem: key => { delete sessionStorage[key]; },
+  clear: () => { sessionStorage = {}; },
 };

--- a/bids-validator/tests/tsv.spec.js
+++ b/bids-validator/tests/tsv.spec.js
@@ -348,12 +348,10 @@ describe('TSV', function () {
 
   it('should not allow mismatched filename entries', function () {
     const fileList = [eegFile]
-    console.log(fileList)
     const tsv =
       'filename\tacq_time\n' +
       'func/sub-08_ses-test_task-linebisection_run-01_bold.nii.gz\t2017-05-03T06:45:45'
     validate.TSV.TSV(scansFile, tsv, fileList, function (issues) {
-      console.log(issues)
       assert(issues.length === 1 && issues[0].code === 129)
     })
   })
@@ -422,8 +420,24 @@ describe('TSV', function () {
     validate.TSV.TSV(scansFile, tsv, fileList, function (issues) {
       assert.deepEqual(issues, [])
     })
+    sessionStorage.removeItem('bidsignoreContent')
   })
 
+
+  it('should not allow missing files listed in scans.tsv and not accounted for by .bidsignore', function () {
+    sessionStorage.setItem('bidsignoreContent', JSON.stringify('sodium/'))
+    const fileList = [niftiFile, eegFile]
+    const tsv =
+      'filename\tacq_time\n' +
+      'func/sub-08_ses-test_task-linebisection_run-01_bold.nii.gz\t2017-05-03T06:45:45\n' +
+      'eeg/sub-08_ses-test_task-linebisection_run-01_eeg.fif\t2017-05-03T06:45:45\n' +
+      'ieeg/sub-08_ses-test_task-linebisection_run-01_ieeg.edf\t2017-05-03T06:45:45\n' +
+      'sodium/sub-08_acq-23Na_echo-01.nii.gz\t2018-04-26T21:30:00'
+    validate.TSV.TSV(scansFile, tsv, fileList, function (issues) {
+      assert(issues.length === 1 && issues[0].code === 129)
+    })
+    sessionStorage.removeItem('bidsignoreContent')
+  })
 
   // channels checks -----------------------------------------------------------------
 

--- a/bids-validator/tests/tsv.spec.js
+++ b/bids-validator/tests/tsv.spec.js
@@ -1,13 +1,6 @@
 import assert from 'assert'
 import validate from '../index'
 
-// Mock sessionStorage
-global.sessionStorage = {
-  getItem: jest.fn(),
-  setItem: jest.fn(),
-  clear: jest.fn()
-};
-
 describe('TSV', function () {
   // general tsv checks ------------------------------------------------------------------
 
@@ -355,10 +348,12 @@ describe('TSV', function () {
 
   it('should not allow mismatched filename entries', function () {
     const fileList = [eegFile]
+    console.log(fileList)
     const tsv =
       'filename\tacq_time\n' +
       'func/sub-08_ses-test_task-linebisection_run-01_bold.nii.gz\t2017-05-03T06:45:45'
     validate.TSV.TSV(scansFile, tsv, fileList, function (issues) {
+      console.log(issues)
       assert(issues.length === 1 && issues[0].code === 129)
     })
   })

--- a/bids-validator/tests/tsv.spec.js
+++ b/bids-validator/tests/tsv.spec.js
@@ -409,6 +409,7 @@ describe('TSV', function () {
   })
 
   it('should ignore files in scans.tsv that correspond to entries in .bidsignore', function () {
+    sessionStorage.clear()
     sessionStorage.setItem('bidsignoreContent', JSON.stringify('sodium/'))
     const fileList = [niftiFile, eegFile, ieegFile]
     const tsv =
@@ -424,6 +425,7 @@ describe('TSV', function () {
   })
 
   it('should not allow missing files listed in scans.tsv and not accounted for by .bidsignore', function () {
+    sessionStorage.clear()
     sessionStorage.setItem('bidsignoreContent', JSON.stringify('sodium/'))
     const fileList = [niftiFile, eegFile]
     const tsv =

--- a/bids-validator/tests/tsv.spec.js
+++ b/bids-validator/tests/tsv.spec.js
@@ -1,6 +1,13 @@
 import assert from 'assert'
 import validate from '../index'
 
+// Mock sessionStorage
+global.sessionStorage = {
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  clear: jest.fn()
+};
+
 describe('TSV', function () {
   // general tsv checks ------------------------------------------------------------------
 

--- a/bids-validator/tests/tsv.spec.js
+++ b/bids-validator/tests/tsv.spec.js
@@ -410,6 +410,21 @@ describe('TSV', function () {
     )
   })
 
+  it('should ignore files in scans.tsv that correspond to entries in .bidsignore', function () {
+    sessionStorage.setItem('bidsignoreContent', JSON.stringify('sodium/'))
+    const fileList = [niftiFile, eegFile, ieegFile]
+    const tsv =
+      'filename\tacq_time\n' +
+      'func/sub-08_ses-test_task-linebisection_run-01_bold.nii.gz\t2017-05-03T06:45:45\n' +
+      'eeg/sub-08_ses-test_task-linebisection_run-01_eeg.fif\t2017-05-03T06:45:45\n' +
+      'ieeg/sub-08_ses-test_task-linebisection_run-01_ieeg.edf\t2017-05-03T06:45:45\n' +
+      'sodium/sub-08_acq-23Na_echo-01.nii.gz\t2018-04-26T21:30:00'
+    validate.TSV.TSV(scansFile, tsv, fileList, function (issues) {
+      assert.deepEqual(issues, [])
+    })
+  })
+
+
   // channels checks -----------------------------------------------------------------
 
   var channelsFileMEG = {

--- a/bids-validator/tests/tsv.spec.js
+++ b/bids-validator/tests/tsv.spec.js
@@ -423,7 +423,6 @@ describe('TSV', function () {
     sessionStorage.removeItem('bidsignoreContent')
   })
 
-
   it('should not allow missing files listed in scans.tsv and not accounted for by .bidsignore', function () {
     sessionStorage.setItem('bidsignoreContent', JSON.stringify('sodium/'))
     const fileList = [niftiFile, eegFile]

--- a/bids-validator/utils/files/readDir.js
+++ b/bids-validator/utils/files/readDir.js
@@ -5,6 +5,29 @@ import fs from 'fs'
 import * as child_proccess from 'child_process'
 import isNode from '../isNode'
 
+function createSessionStorageMock() {
+  const sessionStorage = {}
+
+  return {
+    getItem: (key) => sessionStorage[key],
+    setItem: (key, value) => {
+      sessionStorage[key] = value
+    },
+    removeItem: (key) => {
+      delete sessionStorage[key]
+    },
+    clear: () => {
+      Object.keys(sessionStorage).forEach((key) =>
+        sessionStorage.removeItem(key),
+      )
+    },
+  }
+}
+
+const sessionStorage = isNode
+  ? createSessionStorageMock()
+  : window.sessionStorage
+
 /**
  * Read Directory
  *

--- a/bids-validator/utils/files/readDir.js
+++ b/bids-validator/utils/files/readDir.js
@@ -4,29 +4,9 @@ import path from 'path'
 import fs from 'fs'
 import * as child_proccess from 'child_process'
 import isNode from '../isNode'
+import getSessionStorage from '../getSessionStorage'
 
-function createSessionStorageMock() {
-  const sessionStorage = {}
-
-  return {
-    getItem: (key) => sessionStorage[key],
-    setItem: (key, value) => {
-      sessionStorage[key] = value
-    },
-    removeItem: (key) => {
-      delete sessionStorage[key]
-    },
-    clear: () => {
-      Object.keys(sessionStorage).forEach((key) =>
-        sessionStorage.removeItem(key),
-      )
-    },
-  }
-}
-
-const sessionStorage = isNode
-  ? createSessionStorageMock()
-  : window.sessionStorage
+const sessionStorage = isNode ? getSessionStorage() : window.sessionStorage
 
 /**
  * Read Directory

--- a/bids-validator/utils/files/readDir.js
+++ b/bids-validator/utils/files/readDir.js
@@ -331,7 +331,7 @@ async function getBIDSIgnore(dir) {
     const content = await readFile(bidsIgnoreFileObj)
     ig.add(content)
     // Store the .bidsignore content in session storage
-    sessionStorage.setItem('bidsignoreContent', JSON.stringify(content));
+    sessionStorage.setItem('bidsignoreContent', JSON.stringify(content))
   }
   return ig
 }

--- a/bids-validator/utils/files/readDir.js
+++ b/bids-validator/utils/files/readDir.js
@@ -330,6 +330,8 @@ async function getBIDSIgnore(dir) {
   if (bidsIgnoreFileObj) {
     const content = await readFile(bidsIgnoreFileObj)
     ig.add(content)
+    // Store the .bidsignore content in session storage
+    sessionStorage.setItem('bidsignoreContent', JSON.stringify(content));
   }
   return ig
 }

--- a/bids-validator/utils/getSessionStorage.js
+++ b/bids-validator/utils/getSessionStorage.js
@@ -1,0 +1,31 @@
+// return sessionStorage based on environment
+// uses mock object for use in tests and GitHub workflows
+import isNode from './isNode'
+
+function getSessionStorage() {
+  if ('sessionStorage' in global) {
+    // created in setupTests.js; enables data sharing using same object
+    return global.sessionStorage
+  } else if (!isNode) {
+    return window.sessionStorage
+  } else {
+    const sessionStorage = {}
+
+    return {
+      getItem: (key) => sessionStorage[key],
+      setItem: (key, value) => {
+        sessionStorage[key] = value
+      },
+      removeItem: (key) => {
+        delete sessionStorage[key]
+      },
+      clear: () => {
+        Object.keys(sessionStorage).forEach((key) =>
+          sessionStorage.removeItem(key),
+        )
+      },
+    }
+  }
+}
+
+export default getSessionStorage

--- a/bids-validator/validators/tsv/tsv.js
+++ b/bids-validator/validators/tsv/tsv.js
@@ -614,8 +614,8 @@ const TSV = (file, contents, fileList, callback) => {
       )
     } else {
       // Retrieve the .bidsignore content (if any) from session storage
-      const content = sessionStorage.getItem('bidsignoreContent');
-      const ig = content ? ignore().add(JSON.parse(content)) : null;
+      const content = sessionStorage.getItem('bidsignoreContent')
+      const ig = content ? ignore().add(JSON.parse(content)) : null
 
       // check scans filenames match pathList
       const filenameColumn = headers.indexOf('filename')
@@ -625,7 +625,7 @@ const TSV = (file, contents, fileList, callback) => {
         const scanFullPath = scanDirPath + '/' + scanRelativePath
 
         // check if file should be ignored based on .bidsignore content
-        if (ig && ig.ignores((path.relative('/', scanRelativePath)))) {
+        if (ig && ig.ignores(path.relative('/', scanRelativePath))) {
           continue
         }
 

--- a/bids-validator/validators/tsv/tsv.js
+++ b/bids-validator/validators/tsv/tsv.js
@@ -6,6 +6,7 @@ import checkStatusCol from './checkStatusCol'
 import checkTypecol from './checkTypeCol'
 import parseTSV from './tsvParser'
 import checkMotionComponent from './checkMotionComponent'
+import ignore from 'ignore'
 var path = require('path')
 
 /**
@@ -612,12 +613,21 @@ const TSV = (file, contents, fileList, callback) => {
         }),
       )
     } else {
+      // Retrieve the .bidsignore content (if any) from session storage
+      const content = sessionStorage.getItem('bidsignoreContent');
+      const ig = content ? ignore().add(JSON.parse(content)) : null;
+
       // check scans filenames match pathList
       const filenameColumn = headers.indexOf('filename')
       for (let l = 1; l < rows.length; l++) {
         const row = rows[l]
         const scanRelativePath = row[filenameColumn]
         const scanFullPath = scanDirPath + '/' + scanRelativePath
+
+        // check if file should be ignored based on .bidsignore content
+        if (ig && ig.ignores((path.relative('/', scanRelativePath)))) {
+          continue
+        }
 
         // check if scan matches full dataset path list
         if (!pathList.includes(scanFullPath)) {

--- a/bids-validator/validators/tsv/tsv.js
+++ b/bids-validator/validators/tsv/tsv.js
@@ -6,8 +6,11 @@ import checkStatusCol from './checkStatusCol'
 import checkTypecol from './checkTypeCol'
 import parseTSV from './tsvParser'
 import checkMotionComponent from './checkMotionComponent'
+import getSessionStorage from '../../utils/getSessionStorage'
 import ignore from 'ignore'
 var path = require('path')
+
+const sessionStorage = getSessionStorage()
 
 /**
  * Format TSV headers for evidence string

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "jest": {
     "testEnvironment": "node",
+    "setupFilesAfterEnv": ["<rootDir>/bids-validator/tests/setupTests.js"],
     "moduleNameMapper": {
       "^uuid$": "uuid"
     },


### PR DESCRIPTION
PR for handling bids-standard/bids-validator#48 

Makes use of session storage to save the contents of .bidsignore when it is read originally. This is retrieved later while evaluating _scans.tsv files for ignoring the matching files. All tests with `npm run test` are passing (except two which were failing even on the unchanged master branch), and two new tests have been added. 

For testing purposes, a mock session storage was required to be implemented as Jest is currently configured with `"testEnvironment": "node"`. Could possibly be avoided if set to `"testEnvironment": "jsdom"`. Another option is to employ `jest-localstorage-mock` package. But the current mock implementation seemed the simplest, and so went with it. 

Two tests have been added:
- `should ignore files in scans.tsv that correspond to entries in .bidsignore`
This checks that files to be ignored, based on .bidsignore, are being ignored when evaluating the file list in _scans.tsv

- `should not allow missing files listed in scans.tsv and not accounted for by .bidsignore`
This catches files that are listed in _scans.tsv but are actually missing, and not accounted for by .bidsignore

First PR here; apologies if I have missed anything.
@effigies: Could you take a look?