### PR TITLE
feat(cli): Add configuration file

### DIFF
--- a/bids-validator/src/README.md
+++ b/bids-validator/src/README.md
@@ -18,6 +18,26 @@ $ deno run --allow-read --allow-env https://deno.land/x/bids_validator/bids-vali
 
 Deno by default sandboxes applications like a web browser. `--allow-read` allows the validator to read local files, and `--allow-env` enables OS-specific features.
 
+### Configuration file
+
+The schema validator accepts a JSON configuration file that reclassifies issues as
+warnings, errors or ignored.
+
+```json
+{
+  "ignore": [
+    { "code": "JSON_KEY_RECOMMENDED", "location": "/T1w.json" }
+  ],
+  "warn": [],
+  "error": [
+    { "code": "NO_AUTHORS" }
+  ]
+}
+```
+
+The issues are partial matches of the `issues` that the validator accumulates.
+Pass the `--json` flag to see the issues in detail.
+
 ### Development tools
 
 From the repository root, use `bids-validator/bids-validator-deno` to run with all permissions enabled by default:

--- a/bids-validator/src/README.md
+++ b/bids-validator/src/README.md
@@ -28,7 +28,7 @@ warnings, errors or ignored.
   "ignore": [
     { "code": "JSON_KEY_RECOMMENDED", "location": "/T1w.json" }
   ],
-  "warn": [],
+  "warning": [],
   "error": [
     { "code": "NO_AUTHORS" }
   ]

--- a/bids-validator/src/main.ts
+++ b/bids-validator/src/main.ts
@@ -1,4 +1,5 @@
 import { parseOptions } from './setup/options.ts'
+import type { Config } from './setup/options.ts'
 import * as colors from '@std/fmt/colors'
 import { readFileTree } from './files/deno.ts'
 import { fileListToTree } from './files/browser.ts'
