### PR TITLE
Have filenameIdentify use datasetContext to determine which filename rules to use.

### DIFF
--- a/bids-validator/src/schema/applyRules.ts
+++ b/bids-validator/src/schema/applyRules.ts
@@ -31,7 +31,7 @@ export function applyRules(
     rootSchema = schema
   }
   if (!schemaPath) {
-    schemaPath = 'schema'
+    schemaPath = 'schema.rules'
   }
   Object.assign(context, expressionFunctions)
   // @ts-expect-error

--- a/bids-validator/src/validators/filenameIdentify.ts
+++ b/bids-validator/src/validators/filenameIdentify.ts
@@ -35,6 +35,12 @@ export async function filenameIdentify(schema, context) {
 function findRuleMatches(schema, context) {
   const schemaPath = 'rules.files'
   Object.keys(schema[schemaPath]).map((key) => {
+    if (
+      key == 'deriv' && 
+      context.dataset.dataset_description.DatasetType != 'derivative'
+    ) {
+      return
+    }
     const path = `${schemaPath}.${key}`
     _findRuleMatches(schema[path], path, context)
   })


### PR DESCRIPTION
Currently is applying derived filename rules when it shouldn't be. This makes it difficult to notify a user that has a derivatives dataset mistakenly listed in dataset_description as a derivative. Something that may have never happened before. I'm fine overlooking that for now.

Should we have deriv datasets not apply any schema.rules.files.raw rules? I think thats why we went through all the trouble of making $refs work for filenames in the schema.