### PR TITLE
fix(tsv): Check explicit formats for column contents when defined

### DIFF
--- a/bids-validator/src/schema/applyRules.test.ts
+++ b/bids-validator/src/schema/applyRules.test.ts
@@ -65,6 +65,7 @@ const schemaDefs = {
         MadeUp: {
           columns: {
             onset: 'required',
+            strain_rrid: 'optional',
           },
         },
       },
@@ -164,5 +165,21 @@ Deno.test('evalColumns tests', async (t) => {
     const rule = schemaDefs.rules.tabular_data.made_up.MadeUp
     evalColumns(rule, context, schema, 'rules.tabular_data.made_up.MadeUp')
     assert(context.issues.hasIssue({ key: 'TSV_VALUE_INCORRECT_TYPE' }))
+  })
+
+  await t.step('verify n/a is allowed', () => {
+    const context = {
+      path: '/sub-01/sub-01_something.tsv',
+      extension: '.tsv',
+      sidecar: {},
+      columns: {
+        onset: ['1', '2', 'n/a'],
+        strain_rrid: ['RRID:SCR_012345', 'RRID:SCR_012345', 'n/a'],
+      },
+      issues: new DatasetIssues(),
+    }
+    const rule = schemaDefs.rules.tabular_data.made_up.MadeUp
+    evalColumns(rule, context, schema, 'rules.tabular_data.made_up.MadeUp')
+    assert(context.issues.size === 0)
   })
 })

--- a/bids-validator/src/schema/applyRules.test.ts
+++ b/bids-validator/src/schema/applyRules.test.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import { assert, assertEquals, assertObjectMatch } from '../deps/asserts.ts'
 import { loadSchema } from '../setup/loadSchema.ts'
-import { applyRules, evalCheck } from './applyRules.ts'
+import { applyRules, evalCheck, evalColumns } from './applyRules.ts'
 import { DatasetIssues } from '../issues/datasetIssues.ts'
 
 const ruleContextData = [
@@ -42,6 +42,23 @@ const schemaDefs = {
             'associations.bval.n_cols == nifti_header.dim[4]',
             'associations.bvec.n_cols == nifti_header.dim[4]',
           ],
+        },
+      },
+    },
+    tabular_data: {
+      modality_agnostic: {
+        Scans: {
+          selectors: ['suffix == "scans"', 'extension == ".tsv"'],
+          initial_columns: ['filename'],
+          columns: {
+            filename: {
+              level: 'required',
+              description_addendum: 'There MUST be exactly one row for each file.',
+            },
+            acq_time__scans: 'optional',
+          },
+          index_columns: ['filename'],
+          additional_columns: 'allowed',
         },
       },
     },
@@ -107,3 +124,23 @@ Deno.test(
     assert(context.issues.hasIssue({ key: 'CHECK_ERROR' }))
   },
 )
+
+Deno.test('check column contents', async (t) => {
+  const schema = await loadSchema()
+
+  await t.step('check invalid datetime (scans.tsv:acq_time)', () => {
+    const context = {
+      path: '/sub-01/sub-01_scans.tsv',
+      extension: '.tsv',
+      sidecar: {},
+      columns: {
+        filename: ['func/sub-01_task-rest_bold.nii.gz'],
+        acq_time: ['1900-01-01T00:00:78'],
+      },
+      issues: new DatasetIssues(),
+    }
+    const rule = schemaDefs.rules.tabular_data.modality_agnostic.Scans
+    evalColumns(rule, context, schema, 'rules.tabular_data.modality_agnostic.Scans')
+    assert(context.issues.hasIssue({ key: 'TSV_VALUE_INCORRECT_TYPE_NONREQUIRED' }))
+  })
+})

--- a/bids-validator/src/schema/applyRules.test.ts
+++ b/bids-validator/src/schema/applyRules.test.ts
@@ -61,6 +61,13 @@ const schemaDefs = {
           additional_columns: 'allowed',
         },
       },
+      made_up: {
+        MadeUp: {
+          columns: {
+            onset: 'required',
+          },
+        },
+      },
     },
   },
 }
@@ -125,7 +132,7 @@ Deno.test(
   },
 )
 
-Deno.test('check column contents', async (t) => {
+Deno.test('evalColumns tests', async (t) => {
   const schema = await loadSchema()
 
   await t.step('check invalid datetime (scans.tsv:acq_time)', () => {
@@ -142,5 +149,20 @@ Deno.test('check column contents', async (t) => {
     const rule = schemaDefs.rules.tabular_data.modality_agnostic.Scans
     evalColumns(rule, context, schema, 'rules.tabular_data.modality_agnostic.Scans')
     assert(context.issues.hasIssue({ key: 'TSV_VALUE_INCORRECT_TYPE_NONREQUIRED' }))
+  })
+
+  await t.step('check formatless column', () => {
+    const context = {
+      path: '/sub-01/sub-01_something.tsv',
+      extension: '.tsv',
+      sidecar: {},
+      columns: {
+        onset: ['1', '2', 'not a number'],
+      },
+      issues: new DatasetIssues(),
+    }
+    const rule = schemaDefs.rules.tabular_data.made_up.MadeUp
+    evalColumns(rule, context, schema, 'rules.tabular_data.made_up.MadeUp')
+    assert(context.issues.hasIssue({ key: 'TSV_VALUE_INCORRECT_TYPE' }))
   })
 })

--- a/bids-validator/src/schema/applyRules.ts
+++ b/bids-validator/src/schema/applyRules.ts
@@ -212,7 +212,7 @@ function sidecarDefinedTypeCheck(
  * otherwise we type check each value in the column according to the type
  * specified in the schema rule (or sidecar type information if applicable).
  */
-function evalColumns(
+export function evalColumns(
   rule: GenericRule,
   context: BIDSContext,
   schema: GenericSchema,

--- a/bids-validator/src/schema/applyRules.ts
+++ b/bids-validator/src/schema/applyRules.ts
@@ -172,7 +172,11 @@ function schemaObjectTypeCheck(
     return schemaObject.enum.some((x) => x === value)
   }
   // @ts-expect-error
-  const format = schema.objects.formats[schemaObject.type]
+  const format = schemaObject.format
+    // @ts-expect-error
+    ? schema.objects.formats[schemaObject.format]
+    // @ts-expect-error
+    : schema.objects.formats[schemaObject.type]
   const re = new RegExp(`^${format.pattern}$`)
   return re.test(value)
 }


### PR DESCRIPTION
Resolves a discrepancy between legacy and schema validator. We had been previously validating the type of entries in columns, but not the stated formats, when present.

We now give preference to an explicit format over type checking.