### PR TITLE
Improve test coverage for code added in #2014

### DIFF
--- a/bids-validator/tests/hed.spec.js
+++ b/bids-validator/tests/hed.spec.js
@@ -195,4 +195,54 @@ describe('HED', function () {
       assert.strictEqual(issues[1].code, 105)
     })
   })
+
+  it('should properly issue errors if HED data is used in a sidecar without using HEDVersion', () => {
+    const events = [
+      {
+        file: {
+          path: '/sub01/sub01_task-test_events.tsv',
+          relativePath: '/sub01/sub01_task-test_events.tsv',
+        },
+        path: '/sub01/sub01_task-test_events.tsv',
+        contents: 'onset\tduration\ttest\n' + '7\tsomething\tone\n',
+      },
+    ]
+    const jsonDictionary = {
+      '/sub01/sub01_task-test_events.json': {
+        test: {
+          HED: {
+            one: 'Train',
+          },
+        },
+      },
+      '/dataset_description.json': {},
+    }
+
+    return validateHed(events, jsonDictionary, jsonFiles, '').then((issues) => {
+      assert.strictEqual(issues.length, 1)
+      assert.strictEqual(issues[0].code, 109)
+    })
+  })
+
+  it('should properly issue errors if HED data is used in a TSV file without using HEDVersion', () => {
+    const events = [
+      {
+        file: {
+          path: '/sub01/sub01_task-test_events.tsv',
+          relativePath: '/sub01/sub01_task-test_events.tsv',
+        },
+        path: '/sub01/sub01_task-test_events.tsv',
+        contents: 'onset\tduration\tHED\n' + '7\tsomething\tHuman\n',
+      },
+    ]
+    const jsonDictionary = {
+      '/sub01/sub01_task-test_events.json': {},
+      '/dataset_description.json': {},
+    }
+
+    return validateHed(events, jsonDictionary, jsonFiles, '').then((issues) => {
+      assert.strictEqual(issues.length, 1)
+      assert.strictEqual(issues[0].code, 109)
+    })
+  })
 })

--- a/bids-validator/tests/hed.spec.js
+++ b/bids-validator/tests/hed.spec.js
@@ -245,4 +245,33 @@ describe('HED', function () {
       assert.strictEqual(issues[0].code, 109)
     })
   })
+
+  it('should throw an issue if HEDVersion is invalid', () => {
+    const events = [
+      {
+        file: {
+          path: '/sub01/sub01_task-test_events.tsv',
+          relativePath: '/sub01/sub01_task-test_events.tsv',
+        },
+        path: '/sub01/sub01_task-test_events.tsv',
+        contents:
+          'onset\tduration\ttest\tHED\n' + '7\tsomething\tone\tSpeed/30 mph\n',
+      },
+    ]
+    const jsonDictionary = {
+      '/sub01/sub01_task-test_events.json': {
+        myCodes: {
+          HED: {
+            one: 'Duration/5 s',
+          },
+        },
+      },
+      '/dataset_description.json': { HEDVersion: 'one:two:8.0.0' },
+    }
+
+    return validateHed(events, jsonDictionary, jsonFiles, '').then((issues) => {
+      assert.strictEqual(issues.length, 1)
+      assert.strictEqual(issues[0].code, 104)
+    })
+  })
 })


### PR DESCRIPTION
Per a request from @VisLab, this PR adds test coverage to the three lines listed in https://github.com/bids-standard/bids-validator/pull/2014/files/aeee4c1cfd0c3ea5eced14c6b99f69abc89260df..b2024d91d7efb0a1cc183d8f4d1afb4e9fcb94a7 as not having test coverage. This is a follow-on from #2014.