### PR TITLE
fix(expressions): Make FileTree.contains() return true for directories

### DIFF
--- a/bids-validator/src/types/filetree.ts
+++ b/bids-validator/src/types/filetree.ts
@@ -24,7 +24,10 @@ export class FileTree {
     if (parts.length === 0) {
       return false
     } else if (parts.length === 1) {
-      return this.files.some((x) => x.name === parts[0])
+      return (
+        this.files.some((x) => x.name === parts[0]) ||
+        this.directories.some((x) => x.name === parts[0])
+      )
     } else if (parts.length > 1) {
       const nextDir = this.directories.find((x) => x.name === parts[0])
       if (nextDir) {


### PR DESCRIPTION
Fixes https://github.com/bids-standard/bids-validator/issues/1954.