### PR TITLE
Fix exists for derivative paths in raw datasets.

### DIFF
--- a/bids-validator/src/schema/expressionLanguage.ts
+++ b/bids-validator/src/schema/expressionLanguage.ts
@@ -27,6 +27,17 @@ function exists(list: string[], rule: string = 'dataset'): number {
   } else {
     // dataset, subject and stimuli
     return list.filter((x) => {
+      /* dataset relative paths must start with slash. This leading slash will 
+       * trip up filetree.contains though so chomp if its present and fail if
+       * it isn't present.
+       */
+      if (rule == 'dataset') {
+        if (x[0] == '/') {
+          x = x.substr(1)
+        } else {
+          return false
+        }
+      }
       const parts = prefix.concat(x.split('/'))
       // @ts-expect-error
       return this.fileTree.contains(parts)

--- a/bids-validator/src/schema/expressionLanguage.ts
+++ b/bids-validator/src/schema/expressionLanguage.ts
@@ -27,16 +27,14 @@ function exists(list: string[], rule: string = 'dataset'): number {
   } else {
     // dataset, subject and stimuli
     return list.filter((x) => {
-      /* dataset relative paths must start with slash. This leading slash will 
+      /* local paths must start with slash. This leading slash will 
        * trip up filetree.contains though so chomp if its present and fail if
        * it isn't present.
        */
-      if (rule == 'dataset') {
-        if (x[0] == '/') {
-          x = x.substr(1)
-        } else {
-          return false
-        }
+      if (x[0] == '/') {
+        x = x.substr(1)
+      } else {
+        return false
       }
       const parts = prefix.concat(x.split('/'))
       // @ts-expect-error

--- a/bids-validator/src/schema/expressionLanguage.ts
+++ b/bids-validator/src/schema/expressionLanguage.ts
@@ -27,15 +27,6 @@ function exists(list: string[], rule: string = 'dataset'): number {
   } else {
     // dataset, subject and stimuli
     return list.filter((x) => {
-      /* local paths must start with slash. This leading slash will 
-       * trip up filetree.contains though so chomp if its present and fail if
-       * it isn't present.
-       */
-      if (x[0] == '/') {
-        x = x.substr(1)
-      } else {
-        return false
-      }
       const parts = prefix.concat(x.split('/'))
       // @ts-expect-error
       return this.fileTree.contains(parts)

--- a/bids-validator/src/validators/bids.ts
+++ b/bids-validator/src/validators/bids.ts
@@ -65,7 +65,7 @@ export async function validate(
           derivatives.push(deriv)
         }
       })
-      return false
+      return true
     }
     return true
   })
@@ -73,6 +73,9 @@ export async function validate(
   for await (const context of walkFileTree(fileTree, issues, dsContext)) {
     // TODO - Skip ignored files for now (some tests may reference ignored files)
     if (context.file.ignored) {
+      continue
+    }
+    if (dsContext.dataset_description.DatasetType == 'raw' && context.file.path.includes('derivatives')) {
       continue
     }
     await context.asyncLoads()


### PR DESCRIPTION
 Keep derivatives in filetree for intendedfor check. Make exists checkaware of leading slashes.
#1947 