### PR TITLE
feat(tsv): Accept column definitions in schema entries

### DIFF
--- a/bids-validator/src/schema/applyRules.ts
+++ b/bids-validator/src/schema/applyRules.ts
@@ -252,6 +252,12 @@ function evalColumns(
       ]);
     }
 
+    if ("definition" in columnObject) {
+      typeCheck = (value) =>
+        // @ts-expect-error
+        sidecarDefinedTypeCheck(columnObject.definition, value, schema);
+    }
+
     if (
       name in context.sidecar && context.sidecar[name] &&
       typeof (context.sidecar[name]) === "object"


### PR DESCRIPTION
Pairs with https://github.com/bids-standard/bids-specification/pull/1838. This allows us to use the `definition` field of a column object as if it were the column definition defined in the sidecar.