### PR TITLE
fix: Preserve key properties when using spread to copy BIDSFile objects in browser environments

### DIFF
--- a/bids-validator/src/files/browser.test.ts
+++ b/bids-validator/src/files/browser.test.ts
@@ -1,6 +1,6 @@
 import { FileIgnoreRules } from './ignore.ts'
 import { FileTree } from '../types/filetree.ts'
-import { assertEquals } from '../deps/asserts.ts'
+import { assertEquals, assertObjectMatch } from '../deps/asserts.ts'
 import { BIDSFileBrowser, fileListToTree } from './browser.ts'
 
 class TestFile extends File {
@@ -68,4 +68,22 @@ Deno.test('Browser implementation of FileTree', async (t) => {
     sub01Tree.directories.push(anatTree)
     assertEquals(tree, expectedTree)
   })
+})
+
+Deno.test("Spread copies of BIDSFileBrowser contain name and path properties", async () => {
+  const ignore = new FileIgnoreRules([])
+  const files = [
+    new TestFile(
+      ['{}'],
+      'dataset_description.json',
+      'ds/dataset_description.json',
+    ),
+    new TestFile(['flat test dataset'], 'README.md', 'ds/README.md'),
+  ]
+  const tree = await fileListToTree(files)
+  const expectedTree = new FileTree('', '/', undefined)
+  expectedTree.files = files.map((f) => new BIDSFileBrowser(f, ignore))
+  assertEquals(tree, expectedTree)
+  const spreadFile = {...expectedTree.files[0], evidence: "test evidence"}
+  assertObjectMatch(spreadFile, {name: "dataset_description.json", path: "/dataset_description.json", evidence: "test evidence"})
 })

--- a/bids-validator/src/files/browser.ts
+++ b/bids-validator/src/files/browser.ts
@@ -9,21 +9,17 @@ import { parse, join, SEPARATOR } from '../deps/path.ts'
 export class BIDSFileBrowser implements BIDSFile {
   #ignore: FileIgnoreRules
   #file: File
+  name: string
+  path: string
 
   constructor(file: File, ignore: FileIgnoreRules) {
     this.#file = file
     this.#ignore = ignore
-  }
-
-  get name(): string {
-    return this.#file.name
-  }
-
-  get path(): string {
-    // @ts-expect-error webkitRelativePath is defined in the browser
+    this.name = file.name
+    // @ts-expect-error webkitRelativePath does exist in the browser
     const relativePath = this.#file.webkitRelativePath
     const prefixLength = relativePath.indexOf('/')
-    return relativePath.substring(prefixLength)
+    this.path = relativePath.substring(prefixLength)
   }
 
   get size(): number {


### PR DESCRIPTION
Fix for #1918

These properties defined by getters cannot be copied with the spread operator. Materializing these properties instead matches the Deno behavior and should avoid future differences between the two implementations.