### PR TITLE
Enforce uniqueness of data files in a directory.

### DIFF
--- a/bids-validator/src/issues/list.ts
+++ b/bids-validator/src/issues/list.ts
@@ -42,6 +42,10 @@ export const bidsIssues: IssueDefinitionRecord = {
     severity: 'error',
     reason: 'Extension used by file does not match allowed extensions for its suffix',
   },
+  NON_UNIQUE_DATAFILE: {
+    severity: 'error',
+    reason: 'Multiple files found with the same entities, datatype and suffix.'
+  },
   JSON_KEY_REQUIRED: {
     severity: 'error',
     reason: 'A JSON flle is missing a key listed as required.',

--- a/bids-validator/src/tests/simple-dataset.ts
+++ b/bids-validator/src/tests/simple-dataset.ts
@@ -7,8 +7,8 @@ const text = () => Promise.resolve('')
 const rootFileTree = new FileTree('/', '')
 const subjectFileTree = new FileTree('/sub-01', 'sub-01', rootFileTree)
 const anatFileTree = new FileTree('/sub-01/anat', 'anat', subjectFileTree)
-anatFileTree.files = [
-  {
+export const generateTestAnatFile = () => {
+  return {
     text,
     path: '/sub-01/anat/sub-01_T1w.nii.gz',
     name: 'sub-01_T1w.nii.gz',
@@ -17,7 +17,10 @@ anatFileTree.files = [
     stream: new ReadableStream<Uint8Array>(),
     readBytes: nullReadBytes,
     parent: anatFileTree,
-  },
+  }
+}
+anatFileTree.files = [
+  generateTestAnatFile()
 ]
 subjectFileTree.files = []
 subjectFileTree.directories = [anatFileTree]


### PR DESCRIPTION
https://bids-specification.readthedocs.io/en/stable/common-principles.html#uniqueness-of-data-files
fixes bids-standard/bids-specification#2215

Added in src/valdiators/filenameValidate.ts. This check sees if another file exists in the parent directory of the context that has the contexts exact entities and sufiix but a different valid (non-sidecar) extension from the `rules.files.*` rule that the context matched.

Unfortunately there is a problem with relying on the `rules.files.*`. It does not state which extensions are mutually exclusive. One ieeg format for instance states `Each recording consists of a .vhdr, .vmrk, .eeg file triplet` as valid:
https://bids-specification.readthedocs.io/en/stable/modality-specific-files/intracranial-electroencephalography.html#ieeg-recording-data
https://github.com/bids-standard/bids-specification/blob/master/src/schema/rules/files/raw/ieeg.yaml

Maintaing list of sidecar extensions in filenameValidate.ts is no good and should probably be pulled from the schema if possible.