### PR TITLE
test: Add unit tests for valid and invalid filenames

### DIFF
--- a/bids-validator/src/issues/list.ts
+++ b/bids-validator/src/issues/list.ts
@@ -46,6 +46,11 @@ export const bidsIssues: IssueDefinitionRecord = {
     severity: 'error',
     reason: 'The file has a valid name, but is located in an invalid directory.',
   },
+  FILENAME_MISMATCH: {
+    severity: 'error',
+    reason:
+      'The filename is not formatted correctly. This could result from entity duplication or reordering.',
+  },
   JSON_KEY_REQUIRED: {
     severity: 'error',
     reason: 'A JSON flle is missing a key listed as required.',

--- a/bids-validator/src/issues/list.ts
+++ b/bids-validator/src/issues/list.ts
@@ -42,6 +42,10 @@ export const bidsIssues: IssueDefinitionRecord = {
     severity: 'error',
     reason: 'Extension used by file does not match allowed extensions for its suffix',
   },
+  INVALID_LOCATION: {
+    severity: 'error',
+    reason: 'The file has a valid name, but is located in an invalid directory.',
+  },
   JSON_KEY_REQUIRED: {
     severity: 'error',
     reason: 'A JSON flle is missing a key listed as required.',

--- a/bids-validator/src/schema/entities.ts
+++ b/bids-validator/src/schema/entities.ts
@@ -21,7 +21,8 @@ export function _readEntities(filename: string): BIDSFileParts {
     suffix = parts.pop() as string
   }
   for (const part of parts) {
-    const [entity, label] = part.split('-')
+    // Use capturing regex to split on the first hyphen only
+    const [entity, label] = part.split(/-(.+)/)
     entities[entity] = label || 'NOENTITY'
   }
 

--- a/bids-validator/src/types/schema.ts
+++ b/bids-validator/src/types/schema.ts
@@ -27,6 +27,7 @@ export interface SchemaObjects {
 }
 
 export interface SchemaRules {
+  entities: string[]
   files: SchemaFiles
   modalities: Record<string, unknown>
 }

--- a/bids-validator/src/validators/filenameIdentify.ts
+++ b/bids-validator/src/validators/filenameIdentify.ts
@@ -55,8 +55,8 @@ function findRuleMatches(schema, context) {
  */
 export function _findRuleMatches(node, path, context) {
   if (
-    ('path' in node && context.file.name.endsWith(node.path)) ||
-    ('stem' in node && context.file.name.match(globToRegExp(node.stem + '*'))) ||
+    (`/${node.path}` === context.path) ||
+    (node.stem && matchStemRule(node, context)) ||
     ('suffixes' in node && node.suffixes.includes(context.suffix))
   ) {
     context.filenameRules.push(path)
@@ -70,6 +70,16 @@ export function _findRuleMatches(node, path, context) {
       _findRuleMatches(node[key], `${path}.${key}`, context)
     })
   }
+}
+
+function matchStemRule(node, context): boolean {
+  if (!context.file.name.split('.')[0].match(globToRegExp(node.stem))) {
+    return false
+  }
+  if (node.datatypes) {
+    return node.datatypes.includes(context.datatype)
+  }
+  return true
 }
 
 export async function datatypeFromDirectory(schema, context) {

--- a/bids-validator/src/validators/filenameValidate.test.ts
+++ b/bids-validator/src/validators/filenameValidate.test.ts
@@ -8,20 +8,30 @@ import { FileIgnoreRules } from '../files/ignore.ts'
 import { loadSchema } from '../setup/loadSchema.ts'
 
 const schema = (await loadSchema()) as unknown as GenericSchema
-const ignore = new FileIgnoreRules([])
+const nullFile = {
+  size: 0,
+  ignored: false,
+  parent: new FileTree('/', '/'),
+  viewed: false,
+  stream: new ReadableStream(),
+  text: async () => '',
+  readBytes: async (size: number, offset?: number) => new Uint8Array(),
+}
+
+function newContext(path: string): BIDSContext {
+  return new BIDSContext({
+    name: path.split('/').pop() as string,
+    path: path,
+    ...nullFile,
+  })
+}
 
 Deno.test('test missingLabel', async (t) => {
-  const tmpDir = Deno.makeTempDirSync()
-  const fileTree = new FileTree(tmpDir, '/')
   await t.step('File with underscore and no hyphens errors out.', async () => {
-    const basename = 'no_label_entities.wav'
-    Deno.writeTextFileSync(`${tmpDir}/${basename}`, '')
-
-    const context = new BIDSContext(
-      new BIDSFileDeno(tmpDir, `/${basename}`, ignore),
-      undefined,
-      fileTree,
-    )
+    const context = newContext(`/no_label_entities.wav`)
+    // Need some suffix rule to trigger the check,
+    // otherwise this is trigger-happy.
+    context.filenameRules = ['rules.files.raw.dwi.dwi']
 
     await missingLabel(schema, context)
     assertEquals(
@@ -37,14 +47,9 @@ Deno.test('test missingLabel', async (t) => {
   await t.step(
     "File with underscores and hyphens doesn't error out.",
     async () => {
-      const basename = 'we-do_have-some_entities.wav'
-      Deno.writeTextFileSync(`${tmpDir}/${basename}`, '')
-
-      const context = new BIDSContext(
-        new BIDSFileDeno(tmpDir, `/${basename}`, ignore),
-        undefined,
-        fileTree,
-      )
+      const context = newContext('/we-do_have-some_entities.wav')
+      // Doesn't really matter that the rule doesn't apply
+      context.filenameRules = ['rules.files.raw.dwi.dwi']
 
       await missingLabel(schema, context)
       assertEquals(
@@ -56,5 +61,4 @@ Deno.test('test missingLabel', async (t) => {
       )
     },
   )
-  Deno.removeSync(tmpDir, { recursive: true })
 })

--- a/bids-validator/src/validators/filenameValidate.ts
+++ b/bids-validator/src/validators/filenameValidate.ts
@@ -142,6 +142,7 @@ const ruleChecks: RuleCheckFunction[] = [
   entityRuleIssue,
   datatypeMismatch,
   extensionMismatch,
+  invalidLocation,
 ]
 
 async function checkRules(schema: GenericSchema, context: BIDSContext) {
@@ -271,5 +272,32 @@ async function extensionMismatch(
       location: context.path,
       rule: path,
     })
+  }
+}
+
+async function invalidLocation(
+  path: string,
+  schema: GenericSchema,
+  context: BIDSContext,
+) {
+  const rule = schema[path]
+  if (!('entities' in rule)) {
+    return
+  }
+  const sub: string | undefined = context.entities.sub
+  const ses: string | undefined = context.entities.ses
+
+  if (sub) {
+    let pattern = `/sub-${sub}/`
+    if (ses) {
+      pattern += `ses-${ses}/`
+    }
+    if (!context.path.startsWith(pattern)) {
+      context.dataset.issues.add({
+        code: 'INVALID_LOCATION',
+        location: context.path,
+        issueMessage: `Expected location: ${pattern}`,
+      })
+    }
   }
 }

--- a/bids-validator/src/validators/filenameValidate.ts
+++ b/bids-validator/src/validators/filenameValidate.ts
@@ -300,4 +300,19 @@ async function invalidLocation(
       })
     }
   }
+
+  if (!sub && context.path.match(/^\/sub-/)) {
+    context.dataset.issues.add({
+      code: 'INVALID_LOCATION',
+      location: context.path,
+      issueMessage: `Expected location: /${context.file.name}`,
+    })
+  }
+  if (!ses && context.path.match(/\/ses-/)) {
+    context.dataset.issues.add({
+      code: 'INVALID_LOCATION',
+      location: context.path,
+      issueMessage: `Unexpected session directory`,
+    })
+  }
 }

--- a/bids-validator/src/validators/filenameValidate.ts
+++ b/bids-validator/src/validators/filenameValidate.ts
@@ -35,6 +35,9 @@ export async function missingLabel(
   schema: GenericSchema,
   context: BIDSContext,
 ) {
+  if (!context.filenameRules.some((rule) => 'suffixes' in schema[rule])) {
+    return Promise.resolve()
+  }
   const fileNoLabelEntities = Object.keys(context.entities).filter(
     (key) => context.entities[key] === 'NOENTITY',
   )

--- a/bids-validator/src/validators/validateFiles.test.ts
+++ b/bids-validator/src/validators/validateFiles.test.ts
@@ -72,7 +72,11 @@ Deno.test('test valid paths', async (t) => {
   for (const filename of validFiles) {
     await t.step(filename, async () => {
       const issues = validatePath(filename)
-      assertEquals(issues.get({ location: filename }).length, 0)
+      assertEquals(
+        issues.get({ location: filename }).length,
+        0,
+        Deno.inspect(issues),
+      )
     })
   }
 })
@@ -129,6 +133,7 @@ Deno.test('test invalid paths', async (t) => {
         context.dataset.issues.get({
           location: context.file.path,
         }).length > 0,
+        `Matching filename rules: ${context.filenameRules}`,
       )
     })
   }

--- a/bids-validator/src/validators/validateFiles.test.ts
+++ b/bids-validator/src/validators/validateFiles.test.ts
@@ -120,6 +120,8 @@ Deno.test('test invalid paths', async (t) => {
     '/sub-01/ses-test/sub-02_ses-test_acq-singleband_run-01_dwi.bval', // wrong sub id in the filename
     '/sub-01/sub-01_ses-test_acq-singleband_run-01_dwi.bvec', // ses dir missed
     '/ses-test/sub-01_ses-test_acq-singleband_run-01_dwi.json', // sub id dir missed
+    '/sub-01/ses-test/sub-01_ses-test_run-01_acq-singleband_dwi.json', // incorrect entity order
+    '/sub-01/ses-test/sub-01_ses-test_acq-singleband_acq-singleband_run-01_dwi.json', // entity appears twice
     '/measurement_tool_name.tsv', // missed phenotype dir
     '/phentype/measurement_tool_name.josn', // wrong phenotype dir
     '/phenotype/measurement_tool_name.jsn', // wrong extension

--- a/bids-validator/src/validators/validateFiles.test.ts
+++ b/bids-validator/src/validators/validateFiles.test.ts
@@ -1,0 +1,135 @@
+import { assert, assertEquals } from '../deps/asserts.ts'
+import { filenameIdentify } from './filenameIdentify.ts'
+import { filenameValidate } from './filenameValidate.ts'
+import { FileTree } from '../types/filetree.ts'
+import { BIDSContext } from '../schema/context.ts'
+import { loadSchema } from '../setup/loadSchema.ts'
+import { GenericSchema, Schema } from '../types/schema.ts'
+import { DatasetIssues } from '../issues/datasetIssues.ts'
+
+const schema = await loadSchema() as unknown as GenericSchema
+const nullFile = {
+  size: 0,
+  ignored: false,
+  parent: new FileTree('/', '/'),
+  viewed: false,
+  stream: new ReadableStream(),
+  text: async () => '',
+  readBytes: async (size: number, offset?: number) => new Uint8Array(),
+}
+
+function newContext(path: string): BIDSContext {
+  return new BIDSContext({
+    name: path.split('/').pop() as string,
+    path: path,
+    ...nullFile,
+  })
+}
+
+function validatePath(path: string): DatasetIssues {
+  const context = newContext(path)
+  filenameIdentify(schema, context)
+  filenameValidate(schema, context)
+  return context.dataset.issues
+}
+
+Deno.test('test valid paths', async (t) => {
+  const validFiles = [
+    '/README',
+    '/CHANGES',
+    '/dataset_description.json',
+    '/participants.tsv',
+    '/participants.json',
+    '/sub-01/sub-01_sessions.tsv',
+    '/sub-01/sub-01_sessions.json',
+    '/sub-01/sub-01_dwi.bval',
+    '/sub-01/sub-01_dwi.bvec',
+    '/sub-01/sub-01_dwi.json',
+    '/sub-01/sub-01_run-01_dwi.bval',
+    '/sub-01/sub-01_run-01_dwi.bvec',
+    '/sub-01/sub-01_run-01_dwi.json',
+    '/sub-01/sub-01_acq-singleband_dwi.bval',
+    '/sub-01/sub-01_acq-singleband_dwi.bvec',
+    '/sub-01/sub-01_acq-singleband_dwi.json',
+    '/sub-01/sub-01_acq-singleband_run-01_dwi.bval',
+    '/sub-01/sub-01_acq-singleband_run-01_dwi.bvec',
+    '/sub-01/sub-01_acq-singleband_run-01_dwi.json',
+    '/sub-01/ses-test/sub-01_ses-test_dwi.bval',
+    '/sub-01/ses-test/sub-01_ses-test_dwi.bvec',
+    '/sub-01/ses-test/sub-01_ses-test_dwi.json',
+    '/sub-01/ses-test/sub-01_ses-test_run-01_dwi.bval',
+    '/sub-01/ses-test/sub-01_ses-test_run-01_dwi.bvec',
+    '/sub-01/ses-test/sub-01_ses-test_run-01_dwi.json',
+    '/sub-01/ses-test/sub-01_ses-test_acq-singleband_dwi.bval',
+    '/sub-01/ses-test/sub-01_ses-test_acq-singleband_dwi.bvec',
+    '/sub-01/ses-test/sub-01_ses-test_acq-singleband_dwi.json',
+    '/sub-01/ses-test/sub-01_ses-test_acq-singleband_run-01_dwi.bval',
+    '/sub-01/ses-test/sub-01_ses-test_acq-singleband_run-01_dwi.bvec',
+    '/sub-01/ses-test/sub-01_ses-test_acq-singleband_run-01_dwi.json',
+    '/phenotype/measurement_tool_name.tsv',
+    '/phenotype/measurement_tool_name.json',
+  ]
+  for (const filename of validFiles) {
+    await t.step(filename, async () => {
+      const issues = validatePath(filename)
+      assertEquals(issues.get({ location: filename }).length, 0)
+    })
+  }
+})
+
+Deno.test('test invalid paths', async (t) => {
+  const invalidFiles = [
+    '/RADME', // wrong filename
+    '/CANGES', // wrong filename
+    '/dataset_descrption.json', // wrong filename
+    '/dataset_description.jon', // wrong extension
+    '/participants.sv', // wrong extension
+    '/participnts.tsv', // wrong filename
+    '/particpants.json', // wrong filename
+    '/participants.son', // wrong extension
+    '/sub-02/sub-01_sessions.tsv', // wrong sub id in the filename
+    '/sub-01_sessions.tsv', // missed subject id dir
+    '/sub-01/sub-01_sesions.tsv', // wrong modality
+    '/sub-01/sub-01_sesions.ext', // wrong extension
+    '/sub-01/sub-01_sessions.jon', // wrong extension
+    '/sub-01/ses-ses/sub-01_dwi.bval', // redundant dir /ses-ses/
+    '/sub-01/01_dwi.bvec', // missed subject suffix
+    '/sub-01/sub_dwi.json', // missed subject id
+    '/sub-01/sub-01_23_run-01_dwi.bval', // wrong _23_
+    '/sub-01/sub-01_run-01_dwi.vec', // wrong extension
+    '/sub-01/sub-01_run-01_dwi.jsn', // wrong extension
+    '/sub-01/sub-01_acq_dwi.bval', // missed suffix value
+    '/sub-01/sub-01_acq-23-singleband_dwi.bvec', // redundant -23-
+    '/sub-01/anat/sub-01_acq-singleband_dwi.json', // redundant /anat/
+    '/sub-01/sub-01_recrod-record_acq-singleband_run-01_dwi.bval', // redundant record-record_
+    '/sub_01/sub-01_acq-singleband_run-01_dwi.bvec', // wrong /sub_01/
+    '/sub-01/sub-01_acq-singleband__run-01_dwi.json', // wrong __
+    '/sub-01/ses-test/sub-01_ses_test_dwi.bval', // wrong ses_test
+    '/sub-01/ses-test/sb-01_ses-test_dwi.bvec', // wrong sb-01
+    '/sub-01/ses-test/sub-01_ses-test_dw.json', // wrong modality
+    '/sub-01/ses-test/sub-01_ses-test_run-01_dwi.val', // wrong extension
+    '/sub-01/ses-test/sub-01_run-01_dwi.bvec', // missed session in the filename
+    '/sub-01/ses-test/ses-test_run-01_dwi.json', // missed subject in the filename
+    '/sub-01/ses-test/sub-01_ses-test_acq-singleband.bval', // missed modality
+    '/sub-01/ses-test/sub-01_ses-test_acq-singleband_dwi', // missed extension
+    '/ses-test/sub-01/sub-01_ses-test_acq_singleband_dwi.json', // wrong dirs order
+    '/sub-01/ses-test/sub-02_ses-test_acq-singleband_run-01_dwi.bval', // wrong sub id in the filename
+    '/sub-01/sub-01_ses-test_acq-singleband_run-01_dwi.bvec', // ses dir missed
+    '/ses-test/sub-01_ses-test_acq-singleband_run-01_dwi.json', // sub id dir missed
+    '/measurement_tool_name.tsv', // missed phenotype dir
+    '/phentype/measurement_tool_name.josn', // wrong phenotype dir
+    '/phenotype/measurement_tool_name.jsn', // wrong extension
+  ]
+  for (const filename of invalidFiles) {
+    await t.step(filename, async () => {
+      const context = newContext(filename)
+      await filenameIdentify(schema, context)
+      await filenameValidate(schema, context)
+      assert(
+        context.dataset.issues.get({
+          location: context.file.path,
+        }).length > 0,
+      )
+    })
+  }
+})


### PR DESCRIPTION
Currently failing:

<details open><summary>Failures</summary>

```console
❯ deno test -A src/validators/validateFiles.test.ts --parallel | grep FAILED
./src/validators/validateFiles.test.ts => test valid paths ... /dataset_description.json ... FAILED (2ms)
./src/validators/validateFiles.test.ts => test valid paths ... /phenotype/measurement_tool_name.tsv ... FAILED (0ms)
./src/validators/validateFiles.test.ts => test valid paths ... /phenotype/measurement_tool_name.json ... FAILED (1ms)
./src/validators/validateFiles.test.ts => test valid paths ... FAILED (due to 3 failed steps) (10ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /dataset_descrption.json ... FAILED (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /participnts.tsv ... FAILED (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /particpants.json ... FAILED (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub-02/sub-01_sessions.tsv ... FAILED (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub-01_sessions.tsv ... FAILED (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub-01/sub-01_sesions.tsv ... FAILED (1ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub-01/ses-ses/sub-01_dwi.bval ... FAILED (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub-01/sub-01_acq-23-singleband_dwi.bvec ... FAILED (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub_01/sub-01_acq-singleband_run-01_dwi.bvec ... FAILED (1ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub-01/sub-01_acq-singleband__run-01_dwi.json ... FAILED (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub-01/ses-test/sub-01_ses-test_dw.json ... FAILED (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub-01/ses-test/sub-01_run-01_dwi.bvec ... FAILED (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub-01/ses-test/ses-test_run-01_dwi.json ... FAILED (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /ses-test/sub-01/sub-01_ses-test_acq_singleband_dwi.json ... FAILED (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub-01/ses-test/sub-02_ses-test_acq-singleband_run-01_dwi.bval ... FAILED (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub-01/sub-01_ses-test_acq-singleband_run-01_dwi.bvec ... FAILED (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /ses-test/sub-01_ses-test_acq-singleband_run-01_dwi.json ... FAILED (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /measurement_tool_name.tsv ... FAILED (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... FAILED (due to 18 failed steps) (11ms)
FAILED | 0 passed (52 steps) | 2 failed (21 steps) (23ms)
error: Test failed
```
</details>

<details><summary>Full listing</summary>

```console
❯ deno test -A src/validators/validateFiles.test.ts --parallel
Check file:///home/chris/Projects/bids/validator/bids-validator/src/validators/validateFiles.test.ts
./src/validators/validateFiles.test.ts => test valid paths ... /README ... ok (1ms)
./src/validators/validateFiles.test.ts => test valid paths ... /CHANGES ... ok (0ms)
./src/validators/validateFiles.test.ts => test valid paths ... /dataset_description.json ... FAILED (2ms)
./src/validators/validateFiles.test.ts => test valid paths ... /participants.tsv ... ok (0ms)
./src/validators/validateFiles.test.ts => test valid paths ... /participants.json ... ok (0ms)
./src/validators/validateFiles.test.ts => test valid paths ... /sub-01/sub-01_sessions.tsv ... ok (0ms)
./src/validators/validateFiles.test.ts => test valid paths ... /sub-01/sub-01_sessions.json ... ok (0ms)
./src/validators/validateFiles.test.ts => test valid paths ... /sub-01/sub-01_dwi.bval ... ok (0ms)
./src/validators/validateFiles.test.ts => test valid paths ... /sub-01/sub-01_dwi.bvec ... ok (0ms)
./src/validators/validateFiles.test.ts => test valid paths ... /sub-01/sub-01_dwi.json ... ok (1ms)
./src/validators/validateFiles.test.ts => test valid paths ... /sub-01/sub-01_run-01_dwi.bval ... ok (0ms)
./src/validators/validateFiles.test.ts => test valid paths ... /sub-01/sub-01_run-01_dwi.bvec ... ok (0ms)
./src/validators/validateFiles.test.ts => test valid paths ... /sub-01/sub-01_run-01_dwi.json ... ok (1ms)
./src/validators/validateFiles.test.ts => test valid paths ... /sub-01/sub-01_acq-singleband_dwi.bval ... ok (0ms)
./src/validators/validateFiles.test.ts => test valid paths ... /sub-01/sub-01_acq-singleband_dwi.bvec ... ok (0ms)
./src/validators/validateFiles.test.ts => test valid paths ... /sub-01/sub-01_acq-singleband_dwi.json ... ok (0ms)
./src/validators/validateFiles.test.ts => test valid paths ... /sub-01/sub-01_acq-singleband_run-01_dwi.bval ... ok (0ms)
./src/validators/validateFiles.test.ts => test valid paths ... /sub-01/sub-01_acq-singleband_run-01_dwi.bvec ... ok (0ms)
./src/validators/validateFiles.test.ts => test valid paths ... /sub-01/sub-01_acq-singleband_run-01_dwi.json ... ok (0ms)
./src/validators/validateFiles.test.ts => test valid paths ... /sub-01/ses-test/sub-01_ses-test_dwi.bval ... ok (0ms)
./src/validators/validateFiles.test.ts => test valid paths ... /sub-01/ses-test/sub-01_ses-test_dwi.bvec ... ok (0ms)
./src/validators/validateFiles.test.ts => test valid paths ... /sub-01/ses-test/sub-01_ses-test_dwi.json ... ok (0ms)
./src/validators/validateFiles.test.ts => test valid paths ... /sub-01/ses-test/sub-01_ses-test_run-01_dwi.bval ... ok (0ms)
./src/validators/validateFiles.test.ts => test valid paths ... /sub-01/ses-test/sub-01_ses-test_run-01_dwi.bvec ... ok (0ms)
./src/validators/validateFiles.test.ts => test valid paths ... /sub-01/ses-test/sub-01_ses-test_run-01_dwi.json ... ok (1ms)
./src/validators/validateFiles.test.ts => test valid paths ... /sub-01/ses-test/sub-01_ses-test_acq-singleband_dwi.bval ... ok (0ms)
./src/validators/validateFiles.test.ts => test valid paths ... /sub-01/ses-test/sub-01_ses-test_acq-singleband_dwi.bvec ... ok (0ms)
./src/validators/validateFiles.test.ts => test valid paths ... /sub-01/ses-test/sub-01_ses-test_acq-singleband_dwi.json ... ok (0ms)
./src/validators/validateFiles.test.ts => test valid paths ... /sub-01/ses-test/sub-01_ses-test_acq-singleband_run-01_dwi.bval ... ok (0ms)
./src/validators/validateFiles.test.ts => test valid paths ... /sub-01/ses-test/sub-01_ses-test_acq-singleband_run-01_dwi.bvec ... ok (0ms)
./src/validators/validateFiles.test.ts => test valid paths ... /sub-01/ses-test/sub-01_ses-test_acq-singleband_run-01_dwi.json ... ok (1ms)
./src/validators/validateFiles.test.ts => test valid paths ... /phenotype/measurement_tool_name.tsv ... FAILED (0ms)
./src/validators/validateFiles.test.ts => test valid paths ... /phenotype/measurement_tool_name.json ... FAILED (1ms)
./src/validators/validateFiles.test.ts => test valid paths ... FAILED (due to 3 failed steps) (12ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /RADME ... ok (1ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /CANGES ... ok (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /dataset_descrption.json ... FAILED (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /dataset_description.jon ... ok (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /participants.sv ... ok (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /participnts.tsv ... FAILED (1ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /particpants.json ... FAILED (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /participants.son ... ok (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub-02/sub-01_sessions.tsv ... FAILED (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub-01_sessions.tsv ... FAILED (1ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub-01/sub-01_sesions.tsv ... FAILED (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub-01/sub-01_sesions.ext ... ok (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub-01/sub-01_sessions.jon ... ok (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub-01/ses-ses/sub-01_dwi.bval ... FAILED (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub-01/01_dwi.bvec ... ok (1ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub-01/sub_dwi.json ... ok (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub-01/sub-01_23_run-01_dwi.bval ... ok (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub-01/sub-01_run-01_dwi.vec ... ok (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub-01/sub-01_run-01_dwi.jsn ... ok (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub-01/sub-01_acq_dwi.bval ... ok (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub-01/sub-01_acq-23-singleband_dwi.bvec ... FAILED (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub-01/anat/sub-01_acq-singleband_dwi.json ... ok (1ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub-01/sub-01_recrod-record_acq-singleband_run-01_dwi.bval ... ok (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub_01/sub-01_acq-singleband_run-01_dwi.bvec ... FAILED (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub-01/sub-01_acq-singleband__run-01_dwi.json ... FAILED (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub-01/ses-test/sub-01_ses_test_dwi.bval ... ok (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub-01/ses-test/sb-01_ses-test_dwi.bvec ... ok (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub-01/ses-test/sub-01_ses-test_dw.json ... FAILED (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub-01/ses-test/sub-01_ses-test_run-01_dwi.val ... ok (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub-01/ses-test/sub-01_run-01_dwi.bvec ... FAILED (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub-01/ses-test/ses-test_run-01_dwi.json ... FAILED (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub-01/ses-test/sub-01_ses-test_acq-singleband.bval ... ok (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub-01/ses-test/sub-01_ses-test_acq-singleband_dwi ... ok (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /ses-test/sub-01/sub-01_ses-test_acq_singleband_dwi.json ... FAILED (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub-01/ses-test/sub-02_ses-test_acq-singleband_run-01_dwi.bval ... FAILED (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /sub-01/sub-01_ses-test_acq-singleband_run-01_dwi.bvec ... FAILED (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /ses-test/sub-01_ses-test_acq-singleband_run-01_dwi.json ... FAILED (1ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /measurement_tool_name.tsv ... FAILED (1ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /phentype/measurement_tool_name.josn ... ok (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... /phenotype/measurement_tool_name.jsn ... ok (0ms)
./src/validators/validateFiles.test.ts => test invalid paths ... FAILED (due to 18 failed steps) (11ms)
```

</details>