### PR TITLE
Map issues through the Issue constructor

### DIFF
--- a/bids-validator/validators/hed.js
+++ b/bids-validator/validators/hed.js
@@ -3,7 +3,12 @@ import utils from '../utils'
 
 const Issue = utils.issues.Issue
 
-export default async function checkHedStrings(tsvs, jsonContents, jsonFiles) {
+export default async function returnHedIssues(tsvs, jsonContents, jsonFiles) {
+  const issues = await checkHedStrings(tsvs, jsonContents, jsonFiles)
+  return issues.map((issue) => new Issue(issue))
+}
+
+async function checkHedStrings(tsvs, jsonContents, jsonFiles) {
   const datasetDescription = jsonContents['/dataset_description.json']
   const datasetDescriptionData = new hedValidator.bids.BidsJsonFile(
     '/dataset_description.json',


### PR DESCRIPTION
The direct use of `BidsIssue`/`BidsHedIssue` from `hed-validator` was causing issues with downstream tools. Converting them to plain Issue objects should fix this problem.

Fixes #2142