### PR TITLE
fix(bvec): Improve empty row detection, stop preemptive numeric conversion

### DIFF
--- a/bids-validator/src/files/dwi.ts
+++ b/bids-validator/src/files/dwi.ts
@@ -4,18 +4,13 @@
  */
 const normalizeEOL = (str: string): string => str.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
 
-export function parseBvalBvec(contents: string): number[][] {
+export function parseBvalBvec(contents: string): string[][] {
   // BVEC files are a matrix of numbers, with each row being
   // a different axis
   // BVAL files are a single row of numbers, and may contain
   // trailing whitespace
   return normalizeEOL(contents)
-    .split(/\s*\n/)
-    .filter((x) => x !== '')
-    .map((row) =>
-      row
-        .split(/\s+/)
-        .filter((x) => x !== '')
-        .map((x) => Number(x))
-    )
+    .split(/\s*\n/) // Split on newlines, ignoring trailing whitespace
+    .filter((x) => x.match(/\S/)) // Remove empty lines
+    .map((row) => row.split(/\s+/))
 }

--- a/bids-validator/src/schema/context.ts
+++ b/bids-validator/src/schema/context.ts
@@ -180,7 +180,7 @@ export class BIDSContext implements Context {
   }
 
   async loadAssociations(): Promise<void> {
-    this.associations = await buildAssociations(this.file)
+    this.associations = await buildAssociations(this.file, this.issues)
     return
   }
 

--- a/bids-validator/src/types/context.ts
+++ b/bids-validator/src/types/context.ts
@@ -46,7 +46,7 @@ export interface ContextAssociationsBval {
   path: string
   n_cols: number
   n_rows: number
-  values: number[]
+  values: string[] // Actually numbers, but only used in functions that convert
 }
 export interface ContextAssociationsBvec {
   path: string


### PR DESCRIPTION
While I'm here, also covering `BVEC_ROW_LENGTH`.

Closes #2049.