### PR TITLE
fix(summary): Verify context.json is an object before looking up keys

### DIFF
--- a/bids-validator/src/summary/summary.ts
+++ b/bids-validator/src/summary/summary.ts
@@ -123,7 +123,7 @@ export class Summary {
     }
 
     if (context.extension === '.json') {
-      if ('TaskName' in context.json) {
+      if (typeof context.json === 'object' && 'TaskName' in context.json) {
         this.tasks.add(context.json.TaskName as string)
       }
     }


### PR DESCRIPTION
When a JSON file is empty (e.g., https://openneuro.org/datasets/ds003404/versions/1.0.0/file-display/sub-C39:fmap:sub-C39_dir-PA_run-1_epi.json), the `context.json` object does not get populated. Parsing JSON could also theoretically drop in any JSON data structure, so this checks that it is an object before trying to look up `TaskName`.