### PR TITLE
fix(nifti): Suppress console.error during NIfTI readHeader()

### DIFF
--- a/bids-validator/src/files/nifti.ts
+++ b/bids-validator/src/files/nifti.ts
@@ -27,11 +27,19 @@ async function extract(buffer: Uint8Array, nbytes: number): Promise<Uint8Array> 
   return result
 }
 
+function readHeaderQuiet(buf: ArrayBuffer) {
+  const console_error = console.error
+  console.error = () => {}
+  const header = readHeader(buf)
+  console.error = console_error
+  return header
+}
+
 export async function loadHeader(file: BIDSFile): Promise<ContextNiftiHeader> {
   try {
     const buf = await file.readBytes(1024)
     const data = isCompressed(buf.buffer) ? await extract(buf, 540) : buf
-    const header = readHeader(data.buffer)
+    const header = readHeaderQuiet(data.buffer)
     if (!header) {
       throw { key: 'NIFTI_HEADER_UNREADABLE' }
     }


### PR DESCRIPTION
The NIfTI reader emits a `console.error()` before returning `null` on error. 

https://github.com/rii-mango/NIFTI-Reader-JS/blob/0e406b03775d5687911f9440dffa65d7b0886137/src/nifti.ts#L143-L145

We are checking null and returning our own error. This narrowly suppresses console.error to prevent a library from polluting the output.