### PR TITLE
chore: Import schema and base types from @bids/schema/.

### DIFF
--- a/bids-validator/deno.json
+++ b/bids-validator/deno.json
@@ -28,7 +28,7 @@
     "@std/log": "jsr:@std/log@0.224.5",
     "@std/path": "jsr:@std/path@1.0.2",
     "@ajv": "npm:ajv@8.16.0",
-    "@bids/schema": "jsr:@bids/schema@0.11.1-dev.2+aa884b7e",
+    "@bids/schema": "jsr:@bids/schema@0.11.1-dev.4+a73c1b06",
     "@cliffy/table": "jsr:@cliffy/table@1.0.0-rc.5",
     "@cliffy/command": "jsr:@cliffy/command@1.0.0-rc.5",
     "@hed/validator": "npm:hed-validator@3.15.4",

--- a/bids-validator/src/files/inheritance.ts
+++ b/bids-validator/src/files/inheritance.ts
@@ -1,5 +1,5 @@
 import type { BIDSFile, FileTree } from '../types/filetree.ts'
-import type { Context } from '@bids/schema/context'
+import type { Context } from '@bids/schema'
 import { readEntities } from '../schema/entities.ts'
 
 export function* walkBack(

--- a/bids-validator/src/setup/loadSchema.ts
+++ b/bids-validator/src/setup/loadSchema.ts
@@ -1,6 +1,6 @@
 import type { Schema } from '../types/schema.ts'
 import { objectPathHandler } from '../utils/objectPathHandler.ts'
-import { default as schemaDefault } from '@bids/schema/schema' with { type: 'json' }
+import { schema as schemaDefault } from '@bids/schema'
 import { setCustomMetadataFormats } from '../validators/json.ts'
 
 /**


### PR DESCRIPTION
I updated the jsr-dist branch so that `schema` can be imported without caring that it's JSON: https://github.com/bids-standard/bids-specification/blob/jsr-dist/mod.ts