### PR TITLE
feat: I/O checks for NIfTI and JSON files

### DIFF
--- a/bids-validator/src/files/json.test.ts
+++ b/bids-validator/src/files/json.test.ts
@@ -1,0 +1,64 @@
+import { assert, assertObjectMatch } from '../deps/asserts.ts'
+import { BIDSFileDeno, UnicodeDecodeError } from './deno.ts'
+import { BIDSFile } from '../types/filetree.ts'
+import { FileIgnoreRules } from './ignore.ts'
+
+import { loadJSON } from './json.ts'
+
+function encodeUTF16(text: string) {
+  // Adapted from https://developer.chrome.com/blog/how-to-convert-arraybuffer-to-and-from-string
+
+  // Ensure BOM is present
+  text = text.charCodeAt(0) === 0xFEFF ? text : '\uFEFF' + text
+  const buffer = new ArrayBuffer(text.length * 2)
+  const view = new Uint16Array(buffer)
+  for (let i = 0, strLen = text.length; i < strLen; i++) {
+    view[i] = text.charCodeAt(i)
+  }
+  return buffer
+}
+
+function makeFile(text: string, encoding: string): BIDSFile {
+  const bytes = encoding === 'utf-8' ? new TextEncoder().encode(text) : encodeUTF16(text)
+  return {
+    readBytes: async (size: number) => {
+      return new Uint8Array(bytes)
+    },
+    size: bytes.byteLength,
+  } as unknown as BIDSFile
+}
+
+Deno.test('Test JSON error conditions', async (t) => {
+  await t.step('Load valid JSON', async () => {
+    const JSONfile = makeFile('{"a": 1}', 'utf-8')
+    const result = await loadJSON(JSONfile)
+    assertObjectMatch(result, { a: 1 })
+  })
+
+  await t.step('Error on BOM', async () => {
+    const BOMfile = makeFile('\uFEFF{"a": 1}', 'utf-8')
+    let error: any = undefined
+    await loadJSON(BOMfile).catch((e) => {
+      error = e
+    })
+    assertObjectMatch(error, { key: 'INVALID_JSON_ENCODING' })
+  })
+
+  await t.step('Error on UTF-16', async () => {
+    const UTF16file = makeFile('{"a": 1}', 'utf-16')
+    let error: any = undefined
+    await loadJSON(UTF16file).catch((e) => {
+      error = e
+    })
+    assertObjectMatch(error, { key: 'INVALID_JSON_ENCODING' })
+  })
+
+  await t.step('Error on invalid JSON syntax', async () => {
+    const badJSON = makeFile('{"a": 1]', 'utf-8')
+    let error: any = undefined
+    await loadJSON(badJSON).catch((e) => {
+      error = e
+    })
+    assertObjectMatch(error, { key: 'JSON_INVALID' })
+  })
+})

--- a/bids-validator/src/files/json.ts
+++ b/bids-validator/src/files/json.ts
@@ -1,18 +1,30 @@
 import { BIDSFile } from '../types/filetree.ts'
 
-export async function loadJSON(file: BIDSFile): Promise<Record<string, unknown>> {
-  // Parse JSON more strictly than other files
-  // Do not replace invalid UTF-8 characters or strip the byte order mark (BOM)
-  const text = await file.text({ fatal: true, ignoreBOM: true }).catch((error) => {
+async function readJSONText(file: BIDSFile): Promise<string> {
+  // Read JSON text from a file
+  // JSON must be encoded in UTF-8 without a byte order mark (BOM)
+  const decoder = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true })
+  // Streaming TextDecoders are buggy in Deno and Chrome, so read the
+  // entire file into memory before decoding and parsing
+  const data = await file.readBytes(file.size)
+  try {
+    const text = decoder.decode(data)
+    if (text.startsWith('\uFEFF')) {
+      throw {}
+    }
+    return text
+  } catch (error) {
     throw { key: 'INVALID_JSON_ENCODING' }
-  })
-  // A BOM would cause a syntax error in JSON.parse, but we treat it as an encoding error
-  if (text.match(/^\uFEFF/)) {
-    throw { key: 'INVALID_JSON_ENCODING' }
+  } finally {
+    decoder.decode() // Reset decoder
   }
+}
+
+export async function loadJSON(file: BIDSFile): Promise<Record<string, unknown>> {
+  const text = await readJSONText(file) // Raise encoding errors
   try {
     return JSON.parse(text)
   } catch (error) {
-    throw { key: 'JSON_INVALID' }
+    throw { key: 'JSON_INVALID' } // Raise syntax errors
   }
 }

