### PR TITLE
fix(expr): Escape backslashes in checks before interpolating

### DIFF
--- a/bids-validator/src/schema/applyRules.test.ts
+++ b/bids-validator/src/schema/applyRules.test.ts
@@ -1,8 +1,9 @@
 // @ts-nocheck
 import { assert, assertEquals, assertObjectMatch } from '../deps/asserts.ts'
 import { loadSchema } from '../setup/loadSchema.ts'
-import { applyRules, evalCheck, evalColumns } from './applyRules.ts'
+import { applyRules, evalCheck, evalColumns, evalConstructor } from './applyRules.ts'
 import { DatasetIssues } from '../issues/datasetIssues.ts'
+import { expressionFunctions } from './expressionLanguage.ts'
 
 const ruleContextData = [
   {
@@ -181,5 +182,50 @@ Deno.test('evalColumns tests', async (t) => {
     const rule = schemaDefs.rules.tabular_data.made_up.MadeUp
     evalColumns(rule, context, schema, 'rules.tabular_data.made_up.MadeUp')
     assert(context.issues.size === 0)
+  })
+})
+
+Deno.test('evalConstructor test', async (t) => {
+  const match = expressionFunctions.match
+  await t.step('check veridical reconstruction of match expressions', () => {
+    // match() functions frequently contain escapes in regex patterns
+    // We receive these from the schema as written in YAML, so we need to ensure
+    // that they are correctly reconstructed in the evalConstructor() function
+    //
+    // The goal is to avoid schema authors needing to double-escape their regex patterns
+    // and other implementations to account for the double-escaping
+    let pattern = String.raw`^\.nii(\.gz)?$`
+
+    // Check both a literal and a variable pattern produce the same result
+    for (const check of ['match(extension, pattern)', `match(extension, '${pattern}')`]) {
+      const niftiCheck = evalConstructor(check)
+      for (
+        const [extension, expected] of [
+          ['.nii', true],
+          ['.nii.gz', true],
+          ['.tsv', false],
+          [',nii,gz', false], // Check that . is not treated as a wildcard
+        ]
+      ) {
+        assert(match(extension, pattern) === expected)
+        // Pass in a context object to provide any needed variables
+        assert(niftiCheck({ match, extension, pattern }) === expected)
+      }
+    }
+
+    pattern = String.raw`\S`
+    for (const check of ['match(json.Name, pattern)', `match(json.Name, '${pattern}')`]) {
+      const nonEmptyCheck = evalConstructor(check)
+      for (
+        const [Name, expected] of [
+          ['test', true],
+          ['', false],
+          [' ', false],
+        ]
+      ) {
+        assert(match(Name, pattern) === expected)
+        assert(nonEmptyCheck({ match, json: { Name }, pattern }) === expected)
+      }
+    }
   })
 })

--- a/bids-validator/src/schema/applyRules.ts
+++ b/bids-validator/src/schema/applyRules.ts
@@ -56,7 +56,7 @@ export function applyRules(
 }
 
 export const evalConstructor = (src: string): Function =>
-  new Function('context', `with (context) { return ${src} }`)
+  new Function('context', `with (context) { return ${src.replace(/\\/g, '\\\\')} }`)
 const safeHas = () => true
 const safeGet = (target: any, prop: any) => prop === Symbol.unscopables ? undefined : target[prop]
 

--- a/bids-validator/src/schema/applyRules.ts
+++ b/bids-validator/src/schema/applyRules.ts
@@ -55,7 +55,7 @@ export function applyRules(
   return Promise.resolve()
 }
 
-const evalConstructor = (src: string): Function =>
+export const evalConstructor = (src: string): Function =>
   new Function('context', `with (context) { return ${src} }`)
 const safeHas = () => true
 const safeGet = (target: any, prop: any) => prop === Symbol.unscopables ? undefined : target[prop]


### PR DESCRIPTION
Was testing https://github.com/bids-standard/bids-specification/pull/1879 and getting odd results. Turns out that our creating a function from strings can collapse escapes. This only appears to affect `match()` expressions right now.

Will work on a test.