### PR TITLE
feat(schema): Load subject data

### DIFF
--- a/bids-validator/src/schema/context.test.ts
+++ b/bids-validator/src/schema/context.test.ts
@@ -88,7 +88,7 @@ rootFileTree.files = [
 ]
 rootFileTree.directories = [subjectFileTree]
 
-const context = new BIDSContext(anatFileTree, dataFile, issues)
+let context = new BIDSContext(anatFileTree, dataFile, issues)
 
 Deno.test('test context LoadSidecar', async (t) => {
   await context.loadSidecar(rootFileTree)
@@ -104,5 +104,18 @@ Deno.test('test context LoadSidecar', async (t) => {
     assert(rootValue, 'root')
     assert(subValue, 'subject')
     assert(anatValue, 'anat')
+  })
+})
+
+context = new BIDSContext(rootFileTree, dataFile, issues)
+
+Deno.test('test context loadSubjects', async (t) => {
+  await context.loadSubjects()
+  await t.step('context produces correct subjects object', () => {
+    assert(context.dataset.subjects, "subjects object exists")
+    assert(context.dataset.subjects.sub_dirs.length == 1, "there is only one sub dir found")
+    assert(context.dataset.subjects.sub_dirs[0] == 'sub-01', "that sub dir is sub-01")
+    // no participants.tsv so this should be empty
+    assert(context.dataset.subjects.participant_id == undefined, "no participant_id is populated")
   })
 })

--- a/bids-validator/src/schema/context.ts
+++ b/bids-validator/src/schema/context.ts
@@ -24,7 +24,7 @@ export class BIDSContextDataset implements ContextDataset {
   tree: object
   ignored: any[]
   modalities: any[]
-  subjects: ContextDatasetSubjects
+  subjects?: ContextDatasetSubjects
 
   constructor(options?: ValidatorOptions, description = {}) {
     this.dataset_description = description
@@ -32,7 +32,6 @@ export class BIDSContextDataset implements ContextDataset {
     this.tree = {}
     this.ignored = []
     this.modalities = []
-    this.subjects = new BIDSContextDatasetSubjects()
     if (options) {
       this.options = options
     }
@@ -64,7 +63,6 @@ export class BIDSContextDatasetSubjects implements ContextDatasetSubjects {
 }
 
 const defaultDsContext = new BIDSContextDataset()
-defaultDsContext.subjects = new BIDSContextDatasetSubjects()
 
 export class BIDSContext implements Context {
   // Internal representation of the file tree
@@ -219,6 +217,10 @@ export class BIDSContext implements Context {
 
   // This is currently done for every file. It should be done once for the dataset.
   async loadSubjects(): Promise<void> {
+    if (this.dataset.subjects != null) {
+      return
+    }
+    this.dataset.subjects = new BIDSContextDatasetSubjects()
     // Load subject dirs from the file tree
     this.dataset.subjects.sub_dirs = this.fileTree.directories
       .filter((dir) => dir.name.startsWith('sub-'))

--- a/bids-validator/src/schema/expressionLanguage.ts
+++ b/bids-validator/src/schema/expressionLanguage.ts
@@ -88,7 +88,10 @@ export const expressionFunctions = {
     return arg.substr(start, end - start)
   },
   sorted: <T>(list: T[]): T[] => {
-    list.sort()
-    return list
+    // Copy, sort, return
+    return list.slice().sort()
+  },
+  allequal: <T>(a: T[], b: T[]): boolean => {
+    return (a != null && b != null) && a.length === b.length && a.every((v, i) => v === b[i])
   },
 }

--- a/bids-validator/src/types/context.ts
+++ b/bids-validator/src/types/context.ts
@@ -2,8 +2,8 @@ import { ValidatorOptions } from '../setup/options.ts'
 
 export interface ContextDatasetSubjects {
   sub_dirs: string[]
-  participant_id: string[]
-  phenotype: string[]
+  participant_id?: string[]
+  phenotype?: string[]
 }
 export interface ContextDataset {
   dataset_description: Record<string, unknown>
@@ -11,7 +11,7 @@ export interface ContextDataset {
   tree: object
   ignored: any[]
   modalities: any[]
-  subjects: ContextDatasetSubjects[]
+  subjects: ContextDatasetSubjects
   options?: ValidatorOptions
 }
 export interface ContextSubjectSessions {

--- a/bids-validator/src/types/context.ts
+++ b/bids-validator/src/types/context.ts
@@ -11,7 +11,7 @@ export interface ContextDataset {
   tree: object
   ignored: any[]
   modalities: any[]
-  subjects: ContextDatasetSubjects
+  subjects?: ContextDatasetSubjects
   options?: ValidatorOptions
 }
 export interface ContextSubjectSessions {


### PR DESCRIPTION
This fixes the implementation of:

* `rules.checks.dataset.SubjectFolders`
* `rules.checks.dataset.ParticipantIDMismatch`
* `rules.checks.dataset.PhenotypeSubjectsMissing`

These started failing with https://github.com/bids-standard/bids-specification/pull/1833, which activated previously disabled checks.

@rwblair

Closes #1978.