### PR TITLE
hack: Censor ".parent" fields which can lead to circular references

### DIFF
--- a/bids-validator/src/main.ts
+++ b/bids-validator/src/main.ts
@@ -19,6 +19,10 @@ export async function main(): Promise<ValidationResult> {
   if (options.json) {
     console.log(
       JSON.stringify(schemaResult, (key, value) => {
+        if (value?.parent) {
+          // Remove parent reference to avoid circular references
+          value.parent = undefined
+        }
         if (value instanceof Map) {
           return Array.from(value.values())
         } else {


### PR DESCRIPTION
I don't quite know why this shows up for some datasets and not others, but #2035 adding `.parent` to BIDSFile` results in references to `FileTree`s, which also have `.parent`s.

It's a hack, as it mutates the object in-place, but it's at the end of validation, so it seems fine. More elegant solutions are welcome.