### PR TITLE
fix(channels): Add needed fields to context.associations.channels

### DIFF
--- a/bids-validator/src/schema/associations.ts
+++ b/bids-validator/src/schema/associations.ts
@@ -111,8 +111,9 @@ const associationLookup = {
       const columns = parseTSV(contents)
       return {
         path: file.path,
-        type: columns.get('type') || [],
-        short_channel: columns.get('short_channel') || [],
+        type: columns.get('type'),
+        short_channel: columns.get('short_channel'),
+        sampling_frequency: columns.get('sampling_frequency'),
       }
     },
   },

--- a/bids-validator/src/types/context.ts
+++ b/bids-validator/src/types/context.ts
@@ -57,6 +57,7 @@ export interface ContextAssociationsChannels {
   path?: string
   type?: string[]
   short_channel?: string[]
+  sampling_frequency?: string[]
 }
 export interface ContextAssociationsCoordsystem {
   path: string


### PR DESCRIPTION
Partners with https://github.com/bids-standard/bids-specification/pull/1880 to provide the fields needed for the NIRS checks.

I got rid of the `|| []` guards. Undefined is the more intuitive representation of an absent column.