### PR TITLE
fix(legacy): Prevent prototype pollution (global property) from crashing sidecar merges

### DIFF
--- a/bids-validator/utils/files/generateMergedSidecarDict.js
+++ b/bids-validator/utils/files/generateMergedSidecarDict.js
@@ -12,7 +12,7 @@ function generateMergedSidecarDict(potentialSidecars, jsonContents) {
   potentialSidecars.map((sidecarName) => {
     const jsonObject = jsonContents[sidecarName]
     if (jsonObject) {
-      for (var key in jsonObject) {
+      for (const key of Object.keys(jsonObject)) {
         if (jsonObject.hasOwnProperty(key)) {
           mergedDictionary[key] = jsonObject[key]
         }


### PR DESCRIPTION
This avoids the loop iterating over non-enumerable properties of jsonObject.