### PR TITLE
rf(context): Move file tree, schema, and issues into context.dataset

### DIFF
--- a/bids-validator/src/schema/applyRules.test.ts
+++ b/bids-validator/src/schema/applyRules.test.ts
@@ -101,7 +101,7 @@ Deno.test('evalCheck ensure expression language functions work', () => {
   const context = {
     x: [1, 2, 3, 4],
     y: [1, 1, 1, 1],
-    issues: new DatasetIssues(),
+    dataset: { issues: new DatasetIssues() },
   }
   const rule = [
     {
@@ -117,12 +117,12 @@ Deno.test('evalCheck ensure expression language functions work', () => {
     },
   ]
   applyRules(rule, context)
-  assert(!context.issues.hasIssue({ key: 'CHECK_ERROR' }))
+  assert(!context.dataset.issues.hasIssue({ key: 'CHECK_ERROR' }))
 })
 Deno.test(
   'evalCheck ensure expression language will fail appropriately',
   () => {
-    const context = { issues: new DatasetIssues() }
+    const context = { dataset: { issues: new DatasetIssues() } }
     const rule = [
       {
         selectors: ['true'],
@@ -130,7 +130,7 @@ Deno.test(
       },
     ]
     applyRules(rule, context)
-    assert(context.issues.hasIssue({ key: 'CHECK_ERROR' }))
+    assert(context.dataset.issues.hasIssue({ key: 'CHECK_ERROR' }))
   },
 )
 
@@ -146,11 +146,11 @@ Deno.test('evalColumns tests', async (t) => {
         filename: ['func/sub-01_task-rest_bold.nii.gz'],
         acq_time: ['1900-01-01T00:00:78'],
       },
-      issues: new DatasetIssues(),
+      dataset: { issues: new DatasetIssues() },
     }
     const rule = schemaDefs.rules.tabular_data.modality_agnostic.Scans
     evalColumns(rule, context, schema, 'rules.tabular_data.modality_agnostic.Scans')
-    assert(context.issues.hasIssue({ key: 'TSV_VALUE_INCORRECT_TYPE_NONREQUIRED' }))
+    assert(context.dataset.issues.hasIssue({ key: 'TSV_VALUE_INCORRECT_TYPE_NONREQUIRED' }))
   })
 
   await t.step('check formatless column', () => {
@@ -161,11 +161,11 @@ Deno.test('evalColumns tests', async (t) => {
       columns: {
         onset: ['1', '2', 'not a number'],
       },
-      issues: new DatasetIssues(),
+      dataset: { issues: new DatasetIssues() },
     }
     const rule = schemaDefs.rules.tabular_data.made_up.MadeUp
     evalColumns(rule, context, schema, 'rules.tabular_data.made_up.MadeUp')
-    assert(context.issues.hasIssue({ key: 'TSV_VALUE_INCORRECT_TYPE' }))
+    assert(context.dataset.issues.hasIssue({ key: 'TSV_VALUE_INCORRECT_TYPE' }))
   })
 
   await t.step('verify n/a is allowed', () => {
@@ -177,11 +177,11 @@ Deno.test('evalColumns tests', async (t) => {
         onset: ['1', '2', 'n/a'],
         strain_rrid: ['RRID:SCR_012345', 'RRID:SCR_012345', 'n/a'],
       },
-      issues: new DatasetIssues(),
+      dataset: { issues: new DatasetIssues() },
     }
     const rule = schemaDefs.rules.tabular_data.made_up.MadeUp
     evalColumns(rule, context, schema, 'rules.tabular_data.made_up.MadeUp')
-    assert(context.issues.size === 0)
+    assert(context.dataset.issues.size === 0)
   })
 })
 