--- a/bids-validator/src/files/json.ts
+++ b/bids-validator/src/files/json.ts
@@ -4,15 +4,15 @@ export async function loadJSON(file: BIDSFile): Promise<Record<string, unknown>>
   // Parse JSON more strictly than other files
   // Do not replace invalid UTF-8 characters or strip the byte order mark (BOM)
   const text = await file.text({ fatal: true, ignoreBOM: true }).catch((error) => {
-    throw { 'key': 'INVALID_JSON_ENCODING' }
+    throw { key: 'INVALID_JSON_ENCODING' }
   })
   // A BOM would cause a syntax error in JSON.parse, but we treat it as an encoding error
   if (text.match(/^\uFEFF/)) {
-    throw { 'key': 'INVALID_JSON_ENCODING' }
+    throw { key: 'INVALID_JSON_ENCODING' }
   }
   try {
     return JSON.parse(text)
   } catch (error) {
-    throw { 'key': 'JSON_INVALID' }
+    throw { key: 'JSON_INVALID' }
   }
 }

--- a/bids-validator/src/files/json.ts
+++ b/bids-validator/src/files/json.ts
@@ -1,0 +1,18 @@
+import { BIDSFile } from '../types/filetree.ts'
+
+export async function loadJSON(file: BIDSFile): Promise<Record<string, unknown>> {
+  // Parse JSON more strictly than other files
+  // Do not replace invalid UTF-8 characters or strip the byte order mark (BOM)
+  const text = await file.text({ fatal: true, ignoreBOM: true }).catch((error) => {
+    throw { 'key': 'INVALID_JSON_ENCODING' }
+  })
+  // A BOM would cause a syntax error in JSON.parse, but we treat it as an encoding error
+  if (text.match(/^\uFEFF/)) {
+    throw { 'key': 'INVALID_JSON_ENCODING' }
+  }
+  try {
+    return JSON.parse(text)
+  } catch (error) {
+    throw { 'key': 'JSON_INVALID' }
+  }
+}

