### PR TITLE
feat(deno): Retrieve version from import.meta.url or git, when possible

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+bids-validator/src/.git-meta.json  export-subst

--- a/bids-validator/src/.git-meta.json
+++ b/bids-validator/src/.git-meta.json
@@ -1,0 +1,6 @@
+{
+  "node": "$Format:%H$",
+  "date": "$Format:%cI$",
+  "description": "$Format:%(describe:tags=true,match=*[0-9]*)$",
+  "refnames": "$Format:%D$"
+}

--- a/bids-validator/src/setup/options.ts
+++ b/bids-validator/src/setup/options.ts
@@ -13,34 +13,36 @@ export type ValidatorOptions = {
   debug: LevelName
 }
 
-export const validateCommand = new Command()
-  .name('bids-validator')
-  .type('debugLevel', new EnumType(LogLevelNames))
-  .description(
-    'This tool checks if a dataset in a given directory is compatible with the Brain Imaging Data Structure specification. To learn more about Brain Imaging Data Structure visit http://bids.neuroimaging.io',
-  )
-  .arguments('<dataset_directory>')
-  .version(await getVersion())
-  .option('--json', 'Output machine readable JSON')
-  .option(
-    '-s, --schema <type:string>',
-    'Specify a schema version to use for validation',
-    {
-      default: 'latest',
-    },
-  )
-  .option('-v, --verbose', 'Log more extensive information about issues')
-  .option(
-    '--ignoreNiftiHeaders',
-    'Disregard NIfTI header content during validation',
-  )
-  .option('--debug <type:debugLevel>', 'Enable debug output', {
-    default: 'ERROR',
-  })
-  .option(
-    '--filenameMode',
-    'Enable filename checks for newline separated filenames read from stdin',
-  )
+async function getValidatorCommand() {
+  return new Command()
+    .name('bids-validator')
+    .type('debugLevel', new EnumType(LogLevelNames))
+    .description(
+      'This tool checks if a dataset in a given directory is compatible with the Brain Imaging Data Structure specification. To learn more about Brain Imaging Data Structure visit http://bids.neuroimaging.io',
+    )
+    .arguments('<dataset_directory>')
+    .version(await getVersion())
+    .option('--json', 'Output machine readable JSON')
+    .option(
+      '-s, --schema <type:string>',
+      'Specify a schema version to use for validation',
+      {
+        default: 'latest',
+      },
+    )
+    .option('-v, --verbose', 'Log more extensive information about issues')
+    .option(
+      '--ignoreNiftiHeaders',
+      'Disregard NIfTI header content during validation',
+    )
+    .option('--debug <type:debugLevel>', 'Enable debug output', {
+      default: 'ERROR',
+    })
+    .option(
+      '--filenameMode',
+      'Enable filename checks for newline separated filenames read from stdin',
+    )
+}
 
 /**
  * Parse command line options and return a ValidatorOptions config
@@ -49,7 +51,8 @@ export const validateCommand = new Command()
 export async function parseOptions(
   argumentOverride: string[] = Deno.args,
 ): Promise<ValidatorOptions> {
-  const { args, options } = await validateCommand.parse(argumentOverride)
+  const command = await getValidatorCommand()
+  const { args, options } = await command.parse(argumentOverride)
   return {
     datasetPath: args[0],
     ...options,

--- a/bids-validator/src/setup/options.ts
+++ b/bids-validator/src/setup/options.ts
@@ -13,36 +13,33 @@ export type ValidatorOptions = {
   debug: LevelName
 }
 
-async function getValidatorCommand() {
-  return new Command()
-    .name('bids-validator')
-    .type('debugLevel', new EnumType(LogLevelNames))
-    .description(
-      'This tool checks if a dataset in a given directory is compatible with the Brain Imaging Data Structure specification. To learn more about Brain Imaging Data Structure visit http://bids.neuroimaging.io',
-    )
-    .arguments('<dataset_directory>')
-    .version(await getVersion())
-    .option('--json', 'Output machine readable JSON')
-    .option(
-      '-s, --schema <type:string>',
-      'Specify a schema version to use for validation',
-      {
-        default: 'latest',
-      },
-    )
-    .option('-v, --verbose', 'Log more extensive information about issues')
-    .option(
-      '--ignoreNiftiHeaders',
-      'Disregard NIfTI header content during validation',
-    )
-    .option('--debug <type:debugLevel>', 'Enable debug output', {
-      default: 'ERROR',
-    })
-    .option(
-      '--filenameMode',
-      'Enable filename checks for newline separated filenames read from stdin',
-    )
-}
+export const validateCommand = new Command()
+  .name('bids-validator')
+  .type('debugLevel', new EnumType(LogLevelNames))
+  .description(
+    'This tool checks if a dataset in a given directory is compatible with the Brain Imaging Data Structure specification. To learn more about Brain Imaging Data Structure visit http://bids.neuroimaging.io',
+  )
+  .arguments('<dataset_directory>')
+  .option('--json', 'Output machine readable JSON')
+  .option(
+    '-s, --schema <type:string>',
+    'Specify a schema version to use for validation',
+    {
+      default: 'latest',
+    },
+  )
+  .option('-v, --verbose', 'Log more extensive information about issues')
+  .option(
+    '--ignoreNiftiHeaders',
+    'Disregard NIfTI header content during validation',
+  )
+  .option('--debug <type:debugLevel>', 'Enable debug output', {
+    default: 'ERROR',
+  })
+  .option(
+    '--filenameMode',
+    'Enable filename checks for newline separated filenames read from stdin',
+  )
 
 /**
  * Parse command line options and return a ValidatorOptions config
@@ -51,8 +48,9 @@ async function getValidatorCommand() {
 export async function parseOptions(
   argumentOverride: string[] = Deno.args,
 ): Promise<ValidatorOptions> {
-  const command = await getValidatorCommand()
-  const { args, options } = await command.parse(argumentOverride)
+  const version = await getVersion()
+  const { args, options } = await validateCommand.version(version)
+    .parse(argumentOverride)
   return {
     datasetPath: args[0],
     ...options,

--- a/bids-validator/src/setup/options.ts
+++ b/bids-validator/src/setup/options.ts
@@ -20,7 +20,7 @@ export const validateCommand = new Command()
     'This tool checks if a dataset in a given directory is compatible with the Brain Imaging Data Structure specification. To learn more about Brain Imaging Data Structure visit http://bids.neuroimaging.io',
   )
   .arguments('<dataset_directory>')
-  .version(getVersion())
+  .version(await getVersion())
   .option('--json', 'Output machine readable JSON')
   .option(
     '-s, --schema <type:string>',

--- a/bids-validator/src/setup/options.ts
+++ b/bids-validator/src/setup/options.ts
@@ -1,5 +1,6 @@
 import { LevelName, LogLevelNames } from '../deps/logger.ts'
 import { Command, EnumType } from '../deps/cliffy.ts'
+import { getVersion } from '../version.ts'
 
 export type ValidatorOptions = {
   datasetPath: string
@@ -19,7 +20,7 @@ export const validateCommand = new Command()
     'This tool checks if a dataset in a given directory is compatible with the Brain Imaging Data Structure specification. To learn more about Brain Imaging Data Structure visit http://bids.neuroimaging.io',
   )
   .arguments('<dataset_directory>')
-  .version('alpha')
+  .version(getVersion())
   .option('--json', 'Output machine readable JSON')
   .option(
     '-s, --schema <type:string>',

--- a/bids-validator/src/version.ts
+++ b/bids-validator/src/version.ts
@@ -1,4 +1,5 @@
 import gitmeta from './.git-meta.json' with { type: 'json' }
+import { dirname } from './deps/path.ts'
 
 /**
  * Determine the version of the currently running script.
@@ -24,7 +25,7 @@ export async function getVersion(): Promise<string> {
 
   const url = new URL(Deno.mainModule)
   if (url.protocol === 'file:') {
-    version = await getLocalVersion(url.pathname.split('/').slice(0, -1).join('/'))
+    version = await getLocalVersion(dirname(url.pathname))
     if (version) { return version }
   } else if (url.protocol === 'https:' || url.protocol === 'http:') {
     version = getRemoteVersion(url)

--- a/bids-validator/src/version.ts
+++ b/bids-validator/src/version.ts
@@ -1,6 +1,12 @@
+import gitmeta from './.git-meta.json' with { type: 'json' }
+
 export async function getVersion(): string {
   const url = import.meta.url
   if (url.startsWith('file://')) {
+    const archiveVersion = getArchiveVersion()
+    if (archiveVersion) {
+      return archiveVersion
+    }
     // Get parent directory of current file, without file:/
     const parent = url.slice(7).split('/').slice(0, -1).join('/')
     return await getLocalVersion(parent)
@@ -14,7 +20,7 @@ export async function getVersion(): string {
   return url
 }
 
-export async function getLocalVersion(path: string): string {
+async function getLocalVersion(path: string): string {
   const p = Deno.run({
     cmd: ['git', 'describe', '--tags', '--always'],
     stdout: 'piped',
@@ -23,4 +29,11 @@ export async function getLocalVersion(path: string): string {
   })
   const description = new TextDecoder().decode(await p.output()).trim()
   return description
+}
+
+function getArchiveVersion(): string | undefined {
+  if (!gitmeta.description.startsWith('$Format:')) {
+    return gitmeta.description
+  }
+  return undefined
 }

--- a/bids-validator/src/version.ts
+++ b/bids-validator/src/version.ts
@@ -1,7 +1,9 @@
-export function getVersion(): string {
+export async function getVersion(): string {
   const url = import.meta.url
   if (url.startsWith('file://')) {
-    return 'local'
+    // Get parent directory of current file, without file:/
+    const parent = url.slice(7).split('/').slice(0, -1).join('/')
+    return await getLocalVersion(parent)
   } else if (url.startsWith('https://deno.land/x/')) {
     // Retrieve version X from https://deno.land/x/bids-validator@X/version.ts
     return url.split('@')[1].split('/')[0]
@@ -10,4 +12,15 @@ export function getVersion(): string {
     return url.split('/bids-validator/')[1]
   }
   return url
+}
+
+export async function getLocalVersion(path: string): string {
+  const p = Deno.run({
+    cmd: ['git', 'describe', '--tags', '--always'],
+    stdout: 'piped',
+    stderr: 'piped',
+    cwd: path,
+  })
+  const description = new TextDecoder().decode(await p.output()).trim()
+  return description
 }

--- a/bids-validator/src/version.ts
+++ b/bids-validator/src/version.ts
@@ -1,34 +1,58 @@
 import gitmeta from './.git-meta.json' with { type: 'json' }
 
-export async function getVersion(): string {
-  const url = import.meta.url
-  if (url.startsWith('file://')) {
-    const archiveVersion = getArchiveVersion()
-    if (archiveVersion) {
-      return archiveVersion
-    }
-    // Get parent directory of current file, without file:/
-    const parent = url.slice(7).split('/').slice(0, -1).join('/')
-    return await getLocalVersion(parent)
-  } else if (url.startsWith('https://deno.land/x/')) {
-    // Retrieve version X from https://deno.land/x/bids-validator@X/version.ts
-    return url.split('@')[1].split('/')[0]
-  } else if (url.startsWith('https://raw.githubusercontent.com')) {
-    // Retrieve version X from https://raw.githubusercontent.com/bids-standard/bids-validator/X/bids-validator/src/version.ts
-    return url.split('/bids-validator/')[1]
+/**
+ * Determine the version of the currently running script.
+ *
+ * The version is determined by the following rules:
+ *
+ * 1. Search for a hard-coded version populated by git-archive or the build.
+ * 2. If the script is running from a local file, the version is determined by
+ *    the output of `git describe --tags --always` in the script's directory.
+ * 3. If the script is running from a remote URL, the version is determined by
+ *    the path of the URL. In case of GitHub, the version can be any git ref.
+ *    In the case of deno.land, the tag name should be available and will be parsed.
+ *
+ * If no version can be determined, the URL of the script is returned.
+ *
+ * @returns The version of the script.
+ *
+ */
+export async function getVersion(): Promise<string> {
+  // Hard-coded JSON wins
+  let version = getArchiveVersion()
+  if (version) { return version }
+
+  const url = new URL(Deno.mainModule)
+  if (url.protocol === 'file:') {
+    version = await getLocalVersion(url.pathname.split('/').slice(0, -1).join('/'))
+    if (version) { return version }
+  } else if (url.protocol === 'https:' || url.protocol === 'http:') {
+    version = getRemoteVersion(url)
+    if (version) { return version }
   }
-  return url
+  return url.href
 }
 