--- a/bids-validator/src/schema/applyRules.ts
+++ b/bids-validator/src/schema/applyRules.ts
@@ -135,14 +135,14 @@ function evalRuleChecks(
 ): boolean {
   if (rule.checks && !mapEvalCheck(rule.checks, context)) {
     if (rule.issue?.code && rule.issue?.message) {
-      context.issues.add({
+      context.dataset.issues.add({
         key: rule.issue.code,
         reason: rule.issue.message,
         files: [{ ...context.file, evidence: schemaPath }],
         severity: rule.issue.level as Severity,
       })
     } else {
-      context.issues.addNonSchemaIssue('CHECK_ERROR', [
+      context.dataset.issues.addNonSchemaIssue('CHECK_ERROR', [
         { ...context.file, evidence: schemaPath },
       ])
     }
@@ -241,7 +241,7 @@ export function evalColumns(
     let errorObject = columnObject
 
     if (!headers.includes(name) && requirement === 'required') {
-      context.issues.addNonSchemaIssue('TSV_COLUMN_MISSING', [
+      context.dataset.issues.addNonSchemaIssue('TSV_COLUMN_MISSING', [
         {
           ...context.file,
           evidence: `Column with header ${name} listed as required. ${schemaPath}`,
@@ -267,7 +267,7 @@ export function evalColumns(
         typeCheck = (value) => sidecarDefinedTypeCheck(context.sidecar[name], value, schema)
         errorObject = context.sidecar[name]
       } else {
-        context.issues.addNonSchemaIssue('TSV_COLUMN_TYPE_REDEFINED', [{
+        context.dataset.issues.addNonSchemaIssue('TSV_COLUMN_TYPE_REDEFINED', [{
           ...context.file,
           evidence: `'${name}' redefined with sidecar ${inspect(context.sidecar[name])}`,
         }])
@@ -282,7 +282,7 @@ export function evalColumns(
       if (
         !typeCheck(value)
       ) {
-        context.issues.addNonSchemaIssue(error_code, [
+        context.dataset.issues.addNonSchemaIssue(error_code, [
           {
             ...context.file,
             evidence: `'${value}' ${inspect(columnObject)}`,
@@ -317,13 +317,13 @@ function evalInitialColumns(
     if (contextIndex === -1) {
       const evidence =
         `Column with header ${ruleHeaderName} not found, indexed from 0 it should appear in column ${ruleIndex}. ${schemaPath}`
-      context.issues.addNonSchemaIssue('TSV_COLUMN_MISSING', [
+      context.dataset.issues.addNonSchemaIssue('TSV_COLUMN_MISSING', [
         { ...context.file, evidence: evidence },
       ])
     } else if (ruleIndex !== contextIndex) {
       const evidence =
         `Column with header ${ruleHeaderName} found at index ${contextIndex} while rule specifies, indexed from 0, it should be in column ${ruleIndex}. ${schemaPath}`
-      context.issues.addNonSchemaIssue('TSV_COLUMN_ORDER_INCORRECT', [
+      context.dataset.issues.addNonSchemaIssue('TSV_COLUMN_ORDER_INCORRECT', [
         { ...context.file, evidence: evidence },
       ])
     }
@@ -351,7 +351,7 @@ function evalAdditionalColumns(
       extraCols = extraCols.filter((header) => !(header in context.sidecar))
     }
     if (extraCols.length) {
-      context.issues.addNonSchemaIssue('TSV_ADDITIONAL_COLUMNS_NOT_ALLOWED', [
+      context.dataset.issues.addNonSchemaIssue('TSV_ADDITIONAL_COLUMNS_NOT_ALLOWED', [
         { ...context.file, evidence: `Disallowed columns found ${extraCols}` },
       ])
     }
@@ -380,7 +380,7 @@ function evalIndexColumns(
   })
   const missing = index_columns.filter((col: string) => !headers.includes(col))
   if (missing.length) {
-    context.issues.addNonSchemaIssue('TSV_COLUMN_MISSING', [
+    context.dataset.issues.addNonSchemaIssue('TSV_COLUMN_MISSING', [
       {
         ...context.file,
         evidence: `Columns cited as index columns not in file: ${missing}. ${schemaPath}`,
@@ -397,7 +397,7 @@ function evalIndexColumns(
       )
     })
     if (uniqueIndexValues.has(indexValue)) {
-      context.issues.addNonSchemaIssue('TSV_INDEX_VALUE_NOT_UNIQUE', [
+      context.dataset.issues.addNonSchemaIssue('TSV_INDEX_VALUE_NOT_UNIQUE', [
         { ...context.file, evidence: `Row: ${i + 2}, Value: ${indexValue}` },
       ])
     } else {
@@ -431,14 +431,14 @@ function evalJsonCheck(
     const keyName: string = metadataDef.name
     if (severity && severity !== 'ignore' && !(keyName in json)) {
       if (requirement.issue?.code && requirement.issue?.message) {
-        context.issues.add({
+        context.dataset.issues.add({
           key: requirement.issue.code,
           reason: requirement.issue.message,
           severity,
           files: [{ ...context.file }],
         })
       } else if (severity === 'error') {
-        context.issues.addNonSchemaIssue(
+        context.dataset.issues.addNonSchemaIssue(
           sidecarRule ? 'SIDECAR_KEY_REQUIRED' : 'JSON_KEY_REQUIRED',
           [
             {
@@ -448,7 +448,7 @@ function evalJsonCheck(
           ],
         )
       } else if (severity === 'warning') {
-        context.issues.addNonSchemaIssue(
+        context.dataset.issues.addNonSchemaIssue(
           sidecarRule ? 'SIDECAR_KEY_RECOMMENDED' : 'JSON_KEY_RECOMMENDED',
           [
             {
@@ -485,7 +485,7 @@ function evalJsonCheck(
     if (result === false) {
       const evidenceBase = `Failed for this file.key: ${originFileKey} Schema path: ${schemaPath}`
       if (!validate.errors) {
-        context.issues.addNonSchemaIssue('JSON_SCHEMA_VALIDATION_ERROR', [
+        context.dataset.issues.addNonSchemaIssue('JSON_SCHEMA_VALIDATION_ERROR', [
           {
             ...context.file,
             evidence: evidenceBase,
@@ -494,7 +494,7 @@ function evalJsonCheck(
       } else {
         for (let error of validate.errors) {
           const message = 'message' in error ? `message: ${error['message']}` : ''
-          context.issues.addNonSchemaIssue('JSON_SCHEMA_VALIDATION_ERROR', [
+          context.dataset.issues.addNonSchemaIssue('JSON_SCHEMA_VALIDATION_ERROR', [
             {
               ...context.file,
               evidence: `${evidenceBase} ${message}`,

--- a/bids-validator/src/schema/context.test.ts
+++ b/bids-validator/src/schema/context.test.ts
@@ -4,7 +4,7 @@ import { BIDSContext } from './context.ts'
 import { dataFile, rootFileTree } from './fixtures.test.ts'
 
 Deno.test('test context LoadSidecar', async (t) => {
-  const context = new BIDSContext(rootFileTree, dataFile, new DatasetIssues())
+  const context = new BIDSContext(dataFile)
   await context.loadSidecar()
   await t.step('sidecar overwrites correct fields', () => {
     const { rootOverwrite, subOverwrite } = context.sidecar
@@ -24,7 +24,7 @@ Deno.test('test context LoadSidecar', async (t) => {
 })
 
 Deno.test('test context loadSubjects', async (t) => {
-  const context = new BIDSContext(rootFileTree, dataFile, new DatasetIssues())
+  const context = new BIDSContext(dataFile, undefined, rootFileTree)
   await context.loadSubjects()
   await t.step('context produces correct subjects object', () => {
     assert(context.dataset.subjects, 'subjects object exists')

--- a/bids-validator/src/schema/context.ts
+++ b/bids-validator/src/schema/context.ts
@@ -33,26 +33,19 @@ export class BIDSContextDataset implements ContextDataset {
   schema: Schema
 
   constructor(
-    options?: ValidatorOptions,
-    schema?: Schema,
-    tree?: FileTree,
-    description?: Record<string, unknown>,
-    ignored?: BIDSFile[],
-    datatypes?: string[],
-    modalities?: string[],
-    issues?: DatasetIssues,
+    args: Partial<BIDSContextDataset>
   ) {
-    this.schema = schema || {} as unknown as Schema
-    this.dataset_description = description || {}
-    this.tree = tree || new FileTree('/unknown', 'unknown')
-    this.ignored = ignored || []
-    this.datatypes = datatypes || []
-    this.modalities = modalities || []
+    this.schema = args.schema || {} as unknown as Schema
+    this.dataset_description = args.dataset_description || {}
+    this.tree = args.tree || new FileTree('/unknown', 'unknown')
+    this.ignored = args.ignored || []
+    this.datatypes = args.datatypes || []
+    this.modalities = args.modalities || []
     this.sidecarKeyValidated = new Set<string>()
-    if (options) {
-      this.options = options
+    if (args.options) {
+      this.options = args.options
     }
-    this.issues = issues || new DatasetIssues()
+    this.issues = args.issues || new DatasetIssues()
   }
 
   get dataset_description(): Record<string, unknown> {
@@ -118,7 +111,7 @@ export class BIDSContext implements Context {
     this.suffix = bidsEntities.suffix
     this.extension = bidsEntities.extension
     this.entities = bidsEntities.entities
-    this.dataset = dsContext ? dsContext : new BIDSContextDataset(undefined, undefined, fileTree)
+    this.dataset = dsContext ? dsContext : new BIDSContextDataset({tree: fileTree})
     this.subject = {} as ContextSubject
     this.datatype = ''
     this.modality = ''

--- a/bids-validator/src/schema/context.ts
+++ b/bids-validator/src/schema/context.ts
@@ -6,7 +6,7 @@ import {
   ContextNiftiHeader,
   ContextSubject,
 } from '../types/context.ts'
-import { GenericSchema } from '../types/schema.ts'
+import { Schema } from '../types/schema.ts'
 import { BIDSFile, FileTree } from '../types/filetree.ts'
 import { ColumnsMap } from '../types/columns.ts'
 import { readEntities } from './entities.ts'
@@ -30,9 +30,11 @@ export class BIDSContextDataset implements ContextDataset {
   issues: DatasetIssues
   sidecarKeyValidated: Set<string>
   options?: ValidatorOptions
+  schema: Schema
 
   constructor(
     options?: ValidatorOptions,
+    schema?: Schema,
     tree?: FileTree,
     description?: Record<string, unknown>,
     ignored?: BIDSFile[],
@@ -40,6 +42,7 @@ export class BIDSContextDataset implements ContextDataset {
     modalities?: string[],
     issues?: DatasetIssues,
   ) {
+    this.schema = schema || {} as unknown as Schema
     this.dataset_description = description || {}
     this.tree = tree || new FileTree('/unknown', 'unknown')
     this.ignored = ignored || []
@@ -82,7 +85,6 @@ export class BIDSContextDatasetSubjects implements ContextDatasetSubjects {
 }
 
 export class BIDSContext implements Context {
-  schema?: GenericSchema
   dataset: BIDSContextDataset
   subject: ContextSubject
   // path: string  <- getter
@@ -116,7 +118,7 @@ export class BIDSContext implements Context {
     this.suffix = bidsEntities.suffix
     this.extension = bidsEntities.extension
     this.entities = bidsEntities.entities
-    this.dataset = dsContext ? dsContext : new BIDSContextDataset(undefined, fileTree)
+    this.dataset = dsContext ? dsContext : new BIDSContextDataset(undefined, undefined, fileTree)
     this.subject = {} as ContextSubject
     this.datatype = ''
     this.modality = ''
@@ -125,6 +127,10 @@ export class BIDSContext implements Context {
     this.columns = new ColumnsMap()
     this.json = {}
     this.associations = {} as ContextAssociations
+  }
+
+  get schema(): Schema {
+    return this.dataset.schema
   }
 
   get size(): number {

--- a/bids-validator/src/schema/context.ts
+++ b/bids-validator/src/schema/context.ts
@@ -22,16 +22,16 @@ export class BIDSContextDataset implements ContextDataset {
   dataset_description: Record<string, unknown>
   options?: ValidatorOptions
   files: any[]
-  tree: object
+  tree: FileTree
   ignored: any[]
   modalities: any[]
   subjects?: ContextDatasetSubjects
   sidecarKeyValidated: Set<string>
 
-  constructor(options?: ValidatorOptions, description = {}) {
-    this.dataset_description = description
+  constructor(options?: ValidatorOptions, tree?: FileTree, description?: Record<string, unknown>) {
+    this.dataset_description = description || {}
     this.files = []
-    this.tree = {}
+    this.tree = tree || new FileTree('/unknown', 'unknown')
     this.ignored = []
     this.modalities = []
     this.sidecarKeyValidated = new Set<string>()

--- a/bids-validator/src/schema/context.ts
+++ b/bids-validator/src/schema/context.ts
@@ -20,7 +20,7 @@ import { ValidatorOptions } from '../setup/options.ts'
 import { logger } from '../utils/logger.ts'
 
 export class BIDSContextDataset implements ContextDataset {
-  dataset_description: Record<string, unknown>
+  #dataset_description: Record<string, unknown> = {}
   tree: FileTree
   ignored: BIDSFile[]
   datatypes: string[]
@@ -49,15 +49,19 @@ export class BIDSContextDataset implements ContextDataset {
     if (options) {
       this.options = options
     }
-    if (
-      !this.dataset_description.DatasetType &&
-      this.dataset_description.GeneratedBy
-    ) {
-      this.dataset_description.DatasetType = 'derivative'
-    } else if (!this.dataset_description.DatasetType) {
-      this.dataset_description.DatasetType = 'raw'
-    }
     this.issues = issues || new DatasetIssues()
+  }
+
+  get dataset_description(): Record<string, unknown> {
+    return this.#dataset_description
+  }
+  set dataset_description(value: Record<string, unknown>) {
+    this.#dataset_description = value
+    if (!this.dataset_description.DatasetType) {
+      this.dataset_description.DatasetType = this.dataset_description.GeneratedBy
+        ? 'derivative'
+        : 'raw'
+    }
   }
 }
 

--- a/bids-validator/src/schema/expressionLanguage.test.ts
+++ b/bids-validator/src/schema/expressionLanguage.test.ts
@@ -5,7 +5,7 @@ import { BIDSContext } from './context.ts'
 import { DatasetIssues } from '../issues/datasetIssues.ts'
 
 Deno.test('test expression functions', async (t) => {
-  const context = new BIDSContext(rootFileTree, dataFile, new DatasetIssues())
+  const context = new BIDSContext(dataFile, undefined, rootFileTree)
 
   await t.step('index function', () => {
     const index = expressionFunctions.index

--- a/bids-validator/src/schema/expressionLanguage.ts
+++ b/bids-validator/src/schema/expressionLanguage.ts
@@ -6,7 +6,7 @@ function exists(this: BIDSContext, list: string[], rule: string = 'dataset'): nu
   }
 
   const prefix: string[] = []
-  const fileTree = rule == 'file' ? this.file.parent : this.fileTree
+  const fileTree = rule == 'file' ? this.file.parent : this.dataset.tree
 
   // Stimuli and subject-relative paths get prefixes
   if (rule == 'stimuli') {

--- a/bids-validator/src/schema/walk.test.ts
+++ b/bids-validator/src/schema/walk.test.ts
@@ -6,7 +6,7 @@ import { simpleDataset, simpleDatasetFileCount } from '../tests/simple-dataset.t
 
 Deno.test('file tree walking', async (t) => {
   await t.step('visits each file and creates a BIDSContext', async () => {
-    const dsContext = new BIDSContextDataset(undefined, undefined, simpleDataset)
+    const dsContext = new BIDSContextDataset({tree: simpleDataset})
     for await (const context of walkFileTree(dsContext)) {
       assert(
         context instanceof BIDSContext,
@@ -15,7 +15,7 @@ Deno.test('file tree walking', async (t) => {
     }
   })
   await t.step('visits every file expected', async () => {
-    const dsContext = new BIDSContextDataset(undefined, undefined, simpleDataset)
+    const dsContext = new BIDSContextDataset({tree: simpleDataset})
     let accumulator = 0
     for await (const context of walkFileTree(dsContext)) {
       assert(

--- a/bids-validator/src/schema/walk.test.ts
+++ b/bids-validator/src/schema/walk.test.ts
@@ -1,13 +1,13 @@
 import { assert, assertEquals } from '../deps/asserts.ts'
-import { BIDSContext } from './context.ts'
+import { BIDSContext, BIDSContextDataset } from './context.ts'
 import { walkFileTree } from './walk.ts'
 import { DatasetIssues } from '../issues/datasetIssues.ts'
 import { simpleDataset, simpleDatasetFileCount } from '../tests/simple-dataset.ts'
 
 Deno.test('file tree walking', async (t) => {
   await t.step('visits each file and creates a BIDSContext', async () => {
-    const issues = new DatasetIssues()
-    for await (const context of walkFileTree(simpleDataset, issues)) {
+    const dsContext = new BIDSContextDataset(undefined, simpleDataset)
+    for await (const context of walkFileTree(dsContext)) {
       assert(
         context instanceof BIDSContext,
         'walk file tree did not return a BIDSContext',
@@ -15,9 +15,9 @@ Deno.test('file tree walking', async (t) => {
     }
   })
   await t.step('visits every file expected', async () => {
-    const issues = new DatasetIssues()
+    const dsContext = new BIDSContextDataset(undefined, simpleDataset)
     let accumulator = 0
-    for await (const context of walkFileTree(simpleDataset, issues)) {
+    for await (const context of walkFileTree(dsContext)) {
       assert(
         context instanceof BIDSContext,
         'walk file tree did not return a BIDSContext',

--- a/bids-validator/src/schema/walk.test.ts
+++ b/bids-validator/src/schema/walk.test.ts
@@ -6,7 +6,7 @@ import { simpleDataset, simpleDatasetFileCount } from '../tests/simple-dataset.t
 
 Deno.test('file tree walking', async (t) => {
   await t.step('visits each file and creates a BIDSContext', async () => {
-    const dsContext = new BIDSContextDataset(undefined, simpleDataset)
+    const dsContext = new BIDSContextDataset(undefined, undefined, simpleDataset)
     for await (const context of walkFileTree(dsContext)) {
       assert(
         context instanceof BIDSContext,
@@ -15,7 +15,7 @@ Deno.test('file tree walking', async (t) => {
     }
   })
   await t.step('visits every file expected', async () => {
-    const dsContext = new BIDSContextDataset(undefined, simpleDataset)
+    const dsContext = new BIDSContextDataset(undefined, undefined, simpleDataset)
     let accumulator = 0
     for await (const context of walkFileTree(dsContext)) {
       assert(

--- a/bids-validator/src/schema/walk.ts
+++ b/bids-validator/src/schema/walk.ts
@@ -11,7 +11,7 @@ export async function* _walkFileTree(
   dsContext?: BIDSContextDataset,
 ): AsyncIterable<BIDSContext> {
   for (const file of fileTree.files) {
-    yield new BIDSContext(root, file, issues, dsContext)
+    yield new BIDSContext(file, dsContext, root, issues)
   }
   for (const dir of fileTree.directories) {
     yield* _walkFileTree(dir, root, issues, dsContext)

--- a/bids-validator/src/schema/walk.ts
+++ b/bids-validator/src/schema/walk.ts
@@ -6,24 +6,20 @@ import { loadTSV } from '../files/tsv.ts'
 /** Recursive algorithm for visiting each file in the dataset, creating a context */
 export async function* _walkFileTree(
   fileTree: FileTree,
-  root: FileTree,
-  issues: DatasetIssues,
-  dsContext?: BIDSContextDataset,
+  dsContext: BIDSContextDataset,
 ): AsyncIterable<BIDSContext> {
   for (const file of fileTree.files) {
-    yield new BIDSContext(file, dsContext, root, issues)
+    yield new BIDSContext(file, dsContext)
   }
   for (const dir of fileTree.directories) {
-    yield* _walkFileTree(dir, root, issues, dsContext)
+    yield* _walkFileTree(dir, dsContext)
   }
   loadTSV.cache.delete(fileTree.path)
 }
 
 /** Walk all files in the dataset and construct a context for each one */
 export async function* walkFileTree(
-  fileTree: FileTree,
-  issues: DatasetIssues,
-  dsContext?: BIDSContextDataset,
+  dsContext: BIDSContextDataset,
 ): AsyncIterable<BIDSContext> {
-  yield* _walkFileTree(fileTree, fileTree, issues, dsContext)
+  yield* _walkFileTree(dsContext.tree, dsContext)
 }

--- a/bids-validator/src/tests/local/hed-integration.test.ts
+++ b/bids-validator/src/tests/local/hed-integration.test.ts
@@ -30,9 +30,9 @@ Deno.test('hed-validator not triggered', async (t) => {
   const PATH = 'tests/data/bids-examples/ds003'
   const tree = await readFileTree(PATH)
   const schema = await loadSchema()
-  const dsContext = new BIDSContextDataset(undefined, undefined, undefined, {
+  const dsContext = new BIDSContextDataset({dataset_description: {
     'HEDVersion': ['bad_version'],
-  })
+  }})
   await t.step('detect hed returns false', async () => {
     const eventFile = getFile(tree, 'sub-01/func/sub-01_task-rhymejudgment_events.tsv')
     assert(eventFile !== undefined)
@@ -48,9 +48,9 @@ Deno.test('hed-validator fails with bad schema version', async (t) => {
   const PATH = 'tests/data/bids-examples/eeg_ds003645s_hed_library'
   const tree = await readFileTree(PATH)
   const schema = await loadSchema()
-  const dsContext = new BIDSContextDataset(undefined, undefined, undefined, {
+  const dsContext = new BIDSContextDataset({dataset_description: {
     'HEDVersion': ['bad_version'],
-  })
+  }})
   await t.step('detect hed returns false', async () => {
     const eventFile = getFile(tree, 'sub-002/eeg/sub-002_task-FacePerception_run-3_events.tsv')
     assert(eventFile !== undefined)

--- a/bids-validator/src/tests/local/hed-integration.test.ts
+++ b/bids-validator/src/tests/local/hed-integration.test.ts
@@ -31,7 +31,7 @@ Deno.test('hed-validator not triggered', async (t) => {
   const tree = await readFileTree(PATH)
   const schema = await loadSchema()
   const issues = new DatasetIssues()
-  const dsContext = new BIDSContextDataset(undefined, { 'HEDVersion': ['bad_version'] })
+  const dsContext = new BIDSContextDataset(undefined, undefined, { 'HEDVersion': ['bad_version'] })
   await t.step('detect hed returns false', async () => {
     const eventFile = getFile(tree, 'sub-01/func/sub-01_task-rhymejudgment_events.tsv')
     assert(eventFile !== undefined)
@@ -48,7 +48,7 @@ Deno.test('hed-validator fails with bad schema version', async (t) => {
   const tree = await readFileTree(PATH)
   const schema = await loadSchema()
   const issues = new DatasetIssues()
-  const dsContext = new BIDSContextDataset(undefined, { 'HEDVersion': ['bad_version'] })
+  const dsContext = new BIDSContextDataset(undefined, undefined, { 'HEDVersion': ['bad_version'] })
   await t.step('detect hed returns false', async () => {
     const eventFile = getFile(tree, 'sub-002/eeg/sub-002_task-FacePerception_run-3_events.tsv')
     assert(eventFile !== undefined)

--- a/bids-validator/src/tests/local/hed-integration.test.ts
+++ b/bids-validator/src/tests/local/hed-integration.test.ts
@@ -30,7 +30,9 @@ Deno.test('hed-validator not triggered', async (t) => {
   const PATH = 'tests/data/bids-examples/ds003'
   const tree = await readFileTree(PATH)
   const schema = await loadSchema()
-  const dsContext = new BIDSContextDataset(undefined, undefined, { 'HEDVersion': ['bad_version'] })
+  const dsContext = new BIDSContextDataset(undefined, undefined, undefined, {
+    'HEDVersion': ['bad_version'],
+  })
   await t.step('detect hed returns false', async () => {
     const eventFile = getFile(tree, 'sub-01/func/sub-01_task-rhymejudgment_events.tsv')
     assert(eventFile !== undefined)
@@ -46,7 +48,9 @@ Deno.test('hed-validator fails with bad schema version', async (t) => {
   const PATH = 'tests/data/bids-examples/eeg_ds003645s_hed_library'
   const tree = await readFileTree(PATH)
   const schema = await loadSchema()
-  const dsContext = new BIDSContextDataset(undefined, undefined, { 'HEDVersion': ['bad_version'] })
+  const dsContext = new BIDSContextDataset(undefined, undefined, undefined, {
+    'HEDVersion': ['bad_version'],
+  })
   await t.step('detect hed returns false', async () => {
     const eventFile = getFile(tree, 'sub-002/eeg/sub-002_task-FacePerception_run-3_events.tsv')
     assert(eventFile !== undefined)

--- a/bids-validator/src/tests/local/hed-integration.test.ts
+++ b/bids-validator/src/tests/local/hed-integration.test.ts
@@ -38,7 +38,7 @@ Deno.test('hed-validator not triggered', async (t) => {
     const context = new BIDSContext(eventFile, dsContext)
     await context.asyncLoads()
     await hedValidate(schema as unknown as GenericSchema, context)
-    assert(context.issues.size === 0)
+    assert(context.dataset.issues.size === 0)
   })
 })
 
@@ -54,7 +54,7 @@ Deno.test('hed-validator fails with bad schema version', async (t) => {
     const context = new BIDSContext(eventFile, dsContext)
     await context.asyncLoads()
     await hedValidate(schema as unknown as GenericSchema, context)
-    assert(context.issues.size === 1)
-    assert(context.issues.has('HED_ERROR'))
+    assert(context.dataset.issues.size === 1)
+    assert(context.dataset.issues.has('HED_ERROR'))
   })
 })

--- a/bids-validator/src/tests/local/hed-integration.test.ts
+++ b/bids-validator/src/tests/local/hed-integration.test.ts
@@ -30,16 +30,15 @@ Deno.test('hed-validator not triggered', async (t) => {
   const PATH = 'tests/data/bids-examples/ds003'
   const tree = await readFileTree(PATH)
   const schema = await loadSchema()
-  const issues = new DatasetIssues()
   const dsContext = new BIDSContextDataset(undefined, undefined, { 'HEDVersion': ['bad_version'] })
   await t.step('detect hed returns false', async () => {
     const eventFile = getFile(tree, 'sub-01/func/sub-01_task-rhymejudgment_events.tsv')
     assert(eventFile !== undefined)
     assert(eventFile instanceof BIDSFileDeno)
-    const context = new BIDSContext(tree, eventFile, issues, dsContext)
+    const context = new BIDSContext(eventFile, dsContext)
     await context.asyncLoads()
     await hedValidate(schema as unknown as GenericSchema, context)
-    assert(issues.size === 0)
+    assert(context.issues.size === 0)
   })
 })
 
@@ -47,16 +46,15 @@ Deno.test('hed-validator fails with bad schema version', async (t) => {
   const PATH = 'tests/data/bids-examples/eeg_ds003645s_hed_library'
   const tree = await readFileTree(PATH)
   const schema = await loadSchema()
-  const issues = new DatasetIssues()
   const dsContext = new BIDSContextDataset(undefined, undefined, { 'HEDVersion': ['bad_version'] })
   await t.step('detect hed returns false', async () => {
     const eventFile = getFile(tree, 'sub-002/eeg/sub-002_task-FacePerception_run-3_events.tsv')
     assert(eventFile !== undefined)
     assert(eventFile instanceof BIDSFileDeno)
-    const context = new BIDSContext(tree, eventFile, issues, dsContext)
+    const context = new BIDSContext(eventFile, dsContext)
     await context.asyncLoads()
     await hedValidate(schema as unknown as GenericSchema, context)
-    assert(issues.size === 1)
-    assert(issues.has('HED_ERROR'))
+    assert(context.issues.size === 1)
+    assert(context.issues.has('HED_ERROR'))
   })
 })

--- a/bids-validator/src/tests/schema-expression-language.test.ts
+++ b/bids-validator/src/tests/schema-expression-language.test.ts
@@ -21,8 +21,10 @@ Deno.test('validate schema expression tests', async (t) => {
   const header = ['expression', 'desired', 'actual', 'result'].map((x) => colors.magenta(x))
   for (const test of schema.meta.expression_tests) {
     await t.step(`${test.expression} evals to ${test.result}`, () => {
+      const context = { file: { parent: null }, dataset: { tree: null } } as unknown as BIDSContext
+      Object.assign(context, expressionFunctions)
       // @ts-expect-error
-      const context = expressionFunctions as BIDSContext
+      context.exists.bind(context)
       const actual_result = evalCheck(test.expression, context)
       if (equal(actual_result, test.result)) {
         results.push([

--- a/bids-validator/src/types/check.ts
+++ b/bids-validator/src/types/check.ts
@@ -18,5 +18,4 @@ export type RuleCheckFunction = (
 export type DSCheckFunction = (
   schema: GenericSchema,
   dsContext: BIDSContextDataset,
-  issues: DatasetIssues,
 ) => Promise<void>

--- a/bids-validator/src/types/context.ts
+++ b/bids-validator/src/types/context.ts
@@ -1,4 +1,4 @@
-import { GenericSchema } from './schema.ts'
+import { Schema } from './schema.ts'
 import { ValidatorOptions } from '../setup/options.ts'
 import { FileTree } from '../types/filetree.ts'
 
@@ -95,7 +95,7 @@ export interface ContextNiftiHeader {
   sform_code: number
 }
 export interface Context {
-  schema?: GenericSchema
+  schema: Schema
   dataset: ContextDataset
   subject: ContextSubject
   path: string

--- a/bids-validator/src/types/context.ts
+++ b/bids-validator/src/types/context.ts
@@ -1,4 +1,6 @@
+import { GenericSchema } from './schema.ts'
 import { ValidatorOptions } from '../setup/options.ts'
+import { FileTree } from '../types/filetree.ts'
 
 export interface ContextDatasetSubjects {
   sub_dirs: string[]
@@ -8,10 +10,10 @@ export interface ContextDatasetSubjects {
 
 export interface ContextDataset {
   dataset_description: Record<string, unknown>
-  files: any[]
-  tree: object
+  tree: FileTree
   ignored: any[]
-  modalities: any[]
+  datatypes: string[]
+  modalities: string[]
   subjects?: ContextDatasetSubjects
   options?: ValidatorOptions
   sidecarKeyValidated: Set<string>
@@ -93,6 +95,7 @@ export interface ContextNiftiHeader {
   sform_code: number
 }
 export interface Context {
+  schema?: GenericSchema
   dataset: ContextDataset
   subject: ContextSubject
   path: string

--- a/bids-validator/src/validators/bids.ts
+++ b/bids-validator/src/validators/bids.ts
@@ -48,7 +48,7 @@ export async function validate(
     (file: BIDSFile) => file.name === 'dataset_description.json',
   )
 
-  const dsContext = new BIDSContextDataset(options, schema, fileTree)
+  const dsContext = new BIDSContextDataset({options, schema, tree: fileTree})
   if (ddFile) {
     dsContext.dataset_description = await loadJSON(ddFile).catch((error) => {
       dsContext.issues.addNonSchemaIssue(error.key, [ddFile])

--- a/bids-validator/src/validators/bids.ts
+++ b/bids-validator/src/validators/bids.ts
@@ -37,7 +37,6 @@ export async function validate(
   fileTree: FileTree,
   options: ValidatorOptions,
 ): Promise<ValidationResult> {
-  const issues = new DatasetIssues()
   const summary = new Summary()
   const schema = await loadSchema(options.schema)
   summary.schemaVersion = schema.schema_version
@@ -49,17 +48,15 @@ export async function validate(
     (file: BIDSFile) => file.name === 'dataset_description.json',
   )
 
-  let dsContext
+  const dsContext = new BIDSContextDataset(options, fileTree)
   if (ddFile) {
-    const description = await loadJSON(ddFile).catch((error) => {
-      issues.addNonSchemaIssue(error.key, [ddFile])
+    dsContext.dataset_description = await loadJSON(ddFile).catch((error) => {
+      dsContext.issues.addNonSchemaIssue(error.key, [ddFile])
       return {} as Record<string, unknown>
     })
-    summary.dataProcessed = description.DatasetType === 'derivative'
-    dsContext = new BIDSContextDataset(options, fileTree, description)
+    summary.dataProcessed = dsContext.dataset_description.DatasetType === 'derivative'
   } else {
-    dsContext = new BIDSContextDataset(options, fileTree)
-    issues.addNonSchemaIssue('MISSING_DATASET_DESCRIPTION', [] as IssueFile[])
+    dsContext.issues.addNonSchemaIssue('MISSING_DATASET_DESCRIPTION', [] as IssueFile[])
   }
 
   const bidsDerivatives: FileTree[] = []
@@ -85,7 +82,7 @@ export async function validate(
     return false
   })
 
-  for await (const context of walkFileTree(fileTree, issues, dsContext)) {
+  for await (const context of walkFileTree(dsContext)) {
     // TODO - Skip ignored files for now (some tests may reference ignored files)
     if (context.file.ignored) {
       continue
@@ -104,7 +101,7 @@ export async function validate(
     await summary.update(context)
   }
   for (const check of perDSChecks) {
-    await check(schema as unknown as GenericSchema, dsContext, issues)
+    await check(schema as unknown as GenericSchema, dsContext, dsContext.issues)
   }
 
   let derivativesSummary: Record<string, ValidationResult> = {}
@@ -116,7 +113,7 @@ export async function validate(
   )
 
   let output: ValidationResult = {
-    issues,
+    issues: dsContext.issues,
     summary: summary.formatOutput(),
   }
 

--- a/bids-validator/src/validators/bids.ts
+++ b/bids-validator/src/validators/bids.ts
@@ -56,9 +56,9 @@ export async function validate(
       return {} as Record<string, unknown>
     })
     summary.dataProcessed = description.DatasetType === 'derivative'
-    dsContext = new BIDSContextDataset(options, description)
+    dsContext = new BIDSContextDataset(options, fileTree, description)
   } else {
-    dsContext = new BIDSContextDataset(options)
+    dsContext = new BIDSContextDataset(options, fileTree)
     issues.addNonSchemaIssue('MISSING_DATASET_DESCRIPTION', [] as IssueFile[])
   }
 

--- a/bids-validator/src/validators/bids.ts
+++ b/bids-validator/src/validators/bids.ts
@@ -48,7 +48,7 @@ export async function validate(
     (file: BIDSFile) => file.name === 'dataset_description.json',
   )
 
-  const dsContext = new BIDSContextDataset(options, fileTree)
+  const dsContext = new BIDSContextDataset(options, schema, fileTree)
   if (ddFile) {
     dsContext.dataset_description = await loadJSON(ddFile).catch((error) => {
       dsContext.issues.addNonSchemaIssue(error.key, [ddFile])

--- a/bids-validator/src/validators/bids.ts
+++ b/bids-validator/src/validators/bids.ts
@@ -101,7 +101,7 @@ export async function validate(
     await summary.update(context)
   }
   for (const check of perDSChecks) {
-    await check(schema as unknown as GenericSchema, dsContext, dsContext.issues)
+    await check(schema as unknown as GenericSchema, dsContext)
   }
 
   let derivativesSummary: Record<string, ValidationResult> = {}

--- a/bids-validator/src/validators/filenameIdentify.test.ts
+++ b/bids-validator/src/validators/filenameIdentify.test.ts
@@ -3,14 +3,12 @@ import { BIDSContext } from '../schema/context.ts'
 import { _findRuleMatches, datatypeFromDirectory, hasMatch } from './filenameIdentify.ts'
 import { BIDSFileDeno } from '../files/deno.ts'
 import { FileTree } from '../types/filetree.ts'
-import { DatasetIssues } from '../issues/datasetIssues.ts'
 import { FileIgnoreRules } from '../files/ignore.ts'
 import { loadSchema } from '../setup/loadSchema.ts'
 
 const PATH = 'tests/data/valid_dataset'
 const schema = await loadSchema()
 const fileTree = new FileTree(PATH, '/')
-const issues = new DatasetIssues()
 const ignore = new FileIgnoreRules([])
 
 const node = {
@@ -30,7 +28,7 @@ Deno.test('test _findRuleMatches', async (t) => {
   await t.step('Rule stem matches', async () => {
     const fileName = 'participants.json'
     const file = new BIDSFileDeno(PATH, fileName, ignore)
-    const context = new BIDSContext(fileTree, file, issues)
+    const context = new BIDSContext(file, undefined, fileTree)
     _findRuleMatches(node, schemaPath, context)
     assertEquals(context.filenameRules[0], schemaPath)
   })
@@ -41,7 +39,7 @@ Deno.test('test _findRuleMatches', async (t) => {
     async () => {
       const fileName = 'task-rest_bold.json'
       const file = new BIDSFileDeno(PATH, fileName, ignore)
-      const context = new BIDSContext(fileTree, file, issues)
+      const context = new BIDSContext(file, undefined, fileTree)
       _findRuleMatches(recurseNode, schemaPath, context)
       assertEquals(context.filenameRules[0], `${schemaPath}.recurse`)
     },
@@ -55,7 +53,7 @@ Deno.test('test datatypeFromDirectory', (t) => {
   ]
   filesToTest.map((test) => {
     const file = new BIDSFileDeno(PATH, test[0], ignore)
-    const context = new BIDSContext(fileTree, file, issues)
+    const context = new BIDSContext(file, undefined, fileTree)
     datatypeFromDirectory(schema, context)
     assertEquals(context.datatype, test[1])
   })
@@ -65,7 +63,7 @@ Deno.test('test hasMatch', async (t) => {
   await t.step('hasMatch', async () => {
     const fileName = '/sub-01/ses-01/func/sub-01_ses-01_task-nback_run-01_bold.nii'
     const file = new BIDSFileDeno(PATH, fileName, ignore)
-    const context = new BIDSContext(fileTree, file, issues)
+    const context = new BIDSContext(file, undefined, fileTree)
     hasMatch(schema, context)
   })
 
@@ -78,7 +76,7 @@ Deno.test('test hasMatch', async (t) => {
       ignore,
     )
 
-    const context = new BIDSContext(fileTree, file, issues)
+    const context = new BIDSContext(file, undefined, fileTree)
     await hasMatch(schema, context)
     assertEquals(
       context.issues
@@ -92,7 +90,7 @@ Deno.test('test hasMatch', async (t) => {
     const path = `${PATH}/../bids-examples/fnirs_automaticity`
     const fileName = 'events.json'
     const file = new BIDSFileDeno(path, fileName, ignore)
-    const context = new BIDSContext(fileTree, file, issues)
+    const context = new BIDSContext(file, undefined, fileTree)
     context.filenameRules = [
       'rules.files.raw.task.events__mri',
       'rules.files.raw.task.events__pet',

--- a/bids-validator/src/validators/filenameIdentify.test.ts
+++ b/bids-validator/src/validators/filenameIdentify.test.ts
@@ -79,7 +79,7 @@ Deno.test('test hasMatch', async (t) => {
     const context = new BIDSContext(file, undefined, fileTree)
     await hasMatch(schema, context)
     assertEquals(
-      context.issues
+      context.dataset.issues
         .getFileIssueKeys(context.file.path)
         .includes('NOT_INCLUDED'),
       true,

--- a/bids-validator/src/validators/filenameIdentify.ts
+++ b/bids-validator/src/validators/filenameIdentify.ts
@@ -100,7 +100,7 @@ export function hasMatch(schema, context) {
     context.filenameRules.length === 0 &&
     context.file.path !== '/.bidsignore'
   ) {
-    context.issues.addNonSchemaIssue('NOT_INCLUDED', [context.file])
+    context.dataset.issues.addNonSchemaIssue('NOT_INCLUDED', [context.file])
   }
 
   /* we have matched multiple rules and a datatype, lets see if we have one

--- a/bids-validator/src/validators/filenameValidate.test.ts
+++ b/bids-validator/src/validators/filenameValidate.test.ts
@@ -25,7 +25,7 @@ Deno.test('test missingLabel', async (t) => {
 
     await missingLabel(schema, context)
     assertEquals(
-      context.issues
+      context.dataset.issues
         .getFileIssueKeys(context.file.path)
         .includes('ENTITY_WITH_NO_LABEL'),
       true,
@@ -46,7 +46,7 @@ Deno.test('test missingLabel', async (t) => {
 
       await missingLabel(schema, context)
       assertEquals(
-        context.issues
+        context.dataset.issues
           .getFileIssueKeys(context.file.path)
           .includes('ENTITY_WITH_NO_LABEL'),
         false,

--- a/bids-validator/src/validators/filenameValidate.test.ts
+++ b/bids-validator/src/validators/filenameValidate.test.ts
@@ -4,7 +4,6 @@ import { assertEquals } from '../deps/asserts.ts'
 import { BIDSContext } from '../schema/context.ts'
 import { atRoot, entityLabelCheck, missingLabel } from './filenameValidate.ts'
 import { BIDSFileDeno } from '../files/deno.ts'
-import { DatasetIssues } from '../issues/datasetIssues.ts'
 import { FileIgnoreRules } from '../files/ignore.ts'
 import { loadSchema } from '../setup/loadSchema.ts'
 
@@ -19,9 +18,9 @@ Deno.test('test missingLabel', async (t) => {
     Deno.writeTextFileSync(`${tmpDir}/${basename}`, '')
 
     const context = new BIDSContext(
-      fileTree,
       new BIDSFileDeno(tmpDir, `/${basename}`, ignore),
-      new DatasetIssues(),
+      undefined,
+      fileTree,
     )
 
     await missingLabel(schema, context)
@@ -40,9 +39,9 @@ Deno.test('test missingLabel', async (t) => {
       Deno.writeTextFileSync(`${tmpDir}/${basename}`, '')
 
       const context = new BIDSContext(
-        fileTree,
         new BIDSFileDeno(tmpDir, `/${basename}`, ignore),
-        new DatasetIssues(),
+        undefined,
+        fileTree,
       )
 
       await missingLabel(schema, context)

--- a/bids-validator/src/validators/filenameValidate.ts
+++ b/bids-validator/src/validators/filenameValidate.ts
@@ -44,7 +44,7 @@ export async function missingLabel(
   )
 
   if (fileNoLabelEntities.length) {
-    context.issues.addNonSchemaIssue('ENTITY_WITH_NO_LABEL', [
+    context.dataset.issues.addNonSchemaIssue('ENTITY_WITH_NO_LABEL', [
       { ...context.file, evidence: fileNoLabelEntities.join(', ') },
     ])
   }
@@ -120,7 +120,7 @@ export async function entityLabelCheck(
       const rePattern = new RegExp(`^${pattern}$`)
       const label = context.entities[fileEntity]
       if (!rePattern.test(label)) {
-        context.issues.addNonSchemaIssue('INVALID_ENTITY_LABEL', [
+        context.dataset.issues.addNonSchemaIssue('INVALID_ENTITY_LABEL', [
           {
             ...context.file,
             evidence: `entity: ${fileEntity} label: ${label} pattern: ${pattern}`,
@@ -150,24 +150,24 @@ async function checkRules(schema: GenericSchema, context: BIDSContext) {
       )
     }
   } else {
-    const ogIssues = context.issues
+    const ogIssues = context.dataset.issues
     const noIssues: [string, DatasetIssues][] = []
     const someIssues: [string, DatasetIssues][] = []
     for (const path of context.filenameRules) {
       const tempIssues = new DatasetIssues()
-      context.issues = tempIssues
+      context.dataset.issues = tempIssues
       for (const check of ruleChecks) {
         check(path, schema as unknown as GenericSchema, context)
       }
       tempIssues.size ? someIssues.push([path, tempIssues]) : noIssues.push([path, tempIssues])
     }
     if (noIssues.length) {
-      context.issues = ogIssues
+      context.dataset.issues = ogIssues
       context.filenameRules = [noIssues[0][0]]
     } else if (someIssues.length) {
       // What would we want to do with each rules issues? Add all?
-      context.issues = ogIssues
-      context.issues.addNonSchemaIssue('ALL_FILENAME_RULES_HAVE_ISSUES', [
+      context.dataset.issues = ogIssues
+      context.dataset.issues.addNonSchemaIssue('ALL_FILENAME_RULES_HAVE_ISSUES', [
         {
           ...context.file,
           evidence: `Rules that matched with issues: ${
@@ -210,7 +210,7 @@ function entityRuleIssue(
     )
 
     if (missingRequired.length) {
-      context.issues.addNonSchemaIssue('MISSING_REQUIRED_ENTITY', [
+      context.dataset.issues.addNonSchemaIssue('MISSING_REQUIRED_ENTITY', [
         {
           ...context.file,
           evidence: `${missingRequired.join(', ')} missing from rule ${path}`,
@@ -224,7 +224,7 @@ function entityRuleIssue(
   )
 
   if (entityNotInRule.length) {
-    context.issues.addNonSchemaIssue('ENTITY_NOT_IN_RULE', [
+    context.dataset.issues.addNonSchemaIssue('ENTITY_NOT_IN_RULE', [
       {
         ...context.file,
         evidence: `${entityNotInRule.join(', ')} not in rule ${path}`,
@@ -244,7 +244,7 @@ function datatypeMismatch(
     Array.isArray(rule.datatypes) &&
     !rule.datatypes.includes(context.datatype)
   ) {
-    context.issues.addNonSchemaIssue('DATATYPE_MISMATCH', [
+    context.dataset.issues.addNonSchemaIssue('DATATYPE_MISMATCH', [
       { ...context.file, evidence: `Datatype rule being applied: ${path}` },
     ])
   }
@@ -260,7 +260,7 @@ async function extensionMismatch(
     Array.isArray(rule.extensions) &&
     !rule.extensions.includes(context.extension)
   ) {
-    context.issues.addNonSchemaIssue('EXTENSION_MISMATCH', [
+    context.dataset.issues.addNonSchemaIssue('EXTENSION_MISMATCH', [
       { ...context.file, evidence: `Rule: ${path}` },
     ])
   }

--- a/bids-validator/src/validators/hed.ts
+++ b/bids-validator/src/validators/hed.ts
@@ -77,13 +77,13 @@ export async function hedValidate(
       hedValidationIssues.push(...file.validate(hedSchemas))
     }
   } catch (error) {
-    context.issues.addNonSchemaIssue('HED_ERROR', [{ ...context.file, evidence: error }])
+    context.dataset.issues.addNonSchemaIssue('HED_ERROR', [{ ...context.file, evidence: error }])
   }
 
   hedValidationIssues.map((hedIssue) => {
     const code = hedIssue.code
     if (code in hedOldToNewLookup) {
-      context.issues.addNonSchemaIssue(
+      context.dataset.issues.addNonSchemaIssue(
         hedOldToNewLookup[code],
         [{ ...hedIssue.file, evidence: hedIssue.evidence }],
       )

--- a/bids-validator/src/validators/internal/emptyFile.ts
+++ b/bids-validator/src/validators/internal/emptyFile.ts
@@ -3,7 +3,7 @@ import { ContextCheckFunction } from '../../types/check.ts'
 // Non-schema EMPTY_FILE implementation
 export const emptyFile: ContextCheckFunction = (schema, context) => {
   if (context.file.size === 0) {
-    context.issues.addNonSchemaIssue('EMPTY_FILE', [context.file])
+    context.dataset.issues.addNonSchemaIssue('EMPTY_FILE', [context.file])
   }
   return Promise.resolve()
 }


### PR DESCRIPTION
Dataset issues sensibly accumulate on the long-lived dataset object, instead of the ephemeral context object. `dataset.tree` is defined by the schema, and also makes sense there.

I think `walk.ts` demonstrates this well. The dataset context provides the files to be iterated over, and a new context can be generated with just the current file and the dataset context.

There's still room to pre-allocate a `context.subject` object and pass that through, but this is enough of a change for one PR, IMO.

This will help focus #2057 on the specific changes needed for those issues.