### PR TITLE
fix(json): Validate all JSON fields

### DIFF
--- a/bids-validator/src/tests/local/bids_examples.test.ts
+++ b/bids-validator/src/tests/local/bids_examples.test.ts
@@ -26,7 +26,7 @@ function formatBEIssue(issue: IssueOutput, dsPath: string) {
   errors.push(
     Row.from([
       colors.red(issue.key),
-      issue.files[0].file.name,
+      issue.files[0].file.path,
       issue.files[0].evidence,
     ]),
   )


### PR DESCRIPTION
The JSON validation code strongly assumed it was validating sidecars, not JSON files. These changes streamline the logic a bit to ensure that sidecars and JSON files are treated the same, but the sidecar "origin" code is skipped for JSON files.

Closes #2007.