### PR TITLE
chore(ci): Tag deno builds with full version, truncate history

### DIFF
--- a/.github/workflows/deno_tests.yml
+++ b/.github/workflows/deno_tests.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x

--- a/.github/workflows/deno_tests.yml
+++ b/.github/workflows/deno_tests.yml
@@ -19,6 +19,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Save describe stamp
+        id: describe
+        run: echo version=$( git describe ) >> $GITHUB_OUTPUT
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x
@@ -63,27 +66,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           token: ${{ secrets.PUSH_TOKEN }}
       - name: Set credentials
         run: |
           git config --global user.name "BIDS-Bot"
           git config --global user.email "bids-maintenance@users.noreply.github.com"
-      - name: Save describe stamp
-        run: echo VERSION=$( git describe ) >> $GITHUB_ENV
-      - name: Checkout orphan
+      - name: Reset deno-build to orphan
         run: |
-          git checkout deno-build
-          git rm -rf .
+          git checkout --orphan deno-build
+          git reset --hard
       - uses: actions/download-artifact@v4
         with:
           name: main
           path: main
       - name: Commit to new branch
         run: |
-          mv main/main.js .
-          mv main/bids-validator.js .
+          mv main/main.js main/bids-validator.js .
           git add main.js bids-validator.js
           git commit -m "BLD: $VERSION [skip ci]" || true
+        env:
+          VERSION: ${{ needs.build.describe.version }}
       - name: Push
-        run: git push origin deno-build
+        run: git push -f origin deno-build


### PR DESCRIPTION
We don't have enough git context to properly tag our builds:

```console
❯ deno run -A https://github.com/bids-standard/bids-validator/raw/deno-build/bids-validator.js --version
bids-validator bd30213
```

This fixes that. We're also pipling 5MB of javascript into each commit of `deno-build`. Some of it might compress down well enough, but it's unclear what the benefit is of holding onto this history.

The first commit can be used without the second commit, if there's a reason to keep around the history.