### PR TITLE
CI: Update submodules in the usual way

### DIFF
--- a/.github/workflows/deno_tests.yml
+++ b/.github/workflows/deno_tests.yml
@@ -40,13 +40,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: denoland/setup-deno@v1.1.2
+        with:
+          submodules: true
+      - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x
-      - name: Get bids-examples
-        run: |
-          git submodule update --init --recursive
-          git submodule update --recursive --remote
       - run: deno test --allow-all --coverage=cov/ src/
       - name: Collect coverage
         run: deno coverage cov/ --lcov --output=coverage.lcov


### PR DESCRIPTION
The current CI checkout updates submodules in a separate step, and ends up reverting to a different target commit (I think `master`). This makes it difficult to test examples in a fork or branch.