### PR TITLE
fix(context): Add file size to context, fixes README_FILE_SMALL

### DIFF
--- a/bids-validator/src/schema/context.ts
+++ b/bids-validator/src/schema/context.ts
@@ -107,6 +107,10 @@ export class BIDSContext implements Context {
     this.associations = {} as ContextAssociations
   }
 
+  get size(): number {
+    return this.file.size
+  }
+
   get path(): string {
     return this.file.path
   }

--- a/bids-validator/src/types/context.ts
+++ b/bids-validator/src/types/context.ts
@@ -91,6 +91,7 @@ export interface Context {
   dataset: ContextDataset
   subject: ContextSubject
   path: string
+  size: number
   entities: object
   datatype: string
   suffix: string


### PR DESCRIPTION
We were getting false positives on README_FILE_SMALL:

```
ReadmeFileSmall:
  issue:
    code: README_FILE_SMALL
    message: |
      The recommended file '/README' is very small.
      Please consider expanding it with additional information about the dataset.
    level: warning
  selectors:
    - match(path, '^/README')
  checks:
    - size > 150
```

Turns out size wasn't implemented, but the fix is quick.