-async function getLocalVersion(path: string): string {
+async function getLocalVersion(path: string): Promise<string> {
   const p = Deno.run({
     cmd: ['git', 'describe', '--tags', '--always'],
     stdout: 'piped',
-    stderr: 'piped',
     cwd: path,
   })
   const description = new TextDecoder().decode(await p.output()).trim()
+  p.close()
   return description
+}
+
+function getRemoteVersion(url: URL): string | undefined {
+  if (url.hostname === 'deno.land') {
+    // https://deno.land/x/bids-validator@<ver>/bids-validator.ts
+    return url.pathname.split('@')[1].split('/')[0]
+  } else if (url.hostname === 'raw.githubusercontent.com') {
+    // https://raw.githubusercontent.com/<org>/bids-validator/<ver>/bids-validator/src/bids-validator.ts
+    return url.pathname.split('/bids-validator/')[1]
+  }
+  return undefined
 }
 
 function getArchiveVersion(): string | undefined {

--- a/bids-validator/src/version.ts
+++ b/bids-validator/src/version.ts
@@ -1,0 +1,13 @@
+export function getVersion(): string {
+  const url = import.meta.url
+  if (url.startsWith('file://')) {
+    return 'local'
+  } else if (url.startsWith('https://deno.land/x/')) {
+    // Retrieve version X from https://deno.land/x/bids-validator@X/version.ts
+    return url.split('@')[1].split('/')[0]
+  } else if (url.startsWith('https://raw.githubusercontent.com')) {
+    // Retrieve version X from https://raw.githubusercontent.com/bids-standard/bids-validator/X/bids-validator/src/version.ts
+    return url.split('/bids-validator/')[1]
+  }
+  return url
+}

--- a/bids-validator/src/version.ts
+++ b/bids-validator/src/version.ts
@@ -36,9 +36,8 @@ export async function getVersion(): Promise<string> {
 
 async function getLocalVersion(path: string): Promise<string> {
   const p = Deno.run({
-    cmd: ['git', 'describe', '--tags', '--always'],
+    cmd: ['git', '-C', path, 'describe', '--tags', '--always'],
     stdout: 'piped',
-    cwd: path,
   })
   const description = new TextDecoder().decode(await p.output()).trim()
   p.close()


### PR DESCRIPTION
```
❯ deno run --reload --allow-all https://github.com/effigies/bids-validator/raw/enh/deno-version/bids-validator/src/bids-validator.ts --version
bids-validator enh/deno-version
❯ deno run --allow-all bids-validator/src/bids-validator.ts --version
bids-validator v1.14.7-dev.0-38-g5314ea00
```

Should emit the right version for released versions on deno.land. We can improve it for untagged versions in the future.