@@ -12,11 +13,14 @@ export async function main(): Promise<ValidationResult> {
   const options = await parseOptions(Deno.args)
   colors.setColorEnabled(options.color ?? false)
   setupLogging(options.debug)
+
   const absolutePath = resolve(options.datasetPath)
   const tree = await readFileTree(absolutePath)
 
+  const config = options.config ? JSON.parse(Deno.readTextFileSync(options.config)) as Config : {}
+
   // Run the schema based validator
-  const schemaResult = await validate(tree, options)
+  const schemaResult = await validate(tree, options, config)
 
   if (options.json) {
     console.log(

--- a/bids-validator/src/setup/options.ts
+++ b/bids-validator/src/setup/options.ts
@@ -2,12 +2,10 @@ import { LogLevelNames } from '@std/log'
 import type { LevelName } from '@std/log'
 import { Command, EnumType } from '@cliffy/command'
 import { getVersion } from '../version.ts'
-import type { Issue } from '../types/issues.ts'
+import type { Issue, Severity } from '../types/issues.ts'
 
 export type Config = {
-  ignore?: Partial<Issue>[]
-  warn?: Partial<Issue>[]
-  error?: Partial<Issue>[]
+  [key in Severity]?: Partial<Issue>[]
 }
 
 export type ValidatorOptions = {

--- a/bids-validator/src/setup/options.ts
+++ b/bids-validator/src/setup/options.ts
@@ -1,11 +1,19 @@
-import { type LevelName, LogLevelNames } from '@std/log'
+import { LogLevelNames } from '@std/log'
+import type { LevelName } from '@std/log'
 import { Command, EnumType } from '@cliffy/command'
 import { getVersion } from '../version.ts'
+import type { Issue } from '../types/issues.ts'
+
+export type Config = {
+  ignore?: Partial<Issue>[]
+  warn?: Partial<Issue>[]
+  error?: Partial<Issue>[]
+}
 
 export type ValidatorOptions = {
   datasetPath: string
   schema?: string
-  legacy?: boolean
+  config?: string
   json?: boolean
   verbose?: boolean
   ignoreNiftiHeaders?: boolean
@@ -29,19 +37,20 @@ const validateCommand = new Command()
   .arguments('<dataset_directory>')
   .option('--json', 'Output machine readable JSON')
   .option(
-    '-s, --schema <type:string>',
+    '-s, --schema <URL-or-tag:string>',
     'Specify a schema version to use for validation',
     {
       default: 'latest',
     },
   )
+  .option('-c, --config <file:string>', 'Path to a JSON configuration file')
   .option('-v, --verbose', 'Log more extensive information about issues')
   .option('--ignoreWarnings', 'Disregard non-critical issues')
   .option(
     '--ignoreNiftiHeaders',
     'Disregard NIfTI header content during validation',
   )
-  .option('--debug <type:debugLevel>', 'Enable debug output', {
+  .option('--debug <level:debugLevel>', 'Enable debug output', {
     default: 'ERROR',
   })
   .option(

--- a/bids-validator/src/tests/local/common.ts
+++ b/bids-validator/src/tests/local/common.ts
@@ -5,12 +5,13 @@ import type { ValidationResult } from '../../types/validation-result.ts'
 import type { Issue } from '../../types/issues.ts'
 import { DatasetIssues } from '../../issues/datasetIssues.ts'
 import { Summary } from '../../summary/summary.ts'
-import { parseOptions, type ValidatorOptions } from '../../setup/options.ts'
+import { type Config, parseOptions, type ValidatorOptions } from '../../setup/options.ts'
 
 export async function validatePath(
   t: Deno.TestContext,
   path: string,
   options: Partial<ValidatorOptions> = {},
+  config: Config = {},
 ): Promise<{ tree: FileTree; result: ValidationResult }> {
   let tree: FileTree = new FileTree('', '')
   const summary = new Summary()
@@ -27,7 +28,7 @@ export async function validatePath(
     result = await validate(tree, {
       ...(await parseOptions([path])),
       ...options,
-    })
+    }, config)
   })
 
   return { tree, result }

--- a/bids-validator/src/types/issues.ts
+++ b/bids-validator/src/types/issues.ts
@@ -1,7 +1,6 @@
 import type { BIDSFile } from './filetree.ts'
 
-const all_severities = ['warning', 'error', 'ignore'] as const
-export type Severity = typeof all_severities[number]
+export type Severity = 'warning' | 'error' | 'ignore'
 
 /**
  * Updated internal Issue structure for schema based validation

--- a/bids-validator/src/validators/bids.test.ts
+++ b/bids-validator/src/validators/bids.test.ts
@@ -41,4 +41,24 @@ Deno.test('Smoke tests of main validation function', async (t) => {
     })
     assert(result.issues.get({ code: 'BLACKLISTED_MODALITY' }).length === 1)
   })
+  await t.step('Validate configuration', async () => {
+    let result = await validate(
+      dataset,
+      {
+        datasetPath: '/dataset',
+        debug: 'INFO',
+        blacklistModalities: [],
+      },
+      {
+        ignore: [{ location: '/dataset_description.json' }],
+      },
+    )
+    let errors = result.issues.filter({ severity: 'error' })
+    let warnings = result.issues.filter({ severity: 'warning' })
+    let ignored = result.issues.filter({ severity: 'ignore' })
+    assert(errors.get({ code: 'JSON_KEY_RECOMMENDED' }).length === 0)
+    assert(ignored.get({ code: 'JSON_KEY_RECOMMENDED' }).length > 0)
+    assert(errors.get({ location: '/dataset_description.json' }).length === 0)
+    assert(warnings.get({ location: '/dataset_description.json' }).length === 0)
+  })
 })

--- a/bids-validator/src/validators/bids.ts
+++ b/bids-validator/src/validators/bids.ts
@@ -137,7 +137,7 @@ export async function validate(
   )
 
   if (config) {
-    for (const level of ['ignore', 'warn', 'error'] as const) {
+    for (const level of ['ignore', 'warning', 'error'] as const) {
       for (const filter of config[level] ?? []) {
         for (const issue of dsContext.issues.filter(filter).issues) {
           issue.severity = level as Severity

--- a/bids-validator/src/validators/bids.ts
+++ b/bids-validator/src/validators/bids.ts
@@ -1,13 +1,13 @@
 import type { ContextCheckFunction, DSCheckFunction } from '../types/check.ts'
 import type { BIDSFile, FileTree } from '../types/filetree.ts'
 import { loadJSON } from '../files/json.ts'
-import type { IssueFile } from '../types/issues.ts'
+import type { IssueFile, Severity } from '../types/issues.ts'
 import type { GenericSchema } from '../types/schema.ts'
 import type { ValidationResult } from '../types/validation-result.ts'
 import { applyRules } from '../schema/applyRules.ts'
 import { walkFileTree } from '../schema/walk.ts'
 import { loadSchema } from '../setup/loadSchema.ts'
-import type { ValidatorOptions } from '../setup/options.ts'
+import type { Config, ValidatorOptions } from '../setup/options.ts'
 import { Summary } from '../summary/summary.ts'
 import { filenameIdentify } from './filenameIdentify.ts'
 import { filenameValidate } from './filenameValidate.ts'
@@ -40,6 +40,7 @@ const perDSChecks: DSCheckFunction[] = [
 export async function validate(
   fileTree: FileTree,
   options: ValidatorOptions,
+  config?: Config,
 ): Promise<ValidationResult> {
   const summary = new Summary()
   const schema = await loadSchema(options.schema)
@@ -134,6 +135,16 @@ export async function validate(
       return derivativesSummary[deriv.name]
     }),
   )
+
+  if (config) {
+    for (const level of ['ignore', 'warn', 'error'] as const) {
+      for (const filter of config[level] ?? []) {
+        for (const issue of dsContext.issues.filter(filter).issues) {
+          issue.severity = level as Severity
+        }
+      }
+    }
+  }
 
   if (options.ignoreWarnings) {
     dsContext.issues = dsContext.issues.filter({ severity: 'error' })


### PR DESCRIPTION
Introduces a configuration file. The configuration file maps severities (`ignore`, `warning`, `error`) onto lists of partial issues. The partial issues are used to filter the issue list, and the severity of all matching issues are updated.

This is done in order of `ignore`, `warning`, `error`, so any issue that matches multiple will end with the highest severity.

Closes https://github.com/bids-standard/bids-validator/issues/1937.