### PR TITLE
fix(legacy): Add missing top-level rule for UNIT1 sidecars

### DIFF
--- a/bids-validator/bids_validator/rules/top_level_rules.json
+++ b/bids-validator/bids_validator/rules/top_level_rules.json
@@ -140,7 +140,7 @@
   },
 
   "unit1_top": {
-    "regexp": "^[\\/\\\\](?:ses-[a-zA-Z0-9]+_)?(?:acq-[a-zA-Z0-9]+_)?(?:ce-[a-zA-Z0-9]+_)?(?:rec-[a-zA-Z0-9]+_)?(?:run-[0-9]+_)?(?:chunk-[0-9]+_)?(@@@_unit1_suffixes_@@@)\\.json$",
+    "regexp": "^[\\/\\\\](?:ses-[a-zA-Z0-9]+_)?(?:task-[a-zA-Z0-9]+_)?(?:acq-[a-zA-Z0-9]+_)?(?:ce-[a-zA-Z0-9]+_)?(?:rec-[a-zA-Z0-9]+_)?(?:run-[0-9]+_)?(?:chunk-[0-9]+_)?(@@@_unit1_suffixes_@@@)\\.json$",
     "tokens": {
       "@@@_unit1_suffixes_@@@": ["UNIT1"]
     }

--- a/bids-validator/bids_validator/rules/top_level_rules.json
+++ b/bids-validator/bids_validator/rules/top_level_rules.json
@@ -25,7 +25,6 @@
         "TB1RFM\\.json",
         "TB1SRGE\\.json",
         "RB1COR\\.json",
-        "UNIT1\\.json",
         "events\\.json",
         "scans\\.json",
         "samples\\.json",

--- a/bids-validator/bids_validator/rules/top_level_rules.json
+++ b/bids-validator/bids_validator/rules/top_level_rules.json
@@ -25,6 +25,7 @@
         "TB1RFM\\.json",
         "TB1SRGE\\.json",
         "RB1COR\\.json",
+        "UNIT1\\.json",
         "events\\.json",
         "scans\\.json",
         "samples\\.json",
@@ -135,7 +136,7 @@
   "mp2rage_top": {
     "regexp": "^[\\/\\\\](?:ses-[a-zA-Z0-9]+_)?(?:acq-[a-zA-Z0-9]+_)?(?:ce-[a-zA-Z0-9]+_)?(?:rec-[a-zA-Z0-9]+_)?(?:run-[0-9]+_)?(?:echo-[0-9]+_)?(?:flip-[0-9]+_)?(?:inv-[0-9]+_)?(?:part-(mag|phase|real|imag)_)?(@@@_mp2rage_suffixes_@@@)\\.json$",
     "tokens": {
-      "@@@_mp2rage_suffixes_@@@": ["MP2RAGE"]
+      "@@@_mp2rage_suffixes_@@@": ["MP2RAGE", "UNIT1"]
     }
   },
 

--- a/bids-validator/bids_validator/rules/top_level_rules.json
+++ b/bids-validator/bids_validator/rules/top_level_rules.json
@@ -136,7 +136,14 @@
   "mp2rage_top": {
     "regexp": "^[\\/\\\\](?:ses-[a-zA-Z0-9]+_)?(?:acq-[a-zA-Z0-9]+_)?(?:ce-[a-zA-Z0-9]+_)?(?:rec-[a-zA-Z0-9]+_)?(?:run-[0-9]+_)?(?:echo-[0-9]+_)?(?:flip-[0-9]+_)?(?:inv-[0-9]+_)?(?:part-(mag|phase|real|imag)_)?(@@@_mp2rage_suffixes_@@@)\\.json$",
     "tokens": {
-      "@@@_mp2rage_suffixes_@@@": ["MP2RAGE", "UNIT1"]
+      "@@@_mp2rage_suffixes_@@@": ["MP2RAGE"]
+    }
+  },
+
+  "unit1_top": {
+    "regexp": "^[\\/\\\\](?:ses-[a-zA-Z0-9]+_)?(?:acq-[a-zA-Z0-9]+_)?(?:ce-[a-zA-Z0-9]+_)?(?:rec-[a-zA-Z0-9]+_)?(?:run-[0-9]+_)?(?:chunk-[0-9]+_)?(@@@_unit1_suffixes_@@@)\\.json$",
+    "tokens": {
+      "@@@_unit1_suffixes_@@@": ["UNIT1"]
     }
   },
 


### PR DESCRIPTION
To be reviewed by qMRI BIDS experts.