### PR TITLE
chore: Add docstrings and export missing validateCommand object

### DIFF
--- a/bids-validator/src/main.ts
+++ b/bids-validator/src/main.ts
@@ -9,6 +9,11 @@ import { consoleFormat } from './utils/output.ts'
 import { setupLogging } from './utils/logger.ts'
 import type { ValidationResult } from './types/validation-result.ts'
 
+/**
+ * Validation entrypoint intended for command line usage with Deno
+ *
+ * Parses command line options, runs validation, and formats the result. Call `validate` directly for other environments
+ */
 export async function main(): Promise<ValidationResult> {
   const options = await parseOptions(Deno.args)
   colors.setColorEnabled(options.color ?? false)

--- a/bids-validator/src/setup/options.ts
+++ b/bids-validator/src/setup/options.ts
@@ -4,10 +4,16 @@ import { Command, EnumType } from '@cliffy/command'
 import { getVersion } from '../version.ts'
 import type { Issue, Severity } from '../types/issues.ts'
 
+/**
+ * BIDS Validator config file object definition
+ */
 export type Config = {
   [key in Severity]?: Partial<Issue>[]
 }
 
+/**
+ * BIDS Validator options object definition
+ */
 export type ValidatorOptions = {
   datasetPath: string
   schema?: string
@@ -27,7 +33,8 @@ const modalityType = new EnumType<string>(
   ['MRI', 'PET', 'MEG', 'EEG', 'iEEG', 'Microscopy', 'NIRS', 'MRS'],
 )
 
-const validateCommand = new Command()
+/** Extendable Cliffy Command with built in BIDS validator options */
+export const validateCommand = new Command()
   .name('bids-validator')
   .type('debugLevel', new EnumType(LogLevelNames))
   .description(


### PR DESCRIPTION
The options -> validateCommand export that OpenNeuro CLI depends on was missing. Added docstrings for all the JSR exports.