### PR TITLE
fix: Load schema with fetch, default to JSR package

### DIFF
--- a/bids-validator/deno.json
+++ b/bids-validator/deno.json
@@ -28,7 +28,7 @@
     "@std/log": "jsr:@std/log@0.224.5",
     "@std/path": "jsr:@std/path@1.0.2",
     "@ajv": "npm:ajv@8.16.0",
-    "@bids/schema": "jsr:@bids/schema@0.0.202408141737",
+    "@bids/schema": "jsr:@bids/schema@0.11.1-dev.2+aa884b7e",
     "@cliffy/table": "jsr:@cliffy/table@1.0.0-rc.5",
     "@cliffy/command": "jsr:@cliffy/command@1.0.0-rc.5",
     "@hed/validator": "npm:hed-validator@3.15.4",

--- a/bids-validator/src/setup/options.test.ts
+++ b/bids-validator/src/setup/options.test.ts
@@ -8,7 +8,6 @@ Deno.test('options parsing', async (t) => {
       datasetPath: 'my_dataset',
       debug: 'ERROR',
       json: true,
-      schema: 'latest',
       color: false,
       blacklistModalities: [],
     })

--- a/bids-validator/src/setup/options.ts
+++ b/bids-validator/src/setup/options.ts
@@ -38,9 +38,6 @@ const validateCommand = new Command()
   .option(
     '-s, --schema <URL-or-tag:string>',
     'Specify a schema version to use for validation',
-    {
-      default: 'latest',
-    },
   )
   .option('-c, --config <file:string>', 'Path to a JSON configuration file')
   .option('-v, --verbose', 'Log more extensive information about issues')


### PR DESCRIPTION
The current version emits a more-or-less obligatory error due to the use of `import` with an https URL. That seems like a thing of Deno past.

Given that we're hosting the schema at the JSR, let's go ahead and default to that. If someone wants to provide a URL, then a fetch can be done and the JSON can be loaded. This means BIDS_SCHEMA pointing to local files will need to use `file:///...`, but that seems fine.