### PR TITLE
FIX: Add minimum Python requirement to package metadata

### DIFF
--- a/bids-validator/pyproject.toml
+++ b/bids-validator/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python",
     "Topic :: Scientific/Engineering",
 ]
+requires-python = ">=3.8"
 
 [project.urls]
 Homepage = "https://github.com/bids-standard/bids-validator"


### PR DESCRIPTION
Python 3.8 is the oldest Python that is not EOL, so we only test that far back.
People using older Pythons could still get this installed, and it turns out we
use a Python 3.8 feature.

After the next release, we should yank PyPI packages newer than 1.14.0 so that
Python 3.6 and 3.7 users will install working versions by default.
