### PR TITLE
feat(tsv): Memoize TSV loading with a tiered cache, deleting after leaving a directory

### DIFF
--- a/bids-validator/src/files/browser.ts
+++ b/bids-validator/src/files/browser.ts
@@ -10,15 +10,16 @@ export class BIDSFileBrowser implements BIDSFile {
   #file: File
   name: string
   path: string
-  parent?: FileTree
+  parent: FileTree
 
-  constructor(file: File, ignore: FileIgnoreRules) {
+  constructor(file: File, ignore: FileIgnoreRules, parent?: FileTree) {
     this.#file = file
     this.#ignore = ignore
     this.name = file.name
     const relativePath = this.#file.webkitRelativePath
     const prefixLength = relativePath.indexOf('/')
     this.path = relativePath.substring(prefixLength)
+    this.parent = parent ?? new FileTree('', '/', undefined)
   }
 
   get size(): number {
@@ -49,11 +50,10 @@ export function fileListToTree(files: File[]): Promise<FileTree> {
   const ignore = new FileIgnoreRules([])
   const tree = new FileTree('', '/', undefined)
   for (const f of files) {
-    const file = new BIDSFileBrowser(f, ignore)
+    const file = new BIDSFileBrowser(f, ignore, tree) // Default to root
     const fPath = parse(file.path)
     if (fPath.dir === '/') {
       // Top level file
-      file.parent = tree
       tree.files.push(file)
     } else {
       const levels = fPath.dir.split(SEPARATOR_PATTERN).slice(1)

--- a/bids-validator/src/files/deno.ts
+++ b/bids-validator/src/files/deno.ts
@@ -23,11 +23,11 @@ export class BIDSFileDeno implements BIDSFile {
   #ignore: FileIgnoreRules
   name: string
   path: string
-  parent?: FileTree
+  parent: FileTree
   #fileInfo?: Deno.FileInfo
   #datasetAbsPath: string
 
-  constructor(datasetPath: string, path: string, ignore: FileIgnoreRules) {
+  constructor(datasetPath: string, path: string, ignore: FileIgnoreRules, parent?: FileTree) {
     this.#datasetAbsPath = datasetPath
     this.path = path
     this.name = basename(path)
@@ -39,6 +39,7 @@ export class BIDSFileDeno implements BIDSFile {
         this.#fileInfo = Deno.lstatSync(this._getPath())
       }
     }
+    this.parent = parent ?? new FileTree('', '/', undefined)
   }
 
   private _getPath(): string {

--- a/bids-validator/src/files/inheritance.ts
+++ b/bids-validator/src/files/inheritance.ts
@@ -12,7 +12,7 @@ export function* walkBack(
 
   targetSuffix = targetSuffix || sourceParts.suffix
 
-  let fileTree = source.parent
+  let fileTree: FileTree | undefined = source.parent
   while (fileTree) {
     const candidates = fileTree.files.filter((file) => {
       const { suffix, extension, entities } = readEntities(file.name)

--- a/bids-validator/src/files/tsv.ts
+++ b/bids-validator/src/files/tsv.ts
@@ -3,10 +3,19 @@
  * Module for parsing TSV
  */
 import { ColumnsMap } from '../types/columns.ts'
+import { BIDSFile } from '../types/filetree.ts'
+import { filememoizeAsync } from '../utils/memoize.ts'
+import type { WithCache } from '../utils/memoize.ts'
 
 const normalizeEOL = (str: string): string => str.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
 // Typescript resolved `row && !/^\s*$/.test(row)` as `string | boolean`
 const isContentfulRow = (row: string): boolean => !!(row && !/^\s*$/.test(row))
+
+async function _loadTSV(file: BIDSFile): Promise<ColumnsMap> {
+  return await file.text().then(parseTSV)
+}
+
+export const loadTSV = filememoizeAsync(_loadTSV)
 
 export function parseTSV(contents: string) {
   const columns = new ColumnsMap()

--- a/bids-validator/src/issues/datasetIssues.test.ts
+++ b/bids-validator/src/issues/datasetIssues.test.ts
@@ -1,5 +1,5 @@
 import { assertEquals, assertObjectMatch } from '../deps/asserts.ts'
-import { BIDSFile } from '../types/filetree.ts'
+import { BIDSFile, FileTree } from '../types/filetree.ts'
 import { IssueFile } from '../types/issues.ts'
 import { DatasetIssues } from './datasetIssues.ts'
 
@@ -17,6 +17,7 @@ Deno.test('DatasetIssues management class', async (t) => {
     const issues = new DatasetIssues()
     const testStream = new ReadableStream()
     const text = () => Promise.resolve('')
+    const root = new FileTree('', '/', undefined)
     const files = [
       {
         text,
@@ -25,6 +26,7 @@ Deno.test('DatasetIssues management class', async (t) => {
         size: 500,
         ignored: false,
         stream: testStream,
+        parent: root,
       } as BIDSFile,
       {
         text,
@@ -37,6 +39,7 @@ Deno.test('DatasetIssues management class', async (t) => {
         character: 5,
         severity: 'warning',
         reason: 'Readme borked',
+        parent: root,
       } as IssueFile,
     ]
     issues.add({ key: 'TEST_FILES_ERROR', reason: 'Test issue', files })

--- a/bids-validator/src/schema/associations.ts
+++ b/bids-validator/src/schema/associations.ts
@@ -2,7 +2,7 @@ import { ContextAssociations, ContextAssociationsEvents } from '../types/context
 import { BIDSFile, FileTree } from '../types/filetree.ts'
 import { BIDSContext } from './context.ts'
 import { readEntities } from './entities.ts'
-import { parseTSV } from '../files/tsv.ts'
+import { loadTSV } from '../files/tsv.ts'
 import { parseBvalBvec } from '../files/dwi.ts'
 import { walkBack } from '../files/inheritance.ts'
 
@@ -25,8 +25,10 @@ const associationLookup = {
     extensions: ['.tsv'],
     inherit: true,
     load: async (file: BIDSFile): Promise<ContextAssociations['events']> => {
-      const text = await file.text()
-      const columns = parseTSV(text)
+      const columns = await loadTSV(file)
+        .catch((e) => {
+          return new Map()
+        })
       return {
         path: file.path,
         onset: columns.get('onset') || [],
@@ -40,8 +42,10 @@ const associationLookup = {
     load: async (
       file: BIDSFile,
     ): Promise<ContextAssociations['aslcontext']> => {
-      const contents = await file.text()
-      const columns = parseTSV(contents)
+      const columns = await loadTSV(file)
+        .catch((e) => {
+          return new Map()
+        })
       return {
         path: file.path,
         n_rows: columns.get('volume_type')?.length || 0,
@@ -107,8 +111,10 @@ const associationLookup = {
     extensions: ['.tsv'],
     inherit: true,
     load: async (file: BIDSFile): Promise<ContextAssociations['channels']> => {
-      const contents = await file.text()
-      const columns = parseTSV(contents)
+      const columns = await loadTSV(file)
+        .catch((e) => {
+          return new Map()
+        })
       return {
         path: file.path,
         type: columns.get('type') || [],

--- a/bids-validator/src/schema/walk.ts
+++ b/bids-validator/src/schema/walk.ts
@@ -1,6 +1,7 @@
 import { BIDSContext, BIDSContextDataset } from './context.ts'
 import { FileTree } from '../types/filetree.ts'
 import { DatasetIssues } from '../issues/datasetIssues.ts'
+import { loadTSV } from '../files/tsv.ts'
 
 /** Recursive algorithm for visiting each file in the dataset, creating a context */
 export async function* _walkFileTree(
@@ -15,6 +16,7 @@ export async function* _walkFileTree(
   for (const dir of fileTree.directories) {
     yield* _walkFileTree(dir, root, issues, dsContext)
   }
+  loadTSV.cache.delete(fileTree.path)
 }
 
 /** Walk all files in the dataset and construct a context for each one */

--- a/bids-validator/src/types/filetree.ts
+++ b/bids-validator/src/types/filetree.ts
@@ -16,7 +16,7 @@ export interface BIDSFile {
   text: () => Promise<string>
   // Read a range of bytes
   readBytes: (size: number, offset?: number) => Promise<Uint8Array>
-  parent?: FileTree
+  parent: FileTree
 }
 
 export class FileTree {

--- a/bids-validator/src/utils/memoize.ts
+++ b/bids-validator/src/utils/memoize.ts
@@ -1,9 +1,35 @@
+export type WithCache<T> = T & { cache: Map<string, any> }
+interface HasParent {
+  parent: { path: string }
+}
+
 export const memoize = <T>(
   fn: (...args: any[]) => T,
-): (...args: any[]) => T => {
+): WithCache<(...args: any[]) => T> => {
   const cache = new Map()
   const cached = function (this: any, val: T) {
     return cache.has(val) ? cache.get(val) : cache.set(val, fn.call(this, val)) && cache.get(val)
+  }
+  cached.cache = cache
+  return cached
+}
+
+export function filememoizeAsync<F extends HasParent, T>(
+  fn: (file: F) => Promise<T>,
+): WithCache<(file: F) => Promise<T>> {
+  const cache = new Map<string, Map<F, T>>()
+  const cached = async function (this: any, file: F): Promise<T> {
+    let subcache = cache.get(file.parent.path)
+    if (!subcache) {
+      subcache = new Map()
+      cache.set(file.parent.path, subcache)
+    }
+    let val = subcache.get(file)
+    if (!val) {
+      val = await fn.call(this, file)
+      subcache.set(file, val)
+    }
+    return val
   }
   cached.cache = cache
   return cached


### PR DESCRIPTION
This reduces the runtime of ds004395 from 3m49s to 2m28s, while having negligible memory impact.

In contrast, a naive memoize that never clears hits process limits in ~30s.

Doing the same with JSON does not produce a measurable reduction (actually 2m43s, so it's an increase, but could be within error bars).

The main other things we parse are bvals/bvecs and NIFTI headers. Caching headers could be a good idea, but will need to test with a large, fully downloaded dataset.

Closes #2044.