### PR TITLE
have exists return false on bids-uri check if string doesn't start with 'bids:'

### DIFF
--- a/bids-validator/src/schema/expressionLanguage.ts
+++ b/bids-validator/src/schema/expressionLanguage.ts
@@ -17,8 +17,13 @@ function exists(list: string[], rule: string = 'dataset'): number {
     list = [list]
   }
   if (rule == 'bids-uri') {
-    // XXX To implement
-    return list.length
+    return list.filter((x) => {
+      // XXX To implement
+      if (x.startsWith('bids:')) {
+        return true
+      }
+      return false
+    }).length
   } else {
     // dataset, subject and stimuli
     return list.filter((x) => {

--- a/bids-validator/src/schema/expressionLanguage.ts
+++ b/bids-validator/src/schema/expressionLanguage.ts
@@ -10,7 +10,7 @@ function exists(list: string[], rule: string = 'dataset'): number {
     prefix.push('stimuli')
   } else if (rule == 'subject') {
     // @ts-expect-error
-    prefix.push('sub-' + this.entities.subject)
+    prefix.push('sub-' + this.entities.sub)
   }
 
   if (!Array.isArray(list)) {


### PR DESCRIPTION
instead of always returning true lets at least check for a sensible 'bid:' at the start of string. allows exists(x, 'bids-uri) + exists(x, 'dataset') == 1 style tests to pass for non bids-uris