### PR TITLE
FIX: Start file count at 0

### DIFF
--- a/bids-validator/src/summary/summary.ts
+++ b/bids-validator/src/summary/summary.ts
@@ -69,7 +69,7 @@ export class Summary {
   schemaVersion: string
   constructor() {
     this.dataProcessed = false
-    this.totalFiles = -1
+    this.totalFiles = 0
     this.size = 0
     this.sessions = new Set()
     this.subjects = new Set()


### PR DESCRIPTION
The -1 seems to have been copied from the legacy validator, which used
-1 as an indicator that the value was uninitialized and then later
replaced it with a `length()` call. Since we just increment it when
processing each file, it makes sense to start at 0.
