### PR TITLE
chore: Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+[*.{ts,js,json,yaml,yml}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Neovim's default javascript settings want to use tabs. While I can update my settings on every box, it also makes sense to set conventions at the repo level. `.editorconfig` is widely supported: https://editorconfig.org/