### PR TITLE
fix: Small cleanups from recent test fixes

### DIFF
--- a/bids-validator/src/deps/path.ts
+++ b/bids-validator/src/deps/path.ts
@@ -5,7 +5,6 @@ export {
   basename,
   dirname,
   extname,
-  posix,
   fromFileUrl,
   parse,
   SEPARATOR_PATTERN,
@@ -13,3 +12,4 @@ export {
 export {
   globToRegExp,
 } from 'https://deno.land/std@0.217.0/path/glob_to_regexp.ts'
+export * as posix from 'https://deno.land/std@0.217.0/path/posix/mod.ts'

--- a/bids-validator/src/validators/filenameValidate.test.ts
+++ b/bids-validator/src/validators/filenameValidate.test.ts
@@ -9,28 +9,21 @@ import { FileIgnoreRules } from '../files/ignore.ts'
 import { loadSchema } from '../setup/loadSchema.ts'
 
 const schema = (await loadSchema()) as unknown as GenericSchema
-const fileTree = new FileTree('/tmp', '/')
-const issues = new DatasetIssues()
 const ignore = new FileIgnoreRules([])
 
-const splitFile = (path: string) => {
-  const parts = path.split('/')
-  return {
-    dirname: parts.slice(0, parts.length - 1).join('/'),
-    basename: parts[parts.length - 1],
-  }
-}
-
 Deno.test('test missingLabel', async (t) => {
+  const tmpDir = Deno.makeTempDirSync()
+  const fileTree = new FileTree(tmpDir, '/')
   await t.step('File with underscore and no hyphens errors out.', async () => {
-    const tmpFile = Deno.makeTempFileSync({
-      prefix: 'no_labels_',
-      suffix: '_entities.wav',
-    })
-    const { dirname, basename } = splitFile(tmpFile)
-    const file = new BIDSFileDeno(dirname, basename, ignore)
+    const basename = 'no_label_entities.wav'
+    Deno.writeTextFileSync(`${tmpDir}/${basename}`, '')
 
-    const context = new BIDSContext(fileTree, file, issues)
+    const context = new BIDSContext(
+      fileTree,
+      new BIDSFileDeno(tmpDir, `/${basename}`, ignore),
+      new DatasetIssues(),
+    )
+
     await missingLabel(schema, context)
     assertEquals(
       context.issues
@@ -38,19 +31,20 @@ Deno.test('test missingLabel', async (t) => {
         .includes('ENTITY_WITH_NO_LABEL'),
       true,
     )
-    Deno.removeSync(tmpFile)
   })
 
   await t.step(
     "File with underscores and hyphens doesn't error out.",
     async () => {
-      const tmpFile = Deno.makeTempFileSync({
-        prefix: 'we-do_have-',
-        suffix: '_entities.wav',
-      })
-      const { dirname, basename } = splitFile(tmpFile)
-      const file = new BIDSFileDeno(dirname, basename, ignore)
-      const context = new BIDSContext(fileTree, file, issues)
+      const basename = 'we-do_have-some_entities.wav'
+      Deno.writeTextFileSync(`${tmpDir}/${basename}`, '')
+
+      const context = new BIDSContext(
+        fileTree,
+        new BIDSFileDeno(tmpDir, `/${basename}`, ignore),
+        new DatasetIssues(),
+      )
+
       await missingLabel(schema, context)
       assertEquals(
         context.issues
@@ -58,7 +52,7 @@ Deno.test('test missingLabel', async (t) => {
           .includes('ENTITY_WITH_NO_LABEL'),
         false,
       )
-      Deno.removeSync(tmpFile)
     },
   )
+  Deno.removeSync(tmpDir, { recursive: true })
 })


### PR DESCRIPTION
Was meaning to get these in before #1989 was merged, but nbd. I saw on https://deno.land/std@0.224.0/path/mod.ts?s=posix that `path.posix` is deprecated. Also, the Windows fixes made me want to go back and clean up the changes I made for OSX. The use of an explicit `/tmp` seems like it's asking for trouble, and if we create a temporary directory, things simplify a bit.