### PR TITLE
Pass on multiple rules.files matches from filenameIdentify to filenameValidate.

### DIFF
--- a/bids-validator/src/validators/filenameIdentify.ts
+++ b/bids-validator/src/validators/filenameIdentify.ts
@@ -129,12 +129,9 @@ export function hasMatch(schema, context) {
     const entExtMatch = context.filenameRules.filter((rulePath) => {
       return entitiesExtensionsInRule(schema, context, rulePath)
     })
-    if (entExtMatch.length > 0) {
-      context.filenameRules = [entExtMatch[0]]
+    if (entExtMatch.length == 1) {
+      context.filenameRules = entExtMatch
     }
-  }
-  /* If we end up with multiple rules we should generate an error? */
-  if (context.filenameRules.length > 1) {
   }
 
   return Promise.resolve()

--- a/bids-validator/src/validators/filenameIdentify.ts
+++ b/bids-validator/src/validators/filenameIdentify.ts
@@ -129,7 +129,7 @@ export function hasMatch(schema, context) {
     const entExtMatch = context.filenameRules.filter((rulePath) => {
       return entitiesExtensionsInRule(schema, context, rulePath)
     })
-    if (entExtMatch.length == 1) {
+    if (entExtMatch.length > 0) {
       context.filenameRules = entExtMatch
     }
   }


### PR DESCRIPTION
filenameValidate.ts handles multiple rule matches properly, no need to truncate rule matches unnecessarily in filenameIdentify.ts

fixes longstanding ds000248 validation error.