### PR TITLE
Resolve remaining test failures for schema validator

### DIFF
--- a/bids-validator/src/deps/path.ts
+++ b/bids-validator/src/deps/path.ts
@@ -9,3 +9,6 @@ export {
   parse,
   SEPARATOR,
 } from 'https://deno.land/std@0.217.0/path/mod.ts'
+export {
+  globToRegExp,
+} from 'https://deno.land/std@0.217.0/path/glob_to_regexp.ts'

--- a/bids-validator/src/schema/associations.ts
+++ b/bids-validator/src/schema/associations.ts
@@ -82,11 +82,12 @@ const associationLookup = {
     inherit: true,
     load: async (file: BIDSFile): Promise<ContextAssociations['bval']> => {
       const contents = await file.text()
-      const columns = parseBvalBvec(contents)
+      const rows = parseBvalBvec(contents)
       return {
         path: file.path,
-        n_cols: columns ? columns[0].length : 0,
-        n_rows: columns ? columns.length : 0,
+        n_cols: rows ? rows[0].length : 0,
+        n_rows: rows ? rows.length : 0,
+        values: rows[0],
       }
     },
   },
@@ -96,11 +97,11 @@ const associationLookup = {
     inherit: true,
     load: async (file: BIDSFile): Promise<ContextAssociations['bvec']> => {
       const contents = await file.text()
-      const columns = parseBvalBvec(contents)
+      const rows = parseBvalBvec(contents)
       return {
         path: file.path,
-        n_cols: columns ? columns[0].length : 0,
-        n_rows: columns ? columns.length : 0,
+        n_cols: rows ? rows[0].length : 0,
+        n_rows: rows ? rows.length : 0,
       }
     },
   },

--- a/bids-validator/src/types/context.ts
+++ b/bids-validator/src/types/context.ts
@@ -44,6 +44,7 @@ export interface ContextAssociationsBval {
   path: string
   n_cols: number
   n_rows: number
+  values: number[]
 }
 export interface ContextAssociationsBvec {
   path: string

--- a/bids-validator/src/validators/filenameIdentify.test.ts
+++ b/bids-validator/src/validators/filenameIdentify.test.ts
@@ -74,7 +74,7 @@ Deno.test('test hasMatch', async (t) => {
     hasMatch(schema, context)
   })
 
-  await t.step('No  match', async () => {
+  await t.step('No match', async () => {
     const fileName = Deno.makeTempFileSync().split('/')[2]
     const file = new BIDSFileDeno('/tmp', fileName, ignore)
 
@@ -87,7 +87,7 @@ Deno.test('test hasMatch', async (t) => {
       true,
     )
   })
-  await t.step('1+ matched, datatype match', async () => {
+  await t.step('2 matches, no pruning', async () => {
     const path = `${PATH}/../bids-examples/fnirs_automaticity`
     const fileName = 'events.json'
     const file = new BIDSFileDeno(path, fileName, ignore)
@@ -97,7 +97,6 @@ Deno.test('test hasMatch', async (t) => {
       'rules.files.raw.task.events__pet',
     ]
     await hasMatch(schema, context)
-    assertEquals(context.filenameRules.length, 1)
-    assertEquals(context.filenameRules[0], 'rules.files.raw.task.events__mri')
+    assertEquals(context.filenameRules.length, 2)
   })
 })

--- a/bids-validator/src/validators/filenameIdentify.ts
+++ b/bids-validator/src/validators/filenameIdentify.ts
@@ -12,7 +12,7 @@
  * object in the schema for reference.
  */
 // @ts-nocheck
-import { SEPARATOR } from '../deps/path.ts'
+import { SEPARATOR, globToRegExp } from '../deps/path.ts'
 import { GenericSchema, Schema } from '../types/schema.ts'
 import { BIDSContext } from '../schema/context.ts'
 import { lookupModality } from '../schema/modalities.ts'
@@ -56,7 +56,7 @@ function findRuleMatches(schema, context) {
 export function _findRuleMatches(node, path, context) {
   if (
     ('path' in node && context.file.name.endsWith(node.path)) ||
-    ('stem' in node && context.file.name.startsWith(node.stem)) ||
+    ('stem' in node && context.file.name.match(globToRegExp(node.stem + '*'))) ||
     ('suffixes' in node && node.suffixes.includes(context.suffix))
   ) {
     context.filenameRules.push(path)

--- a/bids-validator/src/validators/filenameIdentify.ts
+++ b/bids-validator/src/validators/filenameIdentify.ts
@@ -74,27 +74,18 @@ export function _findRuleMatches(node, path, context) {
 
 export async function datatypeFromDirectory(schema, context) {
   const subEntity = schema.objects.entities.subject.name
-  const subFormat = schema.objects.formats[subEntity.format]
   const sesEntity = schema.objects.entities.session.name
-  const sesFormat = schema.objects.formats[sesEntity.format]
   const parts = context.file.path.split(SEPARATOR)
-  let datatypeIndex = 2
-  if (parts[0] !== '') {
-    // we assume paths have leading '/'
-  }
-  // Ignoring associated data for now
-  const subParts = parts[1].split('-')
-  if (!(subParts.length === 2 && subParts[0] === subEntity)) {
-    // first directory must be subject
-  }
-  if (parts.length < 3) {
+  let datatypeIndex = parts.length - 2
+  if (datatypeIndex < 1) {
     return Promise.resolve()
   }
-  const sesParts = parts[2].split('-')
-  if (sesParts.length === 2 && sesParts[0] === sesEntity) {
-    datatypeIndex = 3
-  }
   const dirDatatype = parts[datatypeIndex]
+  if (dirDatatype === 'phenotype') {
+    // Phenotype is a pseudo-datatype for now.
+    context.datatype = dirDatatype
+    return Promise.resolve()
+  }
   for (let key in schema.rules.modalities) {
     if (schema.rules.modalities[key].datatypes.includes(dirDatatype)) {
       context.modality = key

--- a/bids-validator/src/validators/filenameIdentify.ts
+++ b/bids-validator/src/validators/filenameIdentify.ts
@@ -145,9 +145,9 @@ function entitiesExtensionsInRule(
 ): boolean {
   const rule = schema[path]
   const fileEntities = Object.keys(context.entities)
-  const ruleEntities = Object.keys(rule.entities).map((key) =>
+  const ruleEntities = rule.entities ? Object.keys(rule.entities).map((key) =>
     lookupEntityLiteral(key, schema),
-  )
+  ) : []
   const extInRule =
     !rule.extensions ||
     (rule.extensions && rule.extensions.includes(context.extension))


### PR DESCRIPTION
This merges:

* [x] #1951 
* [ ] #1952 
* [ ] #1955 
* [x] #1956 
* [ ] #1957

This pulls in the schema from

* [x] bids-standard/bids-specification#1672
* [x] bids-standard/bids-specification#1722

And this pulls in examples with fixes in

* [x] bids-standard/bids-examples#438
* [x] bids-standard/bids-examples#442

Locally, tests are passing. Let's see what CI says.

----

* Checks indicate merges to `master` have allowed this to be dropped from this PR.