### PR TITLE
feat(cli): Detect color support, respect flags and environment variables

### DIFF
--- a/bids-validator/src/main.ts
+++ b/bids-validator/src/main.ts
@@ -1,4 +1,5 @@
 import { parseOptions } from './setup/options.ts'
+import { colors } from './deps/fmt.ts'
 import { readFileTree } from './files/deno.ts'
 import { fileListToTree } from './files/browser.ts'
 import { resolve } from './deps/path.ts'
@@ -9,6 +10,7 @@ import type { ValidationResult } from './types/validation-result.ts'
 
 export async function main(): Promise<ValidationResult> {
   const options = await parseOptions(Deno.args)
+  colors.setColorEnabled(options.color)
   setupLogging(options.debug)
   const absolutePath = resolve(options.datasetPath)
   const tree = await readFileTree(absolutePath)

--- a/bids-validator/src/setup/options.test.ts
+++ b/bids-validator/src/setup/options.test.ts
@@ -9,6 +9,7 @@ Deno.test('options parsing', async (t) => {
       debug: 'ERROR',
       json: true,
       schema: 'latest',
+      color: false,
     })
   })
 })

--- a/bids-validator/src/setup/options.ts
+++ b/bids-validator/src/setup/options.ts
@@ -11,6 +11,7 @@ export type ValidatorOptions = {
   ignoreNiftiHeaders?: boolean
   filenameMode?: boolean
   debug: LevelName
+  color?: boolean
 }
 
 export const validateCommand = new Command()
@@ -39,6 +40,10 @@ export const validateCommand = new Command()
   .option(
     '--filenameMode',
     'Enable filename checks for newline separated filenames read from stdin',
+  )
+  .option(
+    '--color, --no-color [color:boolean]',
+    'Enable/disable color output (defaults to detected support)',
   )
 
 /**

--- a/bids-validator/src/setup/options.ts
+++ b/bids-validator/src/setup/options.ts
@@ -44,6 +44,9 @@ export const validateCommand = new Command()
   .option(
     '--color, --no-color [color:boolean]',
     'Enable/disable color output (defaults to detected support)',
+    {
+      default: !!(Deno.env.get('FORCE_COLOR') || Deno.stdout.isTerminal())
+    },
   )
 
 /**


### PR DESCRIPTION
This PR adds `--color`/`--no-color` flags to let users enable/disable ANSI colors. The default value depends on whether it's a terminal and whether `FORCE_COLOR` is set. If `NO_COLOR` is set, that overrides all coloring, since that is enforced by Deno.

Precedence: `NO_COLOR` > `flag` > `FORCE_COLOR` > `isTerminal()`.

IMO, the only question is what to do if `FORCE_COLOR=1 bids-validator --no-color`. I chose to respect the flag over the environment variable.

Closes #1997.