### PR TITLE
feat: Add FileTree.get method

### DIFF
--- a/bids-validator/src/files/deno.test.ts
+++ b/bids-validator/src/files/deno.test.ts
@@ -2,6 +2,7 @@ import { assert, assertEquals, assertRejects } from '@std/assert'
 import { readAll, readerFromStreamReader } from '@std/io'
 import { basename, dirname, fromFileUrl, join } from '@std/path'
 import { EOL } from '@std/fs'
+import { FileTree } from '../types/filetree.ts'
 import { BIDSFileDeno, readFileTree, UnicodeDecodeError } from './deno.ts'
 import { requestReadPermission } from '../setup/requestPermissions.ts'
 import { FileIgnoreRules } from './ignore.ts'
@@ -67,10 +68,10 @@ Deno.test('Deno implementation of FileTree', async (t) => {
   const tree = await readFileTree(srcdir)
   await t.step('uses POSIX relative paths', async () => {
     assertEquals(tree.path, '/')
-    const parentObj = tree.directories.find((dir) => dir.name === parent)
+    const parentObj = tree.get(parent) as FileTree
     assert(parentObj !== undefined)
     assertEquals(parentObj.path, `/${parent}`)
-    const testObj = parentObj.files.find((file) => file.name === testFilename)
+    const testObj = parentObj.get(testFilename) as BIDSFileDeno
     assert(testObj !== undefined)
     assertEquals(testObj.path, `/${parent}/${testFilename}`)
   })

--- a/bids-validator/src/files/filetree.ts
+++ b/bids-validator/src/files/filetree.ts
@@ -32,7 +32,7 @@ export function filesToTree(fileList: BIDSFile[]): FileTree {
     }
     let current = tree
     for (const level of parts.dir.split(SEPARATOR_PATTERN).slice(1)) {
-      const exists = current.directories.find((dir) => dir.name === level)
+      const exists = current.get(level) as FileTree
       if (exists) {
         current = exists
         continue

--- a/bids-validator/src/schema/context.ts
+++ b/bids-validator/src/schema/context.ts
@@ -246,9 +246,7 @@ export class BIDSContext implements Context {
       .map((dir) => dir.name)
 
     // Load participants from participants.tsv
-    const participants_tsv = this.dataset.tree.files.find(
-      (file) => file.name === 'participants.tsv',
-    )
+    const participants_tsv = this.dataset.tree.get('participants.tsv') as BIDSFile
     if (participants_tsv) {
       const participantsData = await loadTSV(participants_tsv)
       this.dataset.subjects.participant_id = participantsData[
@@ -257,9 +255,7 @@ export class BIDSContext implements Context {
     }
 
     // Load phenotype from phenotype/*.tsv
-    const phenotype_dir = this.dataset.tree.directories.find(
-      (dir) => dir.name === 'phenotype',
-    )
+    const phenotype_dir = this.dataset.tree.get('phenotype') as FileTree
     if (phenotype_dir) {
       const phenotypeFiles = phenotype_dir.files.filter((file) => file.name.endsWith('.tsv'))
       // Collect observed participant_ids

--- a/bids-validator/src/schema/fixtures.test.ts
+++ b/bids-validator/src/schema/fixtures.test.ts
@@ -23,19 +23,15 @@ export const rootFileTree = pathsToTree([
   ...[...Array(10).keys()].map((i) => `/stimuli/stimfile${i}.png`),
 ])
 
-const rootJSONFile = rootFileTree.files.find((f) => f.path === '/T1w.json') as BIDSFile
+const rootJSONFile = rootFileTree.get('T1w.json') as BIDSFile
 rootJSONFile.readBytes = readBytes(rootJson)
 
-const subjectFileTree = rootFileTree.directories.find((d) => d.name === 'sub-01') as FileTree
+const subjectFileTree = rootFileTree.get('sub-01') as FileTree
 const subjectJSONFile = subjectFileTree.files[0] as BIDSFile
 subjectJSONFile.readBytes = readBytes(subjectJson)
 
 const anatFileTree = subjectFileTree.directories[0].directories[0] as FileTree
 
-export const dataFile = anatFileTree.files.find((f) =>
-  f.name === 'sub-01_ses-01_T1w.nii.gz'
-) as BIDSFile
-const anatJSONFile = anatFileTree.files.find((f) =>
-  f.name === 'sub-01_ses-01_T1w.json'
-) as BIDSFile
+export const dataFile = anatFileTree.get('sub-01_ses-01_T1w.nii.gz') as BIDSFile
+const anatJSONFile = anatFileTree.get('sub-01_ses-01_T1w.json') as BIDSFile
 anatJSONFile.readBytes = (size: number) => Promise.resolve(new TextEncoder().encode(anatJson))

--- a/bids-validator/src/schema/walk.ts
+++ b/bids-validator/src/schema/walk.ts
@@ -25,7 +25,7 @@ function pseudoFile(dir: FileTree): BIDSFile {
     size: [...quickWalk(dir)].reduce((acc, file) => acc + file.size, 0),
     ignored: dir.ignored,
     parent: dir.parent as FileTree,
-    viewed: false,
+    viewed: dir.viewed,
     ...nullFile,
   }
 }

--- a/bids-validator/src/tests/local/hed-integration.test.ts
+++ b/bids-validator/src/tests/local/hed-integration.test.ts
@@ -8,24 +8,6 @@ import type { BIDSFile, FileTree } from '../../types/filetree.ts'
 import type { GenericSchema } from '../../types/schema.ts'
 import { hedValidate } from '../../validators/hed.ts'
 
-function getFile(fileTree: FileTree, path: string) {
-  const [current, ...nextPath] = path.split('/')
-  if (nextPath.length === 0) {
-    const target = fileTree.files.find((x) => x.name === current)
-    if (target) {
-      return target
-    }
-    const dirTarget = fileTree.directories.find((x) => x.name === nextPath[0])
-    return dirTarget
-  } else {
-    const nextTree = fileTree.directories.find((x) => x.name === current)
-    if (nextTree) {
-      return getFile(nextTree, nextPath.join('/'))
-    }
-  }
-  return undefined
-}
-
 Deno.test('hed-validator not triggered', async (t) => {
   const PATH = 'tests/data/bids-examples/ds003'
   const tree = await readFileTree(PATH)
@@ -36,7 +18,7 @@ Deno.test('hed-validator not triggered', async (t) => {
     },
   })
   await t.step('detect hed returns false', async () => {
-    const eventFile = getFile(tree, 'sub-01/func/sub-01_task-rhymejudgment_events.tsv')
+    const eventFile = tree.get('sub-01/func/sub-01_task-rhymejudgment_events.tsv')
     assert(eventFile !== undefined)
     assert(eventFile instanceof BIDSFileDeno)
     const context = new BIDSContext(eventFile, dsContext)
@@ -56,7 +38,7 @@ Deno.test('hed-validator fails with bad schema version', async (t) => {
     },
   })
   await t.step('detect hed returns false', async () => {
-    const eventFile = getFile(tree, 'sub-002/eeg/sub-002_task-FacePerception_run-3_events.tsv')
+    const eventFile = tree.get('sub-002/eeg/sub-002_task-FacePerception_run-3_events.tsv')
     assert(eventFile !== undefined)
     assert(eventFile instanceof BIDSFileDeno)
     const context = new BIDSContext(eventFile, dsContext)

--- a/bids-validator/src/validators/bids.ts
+++ b/bids-validator/src/validators/bids.ts
@@ -48,9 +48,7 @@ export async function validate(
   /* There should be a dataset_description in root, this will tell us if we
    * are dealing with a derivative dataset
    */
-  const ddFile = fileTree.files.find(
-    (file: BIDSFile) => file.name === 'dataset_description.json',
-  )
+  const ddFile = fileTree.get('dataset_description.json') as BIDSFile
 
   const dsContext = new BIDSContextDataset({ options, schema, tree: fileTree })
   if (ddFile) {
@@ -73,11 +71,7 @@ export async function validate(
       return true
     }
     for (const deriv of dir.directories) {
-      if (
-        deriv.files.some(
-          (file: BIDSFile) => file.name === 'dataset_description.json',
-        )
-      ) {
+      if (deriv.get('dataset_description.json')) {
         // New root for the derivative dataset
         deriv.parent = undefined
         bidsDerivatives.push(deriv)

--- a/bids-validator/src/validators/internal/unusedFile.ts
+++ b/bids-validator/src/validators/internal/unusedFile.ts
@@ -22,7 +22,7 @@ export async function unusedStimulus(
   schema: GenericSchema,
   dsContext: BIDSContextDataset,
 ) {
-  const stimDir = dsContext.tree.directories.find((dir) => dir.name === 'stimuli')
+  const stimDir = dsContext.tree.get('stimuli') as FileTree
   const unusedStimuli = [...walkFileTree(stimDir)].filter((stimulus) => !stimulus.viewed)
   if (unusedStimuli.length) {
     dsContext.issues.add({ code: 'UNUSED_STIMULUS', affects: unusedStimuli.map((s) => s.path) })


### PR DESCRIPTION
Adds a `FileTree.get()` for relative paths, abstracting the search features of `FileTree.contains()` into a common `_get()` method.

Builds on (actually should be pretty orthogonal to, but I don't want to deal with merge conflicts) #2082. Don't bother reviewing until that's merged, and I'll rebase to keep this clean.