### PR TITLE
ci: Replace web validator with schema version and link to subdirectory build of the legacy validator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,3 +256,8 @@ workflows:
             - test
             - test_docker
             - githubPagesTest
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /v\d+\.\d+\.\d+$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,8 +189,8 @@ jobs:
           name: Clean and remove bids-validator files
           command: git reset . && git clean --force -d --exclude bids-validator-web/out
       - run:
-          name: Move build into root directory
-          command: mv bids-validator-web/out/* .
+          name: Move build into legacy directory
+          command: mv bids-validator-web/out/ legacy
       - run:
           name: Remove files not related to build
           command: rm -r bids-validator bids-validator-web node_modules
@@ -200,14 +200,14 @@ jobs:
       - run: git status
       - run:
           name: Commit updates
-          command: git add . && git commit --allow-empty --no-verify -m "Circle CI - Generate validator demo with version $CIRCLE_TAG [ci skip]"
+          command: git add legacy && git commit --allow-empty --no-verify -m "Circle CI - Generate validator demo with version $CIRCLE_TAG [ci skip]"
       - run: git push origin gh-pages -f
       - save_cache:
           key: npm-deps-{{ checksum "package.json" }}-{{ checksum "./bids-validator/package.json" }}-{{ checksum "./bids-validator-web/package.json" }}-v1
           paths:
             - ./node_modules
       - store_artifacts:
-          path: ~/
+          path: ~/legacy
 workflows:
   version: 2
   build-deploy:
@@ -256,8 +256,3 @@ workflows:
             - test
             - test_docker
             - githubPagesTest
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /v\d+\.\d+\.\d+$/

--- a/.github/workflows/schema_web.yml
+++ b/.github/workflows/schema_web.yml
@@ -1,0 +1,44 @@
+---
+name: Deno web build
+
+on:
+  push:
+    branches: [master]
+    tags: ['*']
+  pull_request:
+    branches: [master]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+      - run: deno task build
+        working-directory: ./web
+      - uses: actions/upload-artifact@v4
+        with:
+          name: web
+          path: web/dist
+  deploy:
+    needs: build
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    # Specify runner + deployment step
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4 # or specific "vX.X.X" version tag for this action

--- a/.github/workflows/schema_web_build.yml
+++ b/.github/workflows/schema_web_build.yml
@@ -1,5 +1,5 @@
 ---
-name: Deno web build
+name: Schema validator web deploy
 
 on:
   push:
@@ -26,19 +26,3 @@ jobs:
         with:
           name: web
           path: web/dist
-  deploy:
-    needs: build
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
-    # Deploy to the github-pages environment
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    # Specify runner + deployment step
-    runs-on: ubuntu-latest
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4 # or specific "vX.X.X" version tag for this action

--- a/.github/workflows/schema_web_deploy.yml
+++ b/.github/workflows/schema_web_deploy.yml
@@ -1,0 +1,41 @@
+---
+name: Schema validator web deploy
+
+on:
+  release:
+    types: [published]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+      - run: deno task build
+        working-directory: ./web
+      - uses: actions/upload-artifact@v4
+        with:
+          name: web
+          path: web/dist
+  deploy:
+    needs: build
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    # Specify runner + deployment step
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4 # or specific "vX.X.X" version tag for this action

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -95,6 +95,7 @@ function App() {
         Note: Selecting a dataset only performs validation. Files are never
         uploaded.
       </div>
+      <div>Previous version of the BIDS validator (non-schema) available <a href="https://bids-standard.github.io/bids-validator/legacy">here.</a></div>
     </>
   )
 }


### PR DESCRIPTION
This moves the old validator to https://bids-standard.github.io/bids-validator/legacy and deploys the schema validator to https://bids-standard.github.io/bids-validator.

Adds a link to the old version.
![image](https://github.com/bids-standard/bids-validator/assets/11369795/29a52f30-bd0e-4a27-8f33-15c2bac09bd8)