### PR TITLE
Add flag for validating derivatives inside /derivatives/

### DIFF
--- a/bids-validator/src/setup/options.ts
+++ b/bids-validator/src/setup/options.ts
@@ -13,6 +13,7 @@ export type ValidatorOptions = {
   filenameMode?: boolean
   debug: LevelName
   color?: boolean
+  recursive?: boolean
   blacklistModalities: string[]
 }
 
@@ -54,6 +55,11 @@ const validateCommand = new Command()
     'Array of modalities to error on if detected.',
     { default: [] as string[] },
   )
+  .option(
+    '-r, --recursive',
+    'Validate datasets found in derivatives directories in addition to root dataset',
+  )
+
 
 // Disabling color output is only available in Deno
 if (typeof Deno !== 'undefined') {

--- a/bids-validator/src/tests/local/derivatives.test.ts
+++ b/bids-validator/src/tests/local/derivatives.test.ts
@@ -1,0 +1,13 @@
+import { assert } from '@std/assert'
+import { validatePath } from './common.ts'
+import { parseOptions } from '../../setup/options.ts'
+
+Deno.test('recursive option works as expected', async (t) => {
+  const path = 'tests/data/bids-examples/qmri_mp2rage/'
+  let options = await parseOptions(['fake_dataset_arg', ...Deno.args])
+  let result = await validatePath(t, path, options)
+  assert(!Object.hasOwn(result.result, 'derivativesSummary'))
+  options = await parseOptions(['fake_dataset_arg', ...Deno.args, '-r'])
+  result = await validatePath(t, path, options)
+  assert(Object.hasOwn(result.result, 'derivativesSummary'))
+})

--- a/bids-validator/src/validators/bids.ts
+++ b/bids-validator/src/validators/bids.ts
@@ -128,12 +128,14 @@ export async function validate(
   })
 
   const derivativesSummary: Record<string, ValidationResult> = {}
-  await Promise.allSettled(
-    bidsDerivatives.map(async (deriv) => {
-      derivativesSummary[deriv.name] = await validate(deriv, options)
-      return derivativesSummary[deriv.name]
-    }),
-  )
+  if (options.recursive) {
+    await Promise.allSettled(
+      bidsDerivatives.map(async (deriv) => {
+        derivativesSummary[deriv.name] = await validate(deriv, options)
+        return derivativesSummary[deriv.name]
+      }),
+    )
+  }
 
   if (options.ignoreWarnings) {
     dsContext.issues = dsContext.issues.filter({ severity: 'error' })


### PR DESCRIPTION
Makes it so nested derivatives are *not* validated by default. Adds a recursive flag to re-enable old behavior.