### PR TITLE
feat: Hack around missing round() function

### DIFF
--- a/bids-validator/src/files/nifti.ts
+++ b/bids-validator/src/files/nifti.ts
@@ -46,7 +46,8 @@ export async function loadHeader(file: BIDSFile): Promise<NiftiHeader> {
     const ndim = header.dims[0]
     return {
       dim: header.dims,
-      pixdim: header.pixDims,
+      // Hack: round pixdim to 3 decimal places; schema should add rounding function
+      pixdim: header.pixDims.map((pixdim) => Math.round(pixdim * 1000) / 1000),
       shape: header.dims.slice(1, ndim + 1),
       voxel_sizes: header.pixDims.slice(1, ndim + 1),
       dim_info: {

--- a/bids-validator/src/schema/context.ts
+++ b/bids-validator/src/schema/context.ts
@@ -197,6 +197,10 @@ export class BIDSContext implements Context {
       this.sidecar = { ...json, ...this.sidecar }
       Object.keys(json).map((x) => this.sidecarKeyOrigin[x] ??= file.path)
     }
+    // Hack: round RepetitionTime to 3 decimal places; schema should add rounding function
+    if (typeof this.sidecar.RepetitionTime === 'number') {
+      this.sidecar.RepetitionTime = Math.round(this.sidecar.RepetitionTime * 1000) / 1000
+    }
   }
 
   async loadNiftiHeader(): Promise<void> {


### PR DESCRIPTION
Short-term fix for #2091. We should add a `round()` function to the schema and implement it here.