### PR TITLE
build: Include exports for extending validator in JSR packaging

### DIFF
--- a/bids-validator/deno.json
+++ b/bids-validator/deno.json
@@ -1,7 +1,13 @@
 {
   "name": "@bids/validator",
   "version": "1.14.10",
-  "exports": "./src/bids-validator.ts",
+  "exports": {
+    ".": "./src/bids-validator.ts",
+    "./main": "./src/main.ts",
+    "./output": "./src/utils/output.ts",
+    "./files": "./src/files/deno.ts",
+    "./options": "./src/setup/options.ts"
+  },
   "publish": {
     "exclude": [
       "bids_validator/",


### PR DESCRIPTION
These exports are used by OpenNeuro's CLI to extend the Deno validator.