### PR TITLE
feat(legacy): Support local BIDS-URIs for IntendedFor fields

### DIFF
--- a/bids-validator/validators/microscopy/checkJSONAndField.js
+++ b/bids-validator/validators/microscopy/checkJSONAndField.js
@@ -100,16 +100,16 @@ const checkIfIntendedExists = (intendedFor, fileList, file) => {
   for (let key = 0; key < intendedFor.length; key++) {
     const intendedForFile = intendedFor[key]
     const intendedForFileFull =
-      '/' + file.relativePath.split('/')[1] + '/' + intendedForFile
-    let onTheList = false
-    for (let key2 in fileList) {
-      if (key2) {
-        const filePath = fileList[key2].relativePath
-        if (filePath === intendedForFileFull) {
-          onTheList = true
-        }
-      }
-    }
+      '/' +
+      (intendedForFile.startsWith('bids::')
+        ? intendedForFile.split('::')[1]
+        : file.relativePath.split('/')[1] + '/' + intendedForFile)
+    const onTheList = Object.values(fileList).some(
+      (f) =>
+        f.relativePath === intendedForFileFull ||
+        // Consider .ome.zarr/ files
+        f.relativePath.startsWith(`${intendedForFileFull}/`),
+    )
     if (!onTheList) {
       issues.push(
         new Issue({

--- a/bids-validator/validators/nifti/nii.js
+++ b/bids-validator/validators/nifti/nii.js
@@ -1396,17 +1396,13 @@ function sliceTimingGreaterThanRepetitionTime(array, repetitionTime) {
 
 function checkIfIntendedExists(intendedForFile, fileList, issues, file) {
   const intendedForFileFull =
-    '/' + file.relativePath.split('/')[1] + '/' + intendedForFile
-  let onTheList = false
-
-  for (let key2 in fileList) {
-    if (key2) {
-      const filePath = fileList[key2].relativePath
-      if (filePath === intendedForFileFull) {
-        onTheList = true
-      }
-    }
-  }
+    '/' +
+    (intendedForFile.startsWith('bids::')
+      ? intendedForFile.split('::')[1]
+      : file.relativePath.split('/')[1] + '/' + intendedForFile)
+  const onTheList = Object.values(fileList).some(
+    (f) => f.relativePath === intendedForFileFull,
+  )
   if (!onTheList) {
     issues.push(
       new Issue({


### PR DESCRIPTION
Was going to skip validation for the legacy validator for https://github.com/bids-standard/bids-examples/pull/455, but this was pretty straightforward just to fix.

It's not 100% BIDS-URI support, but it is easily over 80% for these fields.