### PR TITLE
fix: Set deno validator exit code on errors

### DIFF
--- a/bids-validator/src/bids-validator.ts
+++ b/bids-validator/src/bids-validator.ts
@@ -1,3 +1,9 @@
 import { main } from './main.ts'
 
-await main()
+const result = await main()
+
+for (const issue of result.issues.values()) {
+  if (issue.severity === 'error') {
+    Deno.exit(1)
+  }
+}

--- a/bids-validator/src/main.ts
+++ b/bids-validator/src/main.ts
@@ -5,8 +5,9 @@ import { resolve } from './deps/path.ts'
 import { validate } from './validators/bids.ts'
 import { consoleFormat } from './utils/output.ts'
 import { setupLogging } from './utils/logger.ts'
+import type { ValidationResult } from './types/validation-result.ts'
 
-export async function main() {
+export async function main(): Promise<ValidationResult> {
   const options = await parseOptions(Deno.args)
   setupLogging(options.debug)
   const absolutePath = resolve(options.datasetPath)
@@ -32,6 +33,8 @@ export async function main() {
       }),
     )
   }
+
+  return schemaResult
 }
 
 export { validate, fileListToTree }


### PR DESCRIPTION
Sets exit code 1 on validation failure with the CLI mode.

Fixes #1909