### PR TITLE
fix(legacy): Combine sidecars with a method resilient to Object namespace pollution

### DIFF
--- a/bids-validator/utils/files/__tests__/generateMergedSidecarDict.spec.js
+++ b/bids-validator/utils/files/__tests__/generateMergedSidecarDict.spec.js
@@ -18,6 +18,10 @@ describe('generateMergedSidecarDict.js', () => {
       delete Object.prototype.global
     })
 
+    it('trivial check', () => {
+      expect(generateMergedSidecarDict([], {})).toStrictEqual({})
+    })
+
     it('merges objects with global property', () => {
       const potentialSidecars = ['/sidecar1.json', '/sidecar2.json']
       const jsonContents = {
@@ -33,7 +37,7 @@ describe('generateMergedSidecarDict.js', () => {
       }
       expect(
         generateMergedSidecarDict(potentialSidecars, jsonContents),
-      ).toEqual({
+      ).toStrictEqual({
         RegularMetadata1: 'value1',
         RegularMetadata2: 'value2',
         global: {

--- a/bids-validator/utils/files/__tests__/generateMergedSidecarDict.spec.js
+++ b/bids-validator/utils/files/__tests__/generateMergedSidecarDict.spec.js
@@ -1,0 +1,44 @@
+import generateMergedSidecarDict from '../generateMergedSidecarDict.js'
+
+describe('generateMergedSidecarDict.js', () => {
+  describe('Object pollution test', () => {
+    beforeAll(() => {
+      // Simulate code that injects globalThis into every object
+      Object.defineProperty(Object.prototype, 'global', {
+        get: function () {
+          return globalThis
+        },
+        configurable: true,
+      })
+    })
+
+    afterAll(() => {
+      // Clean up the pollution
+      delete Object.prototype.global
+    })
+
+    it('merges objects with global property', () => {
+      const potentialSidecars = ['/sidecar1.json', '/sidecar2.json']
+      const jsonContents = {
+        '/sidecar1.json': {
+          RegularMetadata1: 'value1',
+          global: {
+            globalMetadata: 'value1',
+          },
+        },
+        '/sidecar2.json': {
+          RegularMetadata2: 'value2',
+        },
+      }
+      expect(
+        generateMergedSidecarDict(potentialSidecars, jsonContents),
+      ).toEqual({
+        RegularMetadata1: 'value1',
+        RegularMetadata2: 'value2',
+        global: {
+          globalMetadata: 'value1',
+        },
+      })
+    })
+  })
+})

--- a/bids-validator/utils/files/__tests__/generateMergedSidecarDict.spec.js
+++ b/bids-validator/utils/files/__tests__/generateMergedSidecarDict.spec.js
@@ -1,3 +1,4 @@
+/*global globalThis*/
 import generateMergedSidecarDict from '../generateMergedSidecarDict.js'
 
 describe('generateMergedSidecarDict.js', () => {

--- a/bids-validator/utils/files/generateMergedSidecarDict.js
+++ b/bids-validator/utils/files/generateMergedSidecarDict.js
@@ -8,20 +8,26 @@
  * sidecars.
  */
 function generateMergedSidecarDict(potentialSidecars, jsonContents) {
-  let mergedDictionary = {}
+  // Use a map to avoid potential conflicts with keys in Object.prototype
+  const mergedDictionary = new Map()
+  let valid = true
   potentialSidecars.map((sidecarName) => {
     const jsonObject = jsonContents[sidecarName]
     if (jsonObject) {
       for (const key of Object.keys(jsonObject)) {
         if (jsonObject.hasOwnProperty(key)) {
-          mergedDictionary[key] = jsonObject[key]
+          mergedDictionary.set(key, jsonObject[key])
         }
       }
     } else if (jsonObject === null) {
-      mergedDictionary.invalid = true
+      valid = false
     }
   })
-  return mergedDictionary
+  const mergedDictionaryObj = Object.fromEntries(mergedDictionary)
+  if (!valid) {
+    mergedDictionaryObj.invalid = true
+  }
+  return mergedDictionaryObj
 }
 
 export default generateMergedSidecarDict


### PR DESCRIPTION
Follow-up to #2015.

I think that fix did not fix things.

```
 FAIL  bids-validator/utils/files/__tests__/generateMergedSidecarDict.spec.js
  ● generateMergedSidecarDict.js › Object pollution test › merges objects with global property

    TypeError: Cannot set property global of #<Object> which has only a getter

      15 |       for (const key of Object.keys(jsonObject)) {
      16 |         if (jsonObject.hasOwnProperty(key)) {
    > 17 |           mergedDictionary[key] = jsonObject[key]
         |                                ^
      18 |         }
      19 |       }
      20 |     } else if (jsonObject === null) {

      at bids-validator/utils/files/generateMergedSidecarDict.js:17:32
          at Array.map (<anonymous>)
      at map (bids-validator/utils/files/generateMergedSidecarDict.js:12:21)
      at Object.<anonymous> (bids-validator/utils/files/__tests__/generateMergedSidecarDict.spec.js:34:34)
```