--- a/bids-validator/src/files/nifti.test.ts
+++ b/bids-validator/src/files/nifti.test.ts
@@ -6,14 +6,43 @@ import { loadHeader } from './nifti.ts'
 
 Deno.test('Test loading nifti header', async (t) => {
   const ignore = new FileIgnoreRules([])
-  await t.step('Load header from compressed file', async () => {
+
+  await t.step('Load header from compressed 3D file', async () => {
+    const path = 'sub-01/anat/sub-01_T1w.nii.gz'
+    const root = './tests/data/valid_headers'
+    const file = new BIDSFileDeno(root, path, ignore)
+    const header = await loadHeader(file)
+    assert(header !== undefined)
+    assertObjectMatch(header, {
+      dim: [3, 40, 48, 48, 1, 1, 1, 1],
+      shape: [40, 48, 48],
+      dim_info: { freq: 0, phase: 0, slice: 0 },
+      xyzt_units: { xyz: 'mm', t: 'sec' },
+      qform_code: 1,
+      sform_code: 1,
+    })
+    // Annoying floating point precision, skipping pixdim details
+    assert(header.voxel_sizes.length === 3)
+  })
+
+  await t.step('Load header from compressed 4D file', async () => {
     const path = 'sub-01/func/sub-01_task-rhymejudgment_bold.nii.gz'
     const root = './tests/data/valid_headers'
     const file = new BIDSFileDeno(root, path, ignore)
     const header = await loadHeader(file)
     assert(header !== undefined)
-    assert(header['pixdim'].length === 8)
+    assertObjectMatch(header, {
+      dim: [4, 16, 16, 9, 20, 1, 1, 1],
+      pixdim: [0, 12.5, 12.5, 16, 1, 0, 0, 0],
+      shape: [16, 16, 9, 20],
+      voxel_sizes: [12.5, 12.5, 16, 1],
+      dim_info: { freq: 0, phase: 0, slice: 0 },
+      xyzt_units: { xyz: 'mm', t: 'sec' },
+      qform_code: 0,
+      sform_code: 0,
+    })
   })
+
   await t.step('Fail on non-nifti file', async () => {
     const path = 'sub-01/func/sub-01_task-rhymejudgment_events.tsv'
     const root = './tests/data/valid_headers'

--- a/bids-validator/src/files/nifti.test.ts
+++ b/bids-validator/src/files/nifti.test.ts
@@ -1,4 +1,4 @@
-import { assert } from '../deps/asserts.ts'
+import { assert, assertObjectMatch } from '../deps/asserts.ts'
 import { FileIgnoreRules } from './ignore.ts'
 import { BIDSFileDeno } from './deno.ts'
 
@@ -18,8 +18,10 @@ Deno.test('Test loading nifti header', async (t) => {
     const path = 'sub-01/func/sub-01_task-rhymejudgment_events.tsv'
     const root = './tests/data/valid_headers'
     const file = new BIDSFileDeno(root, path, ignore)
-    const header = await loadHeader(file)
-    assert(header !== undefined)
-    assert(header === null)
+    let error: any = undefined
+    const header = await loadHeader(file).catch((e) => {
+      error = e
+    })
+    assertObjectMatch(error, { key: 'NIFTI_HEADER_UNREADABLE' })
   })
 })

--- a/bids-validator/src/issues/list.ts
+++ b/bids-validator/src/issues/list.ts
@@ -107,6 +107,11 @@ export const bidsIssues: IssueDefinitionRecord = {
     reason:
       'A column required in a TSV file has been redefined in a sidecar file. This redefinition is being ignored.',
   },
+  NIFTI_HEADER_UNREADABLE: {
+    severity: 'error',
+    reason:
+      'We were unable to parse header data from this NIfTI file. Please ensure it is not corrupted or mislabeled.',
+  },
   CHECK_ERROR: {
     severity: 'error',
     reason: 'generic place holder for errors from failed `checks` evaluated from schema.',

--- a/bids-validator/src/issues/list.ts
+++ b/bids-validator/src/issues/list.ts
@@ -1,6 +1,14 @@
 import { IssueDefinitionRecord } from '../types/issues.ts'
 
 export const bidsIssues: IssueDefinitionRecord = {
+  INVALID_JSON_ENCODING: {
+    severity: 'error',
+    reason: 'JSON files must be valid UTF-8 encoded text.',
+  },
+  JSON_INVALID: {
+    severity: 'error',
+    reason: 'Not a valid JSON file.',
+  },
   MISSING_DATASET_DESCRIPTION: {
     severity: 'error',
     reason: 'A dataset_description.json file is required in the root of the dataset',

--- a/bids-validator/src/schema/context.test.ts
+++ b/bids-validator/src/schema/context.test.ts
@@ -1,4 +1,4 @@
-import { assert } from '../deps/asserts.ts'
+import { assert, assertObjectMatch } from '../deps/asserts.ts'
 import { DatasetIssues } from '../issues/datasetIssues.ts'
 import { BIDSContext } from './context.ts'
 import { dataFile, rootFileTree } from './fixtures.test.ts'
@@ -8,14 +8,18 @@ Deno.test('test context LoadSidecar', async (t) => {
   await context.loadSidecar()
   await t.step('sidecar overwrites correct fields', () => {
     const { rootOverwrite, subOverwrite } = context.sidecar
-    assert(rootOverwrite === 'anat')
-    assert(subOverwrite === 'anat')
+    assertObjectMatch(context.sidecar, {
+      rootOverwrite: 'anat',
+      subOverwrite: 'anat',
+    })
   })
   await t.step('sidecar adds new fields at each level', () => {
     const { rootValue, subValue, anatValue } = context.sidecar
-    assert(rootValue === 'root')
-    assert(subValue === 'subject')
-    assert(anatValue === 'anat')
+    assertObjectMatch(context.sidecar, {
+      rootValue: 'root',
+      subValue: 'subject',
+      anatValue: 'anat',
+    })
   })
 })
 

--- a/bids-validator/src/schema/context.ts
+++ b/bids-validator/src/schema/context.ts
@@ -12,6 +12,7 @@ import { readEntities } from './entities.ts'
 import { DatasetIssues } from '../issues/datasetIssues.ts'
 import { walkBack } from '../files/inheritance.ts'
 import { loadTSV } from '../files/tsv.ts'
+import { loadJSON } from '../files/json.ts'
 import { loadHeader } from '../files/nifti.ts'
 import { buildAssociations } from './associations.ts'
 import { ValidatorOptions } from '../setup/options.ts'
@@ -139,10 +140,10 @@ export class BIDSContext implements Context {
     }
     const sidecars = walkBack(this.file)
     for (const file of sidecars) {
-      const json = await file
-        .text()
-        .then((text) => JSON.parse(text))
-        .catch((error) => {})
+      const json = await loadJSON(file).catch((error) => {
+        this.issues.addNonSchemaIssue(error.key, [file])
+        return {}
+      })
       this.sidecar = { ...json, ...this.sidecar }
       Object.keys(json).map((x) => this.sidecarKeyOrigin[x] ??= file.path)
     }
@@ -186,10 +187,10 @@ export class BIDSContext implements Context {
     if (this.extension !== '.json') {
       return
     }
-    this.json = await this.file
-      .text()
-      .then((text) => JSON.parse(text))
-      .catch((error) => {})
+    this.json = await loadJSON(this.file).catch((error) => {
+      this.issues.addNonSchemaIssue(error.key, [this.file])
+      return {}
+    })
   }
 
   // This is currently done for every file. It should be done once for the dataset.

--- a/bids-validator/src/schema/context.ts
+++ b/bids-validator/src/schema/context.ts
@@ -151,12 +151,13 @@ export class BIDSContext implements Context {
 
   async loadNiftiHeader(): Promise<void> {
     if (
-      this.extension.startsWith('.nii') &&
-      this.dataset.options &&
-      !this.dataset.options.ignoreNiftiHeaders
-    ) {
-      this.nifti_header = await loadHeader(this.file)
-    }
+      !this.extension.startsWith('.nii') || this.dataset?.options?.ignoreNiftiHeaders
+    ) return
+
+    this.nifti_header = await loadHeader(this.file).catch((error) => {
+      this.issues.addNonSchemaIssue(error.key, [this.file])
+      return undefined
+    })
   }
 
   async loadColumns(): Promise<void> {

--- a/bids-validator/src/schema/fixtures.test.ts
+++ b/bids-validator/src/schema/fixtures.test.ts
@@ -52,7 +52,7 @@ anatFileTree.files = [
     size: 311112,
     ignored: false,
     stream: new ReadableStream<Uint8Array>(),
-    readBytes: nullReadBytes,
+    readBytes: async (size: number) => new TextEncoder().encode(await anatJson()),
     parent: anatFileTree,
   },
 ]
@@ -68,7 +68,7 @@ subjectFileTree.files = [
     size: 311112,
     ignored: false,
     stream: new ReadableStream<Uint8Array>(),
-    readBytes: nullReadBytes,
+    readBytes: async (size: number) => new TextEncoder().encode(await subjectJson()),
     parent: subjectFileTree,
   },
 ]
@@ -95,7 +95,7 @@ rootFileTree.files = [
     size: 311112,
     ignored: false,
     stream: new ReadableStream<Uint8Array>(),
-    readBytes: nullReadBytes,
+    readBytes: async (size: number) => new TextEncoder().encode(await rootJson()),
     parent: rootFileTree,
   },
 ]

--- a/bids-validator/src/types/context.ts
+++ b/bids-validator/src/types/context.ts
@@ -86,6 +86,8 @@ export interface ContextNiftiHeader {
   dim_info: ContextNiftiHeaderDimInfo
   dim: number[]
   pixdim: number[]
+  shape: number[]
+  voxel_sizes: number[]
   xyzt_units: ContextNiftiHeaderXyztUnits
   qform_code: number
   sform_code: number

--- a/bids-validator/src/validators/bids.ts
+++ b/bids-validator/src/validators/bids.ts
@@ -1,5 +1,6 @@
 import { ContextCheckFunction, DSCheckFunction } from '../types/check.ts'
 import { BIDSFile, FileTree } from '../types/filetree.ts'
+import { loadJSON } from '../files/json.ts'
 import { IssueFile } from '../types/issues.ts'
 import { GenericSchema } from '../types/schema.ts'
 import { ValidationResult } from '../types/validation-result.ts'
@@ -50,7 +51,10 @@ export async function validate(
 
   let dsContext
   if (ddFile) {
-    const description = await ddFile.text().then((text) => JSON.parse(text))
+    const description = await loadJSON(ddFile).catch((error) => {
+      issues.addNonSchemaIssue(error.key, [ddFile])
+      return {} as Record<string, unknown>
+    })
     summary.dataProcessed = description.DatasetType === 'derivative'
     dsContext = new BIDSContextDataset(options, description)
   } else {


### PR DESCRIPTION
This implements standard issues:

* INVALID_JSON_ENCODING
* JSON_INVALID
* NIFTI_HEADER_UNREADABLE

Because `BIDSFile.text()` is intended to mimic the behavior of `File.text()` and replace unknown characters, it's unsuited to validating JSON, which needs to be actual UTF-8. Further, piping `BIDSFile.stream` through a `TextDecoderStream` can reliably cause resource leaks on UTF16 data (https://github.com/denoland/deno/issues/24872). Therefore I've reimplemented reading with `readBytes()` followed by an all-at-once decoding, which seems to be safer.

~~The main bit of interest is in passing options to `TextDecoderStream` to ensure we catch bad unicode. This creates a divergence with the browser implementation, so we would need to decide what the best API is. I could switch to using `file.stream` directly.~~

~~There appears to be a bug in `TextDecoderStream` (https://github.com/denoland/deno/issues/24872) that prevents us cleaning up properly. So the subtests all pass, but the whole JSON UTF-16 test fails due to a detected leak.~~