### PR TITLE
fix(expr): Use a sensible sorting function for sorted()

### DIFF
--- a/bids-validator/src/schema/expressionLanguage.ts
+++ b/bids-validator/src/schema/expressionLanguage.ts
@@ -88,8 +88,8 @@ export const expressionFunctions = {
     return arg.substr(start, end - start)
   },
   sorted: <T>(list: T[]): T[] => {
-    // Copy, sort, return
-    return list.slice().sort()
+    // Use a cmp function that will work for any comparable types
+    return list.toSorted((a, b) => +(a > b) - +(a < b))
   },
   allequal: <T>(a: T[], b: T[]): boolean => {
     return (a != null && b != null) && a.length === b.length && a.every((v, i) => v === b[i])


### PR DESCRIPTION
Array.sort(), by default, converts numbers to unicode strings and sorts them lexically. This uses `(a > b) - (a < b)` to implement a standard comparison operator. Greater results in 1, equal in 0, lesser in -1.
