### PR TITLE
ci: Fix artifact name for schema web validator deployment

### DIFF
--- a/.github/workflows/schema_web_deploy.yml
+++ b/.github/workflows/schema_web_deploy.yml
@@ -21,7 +21,7 @@ jobs:
         working-directory: ./web
       - uses: actions/upload-artifact@v4
         with:
-          name: web
+          name: github-pages
           path: web/dist
   deploy:
     needs: build


### PR DESCRIPTION
Fix for `No artifacts named "github-pages" were found for this workflow run. Ensure artifacts are uploaded with actions/upload-artifact@v4 or later.`

https://github.com/bids-standard/bids-validator/actions/runs/9023707172/job/24796100179