### PR TITLE
Use /usr/bin/env not /bin/env  as a more portable (present on OSX)

### DIFF
--- a/bids-validator/bids-validator-deno
+++ b/bids-validator/bids-validator-deno
@@ -1,3 +1,3 @@
-#!/bin/env -S deno run --allow-read --allow-write --allow-env --allow-net --allow-run
+#!/usr/bin/env -S deno run --allow-read --allow-write --allow-env --allow-net --allow-run
 import './src/bids-validator.ts'
 

--- a/bids-validator/build.ts
+++ b/bids-validator/build.ts
@@ -1,4 +1,4 @@
-#!/bin/env -S deno run --allow-read --allow-write --allow-env --allow-net --allow-run
+#!/usr/bin/env -S deno run --allow-read --allow-write --allow-env --allow-net --allow-run
 /**
  * Build the schema based validator for distribution (web and npm), targets browser compatible ESM
  *


### PR DESCRIPTION
Discovered in https://github.com/bids-standard/bids-examples/actions/runs/8840102018/job/24274801958?pr=435 for https://github.com/bids-standard/bids-examples/pull/435

Trivial , so quick Merge would be appreciated to facilitate further work on above PR 