### PR TITLE
Completely rewrite HED support

### DIFF
--- a/bids-validator/package.json
+++ b/bids-validator/package.json
@@ -45,7 +45,7 @@
     "date-fns": "^3.6.0",
     "events": "^3.3.0",
     "exifreader": "^4.23.2",
-    "hed-validator": "^3.14.0",
+    "hed-validator": "^3.15.0",
     "ignore": "^5.3.1",
     "is-utf8": "^0.2.1",
     "jest": "^29.7.0",

--- a/bids-validator/validators/bids/fullTest.js
+++ b/bids-validator/validators/bids/fullTest.js
@@ -221,7 +221,7 @@ const fullTest = (fileList, options, annexed, dir, callback) => {
       )
 
       // check the HED strings
-      return hed(tsvs, jsonContentsDict, jsonFiles, dir)
+      return hed(tsvs, jsonContentsDict, jsonFiles)
     })
     .then((hedIssues) => {
       self.issues = self.issues.concat(hedIssues)

--- a/bids-validator/validators/hed.js
+++ b/bids-validator/validators/hed.js
@@ -68,7 +68,7 @@ function buildTsv(tsv, jsonContents) {
   )
 
   return new hedValidator.bids.BidsTsvFile(
-    tsv.path,
+    tsv.file.relativePath,
     tsv.contents,
     tsv.file,
     potentialSidecars,

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "date-fns": "^3.6.0",
         "events": "^3.3.0",
         "exifreader": "^4.23.2",
-        "hed-validator": "^3.14.0",
+        "hed-validator": "^3.15.0",
         "ignore": "^5.3.1",
         "is-utf8": "^0.2.1",
         "jest": "^29.7.0",
@@ -65,7 +65,7 @@
       "devDependencies": {
         "adm-zip": "",
         "chai": "",
-        "esbuild": "0.21.4",
+        "esbuild": "^0.21.4",
         "esbuild-plugin-globals": "^0.2.0",
         "esbuild-runner": "^2.2.2",
         "eslint": "^8.57.0",
@@ -10342,9 +10342,9 @@
       }
     },
     "node_modules/hed-validator": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/hed-validator/-/hed-validator-3.14.0.tgz",
-      "integrity": "sha512-x323vRSe/YOSD4RuOueZH2VZ+rh2VYMgEXiMWfnbHDzidpWZnQQZYF+b8GQoNA4oisZA1DLoZ1HY2lp+9XuJ3w==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/hed-validator/-/hed-validator-3.15.0.tgz",
+      "integrity": "sha512-gJAiSE2YKSjV4Vs7zu2bb8lgA0obvNN0CgUspIQv7yJCdnVc+GArPBGYXZbqoPtEXzK+aYnz1x/c+ioenEE3pw==",
       "dependencies": {
         "buffer": "^6.0.3",
         "cross-fetch": "^4.0.0",
@@ -24518,7 +24518,7 @@
         "colors": "^1.4.0",
         "cross-fetch": "^4.0.0",
         "date-fns": "^3.6.0",
-        "esbuild": "0.21.4",
+        "esbuild": "^0.21.4",
         "esbuild-plugin-globals": "^0.2.0",
         "esbuild-runner": "^2.2.2",
         "eslint": "^8.57.0",
@@ -24526,7 +24526,7 @@
         "eslint-plugin-prettier": "^5.1.3",
         "events": "^3.3.0",
         "exifreader": "^4.23.2",
-        "hed-validator": "^3.14.0",
+        "hed-validator": "^3.15.0",
         "husky": "^9.0.11",
         "ignore": "^5.3.1",
         "is-utf8": "^0.2.1",
@@ -27045,9 +27045,9 @@
       }
     },
     "hed-validator": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/hed-validator/-/hed-validator-3.14.0.tgz",
-      "integrity": "sha512-x323vRSe/YOSD4RuOueZH2VZ+rh2VYMgEXiMWfnbHDzidpWZnQQZYF+b8GQoNA4oisZA1DLoZ1HY2lp+9XuJ3w==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/hed-validator/-/hed-validator-3.15.0.tgz",
+      "integrity": "sha512-gJAiSE2YKSjV4Vs7zu2bb8lgA0obvNN0CgUspIQv7yJCdnVc+GArPBGYXZbqoPtEXzK+aYnz1x/c+ioenEE3pw==",
       "requires": {
         "buffer": "^6.0.3",
         "cross-fetch": "^4.0.0",


### PR DESCRIPTION
This commit completely rewrites the HED integration module to only build most objects when necessary (due to memory issues).

This depends on code in hed-validator that has not yet been released to npm, and thus it currently does not build. Please test using the `modify-bids-interface` branch of hed-validator and `npm link`.