### PR TITLE
Bump hed-validator to v3.15.4

### DIFF
--- a/bids-validator/package.json
+++ b/bids-validator/package.json
@@ -45,7 +45,7 @@
     "date-fns": "^3.6.0",
     "events": "^3.3.0",
     "exifreader": "^4.23.3",
-    "hed-validator": "^3.15.3",
+    "hed-validator": "^3.15.4",
     "ignore": "^5.3.1",
     "is-utf8": "^0.2.1",
     "jest": "^29.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "date-fns": "^3.6.0",
         "events": "^3.3.0",
         "exifreader": "^4.23.3",
-        "hed-validator": "^3.15.3",
+        "hed-validator": "^3.15.4",
         "ignore": "^5.3.1",
         "is-utf8": "^0.2.1",
         "jest": "^29.7.0",
@@ -10805,9 +10805,9 @@
       }
     },
     "node_modules/hed-validator": {
-      "version": "3.15.3",
-      "resolved": "https://registry.npmjs.org/hed-validator/-/hed-validator-3.15.3.tgz",
-      "integrity": "sha512-+7/W9Wt+rb/V5xCvT11cHsYtGW8bUi206FYWzAQp6eF2TE3L7zdNyBBulOYR1sp9OeibHIHlb6yQ58lIFHgoWg==",
+      "version": "3.15.4",
+      "resolved": "https://registry.npmjs.org/hed-validator/-/hed-validator-3.15.4.tgz",
+      "integrity": "sha512-40Jbd5CQ3mShQtJKQyYUiNB8Ym4FrLq21zzaQ067Mxj/9ILSJanx+Pmab4G1vVBl45NPLU9wLFvo+5YDomzlWA==",
       "dependencies": {
         "buffer": "^6.0.3",
         "cross-fetch": "^4.0.0",
@@ -24478,7 +24478,7 @@
         "eslint-plugin-prettier": "^5.2.1",
         "events": "^3.3.0",
         "exifreader": "^4.23.3",
-        "hed-validator": "^3.15.3",
+        "hed-validator": "^3.15.4",
         "husky": "^9.1.1",
         "ignore": "^5.3.1",
         "is-utf8": "^0.2.1",
@@ -27079,9 +27079,9 @@
       }
     },
     "hed-validator": {
-      "version": "3.15.3",
-      "resolved": "https://registry.npmjs.org/hed-validator/-/hed-validator-3.15.3.tgz",
-      "integrity": "sha512-+7/W9Wt+rb/V5xCvT11cHsYtGW8bUi206FYWzAQp6eF2TE3L7zdNyBBulOYR1sp9OeibHIHlb6yQ58lIFHgoWg==",
+      "version": "3.15.4",
+      "resolved": "https://registry.npmjs.org/hed-validator/-/hed-validator-3.15.4.tgz",
+      "integrity": "sha512-40Jbd5CQ3mShQtJKQyYUiNB8Ym4FrLq21zzaQ067Mxj/9ILSJanx+Pmab4G1vVBl45NPLU9wLFvo+5YDomzlWA==",
       "requires": {
         "buffer": "^6.0.3",
         "cross-fetch": "^4.0.0",


### PR DESCRIPTION
This should provide the actual exception messages for the internal errors in #2059.