### PR TITLE
fix(expr): Coerce arguments to min/max to numbers

### DIFF
--- a/bids-validator/src/schema/expressionLanguage.test.ts
+++ b/bids-validator/src/schema/expressionLanguage.test.ts
@@ -50,6 +50,12 @@ Deno.test('test expression functions', async (t) => {
     assert(min([3, 2, 1]) === 1)
     assert(min([]) === Infinity)
     // @ts-ignore
+    assert(min(["3", "2", "1"]) === 1)
+    // @ts-ignore
+    assert(min(["3", "string", "1"]) === 1)
+    // @ts-ignore
+    assert(min(["3", "n/a", "1"]) === 1)
+    // @ts-ignore
     assert(min(null) === null)
   })
   await t.step('max function', () => {
@@ -57,6 +63,12 @@ Deno.test('test expression functions', async (t) => {
     assert(max([1, 2, 3]) === 3)
     assert(max([3, 2, 1]) === 3)
     assert(max([]) === -Infinity)
+    // @ts-ignore
+    assert(max(["3", "2", "1"]) === 3)
+    // @ts-ignore
+    assert(max(["3", "string", "1"]) === 3)
+    // @ts-ignore
+    assert(max(["3", "n/a", "1"]) === 3)
     // @ts-ignore
     assert(max(null) === null)
   })

--- a/bids-validator/src/schema/expressionLanguage.ts
+++ b/bids-validator/src/schema/expressionLanguage.ts
@@ -62,10 +62,10 @@ export const expressionFunctions = {
     return typeof operand
   },
   min: (list: number[]): number | null => {
-    return list != null ? Math.min(...list.filter((x) => typeof x === 'number')) : null
+    return list != null ? Math.min(...list.map(Number).filter((x) => !isNaN(x))) : null
   },
   max: (list: number[]): number | null => {
-    return list != null ? Math.max(...list.filter((x) => typeof x === 'number')) : null
+    return list != null ? Math.max(...list.map(Number).filter((x) => !isNaN(x))) : null
   },
   length: <T>(list: T[]): number | null => {
     if (Array.isArray(list) || typeof list == 'string') {


### PR DESCRIPTION
`max(events.columns.onset)` was always `null`, because the column contains strings. Here we coerce values to numbers and filter nans, which gives us the behavior we want.