### PR TITLE
FIX: Expect multiple rule matches for events.json

### DIFF
--- a/bids-validator/src/validators/filenameIdentify.test.ts
+++ b/bids-validator/src/validators/filenameIdentify.test.ts
@@ -74,7 +74,7 @@ Deno.test('test hasMatch', async (t) => {
     hasMatch(schema, context)
   })
 
-  await t.step('No  match', async () => {
+  await t.step('No match', async () => {
     const fileName = Deno.makeTempFileSync().split('/')[2]
     const file = new BIDSFileDeno('/tmp', fileName, ignore)
 
@@ -87,7 +87,7 @@ Deno.test('test hasMatch', async (t) => {
       true,
     )
   })
-  await t.step('1+ matched, datatype match', async () => {
+  await t.step('2 matches, no pruning', async () => {
     const path = `${PATH}/../bids-examples/fnirs_automaticity`
     const fileName = 'events.json'
     const file = new BIDSFileDeno(path, fileName, ignore)
@@ -97,7 +97,6 @@ Deno.test('test hasMatch', async (t) => {
       'rules.files.raw.task.events__pet',
     ]
     await hasMatch(schema, context)
-    assertEquals(context.filenameRules.length, 1)
-    assertEquals(context.filenameRules[0], 'rules.files.raw.task.events__mri')
+    assertEquals(context.filenameRules.length, 2)
   })
 })


### PR DESCRIPTION
This test is a bit weird; it seems to have been relying on arbitrary
pruning. There's nothing in the rules or code that now (as of #1940)
should prevent multiple rules from being returned.

If we do want a test to verify pruning, we should come up with a new
one.
