### PR TITLE
Bump hed-validator to 3.14.0

### DIFF
--- a/bids-validator/package.json
+++ b/bids-validator/package.json
@@ -45,7 +45,7 @@
     "date-fns": "^3.6.0",
     "events": "^3.3.0",
     "exifreader": "^4.23.1",
-    "hed-validator": "^3.13.5",
+    "hed-validator": "^3.14.0",
     "ignore": "^5.3.1",
     "is-utf8": "^0.2.1",
     "jest": "^29.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       "version": "1.14.7-dev.0",
       "license": "MIT",
       "dependencies": {
-        "@aws-sdk/client-s3": "3.577.0",
+        "@aws-sdk/client-s3": "^3.577.0",
         "ajv": "^6.5.2",
         "bytes": "^3.1.2",
         "colors": "^1.4.0",
@@ -37,7 +37,7 @@
         "date-fns": "^3.6.0",
         "events": "^3.3.0",
         "exifreader": "^4.23.1",
-        "hed-validator": "^3.13.5",
+        "hed-validator": "^3.14.0",
         "ignore": "^5.3.1",
         "is-utf8": "^0.2.1",
         "jest": "^29.7.0",
@@ -10342,9 +10342,9 @@
       }
     },
     "node_modules/hed-validator": {
-      "version": "3.13.5",
-      "resolved": "https://registry.npmjs.org/hed-validator/-/hed-validator-3.13.5.tgz",
-      "integrity": "sha512-ZB2QKMFfCHIwuaO68VshtVXGuqVyNvYJxyWaJcxp6XRILu2BILx3oyTki+x4YPzDHW8BT9d34AKehnf1ONWJjg==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/hed-validator/-/hed-validator-3.14.0.tgz",
+      "integrity": "sha512-x323vRSe/YOSD4RuOueZH2VZ+rh2VYMgEXiMWfnbHDzidpWZnQQZYF+b8GQoNA4oisZA1DLoZ1HY2lp+9XuJ3w==",
       "dependencies": {
         "buffer": "^6.0.3",
         "cross-fetch": "^4.0.0",
@@ -24510,7 +24510,7 @@
     "bids-validator": {
       "version": "file:bids-validator",
       "requires": {
-        "@aws-sdk/client-s3": "3.577.0",
+        "@aws-sdk/client-s3": "^3.577.0",
         "adm-zip": "",
         "ajv": "^6.5.2",
         "bytes": "^3.1.2",
@@ -24526,7 +24526,7 @@
         "eslint-plugin-prettier": "^5.1.3",
         "events": "^3.3.0",
         "exifreader": "^4.23.1",
-        "hed-validator": "^3.13.5",
+        "hed-validator": "^3.14.0",
         "husky": "^9.0.11",
         "ignore": "^5.3.1",
         "is-utf8": "^0.2.1",
@@ -27045,9 +27045,9 @@
       }
     },
     "hed-validator": {
-      "version": "3.13.5",
-      "resolved": "https://registry.npmjs.org/hed-validator/-/hed-validator-3.13.5.tgz",
-      "integrity": "sha512-ZB2QKMFfCHIwuaO68VshtVXGuqVyNvYJxyWaJcxp6XRILu2BILx3oyTki+x4YPzDHW8BT9d34AKehnf1ONWJjg==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/hed-validator/-/hed-validator-3.14.0.tgz",
+      "integrity": "sha512-x323vRSe/YOSD4RuOueZH2VZ+rh2VYMgEXiMWfnbHDzidpWZnQQZYF+b8GQoNA4oisZA1DLoZ1HY2lp+9XuJ3w==",
       "requires": {
         "buffer": "^6.0.3",
         "cross-fetch": "^4.0.0",


### PR DESCRIPTION
See the release notes at https://github.com/hed-standard/hed-javascript/releases/tag/v3.14.0. The primary new feature is lazy merging of partnered schemas. Some experimental features were removed, but this should not affect BIDS.