### PR TITLE
FIX: Disable strictSchema for legacy validator JSON schema validation

### DIFF
--- a/bids-validator/validators/json/json.js
+++ b/bids-validator/validators/json/json.js
@@ -1,6 +1,8 @@
 import utils from '../../utils'
 import Ajv from 'ajv'
-const ajv = new Ajv({ allErrors: true })
+import addFormats from "ajv-formats"
+const ajv = new Ajv({ allErrors: true, strictSchema: false })
+addFormats(ajv)
 ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-06.json'))
 ajv.addSchema(require('./schemas/common_definitions.json'))
 const Issue = utils.issues.Issue

--- a/bids-validator/validators/json/json.js
+++ b/bids-validator/validators/json/json.js
@@ -1,8 +1,6 @@
 import utils from '../../utils'
 import Ajv from 'ajv'
-import addFormats from "ajv-formats"
 const ajv = new Ajv({ allErrors: true, strictSchema: false })
-addFormats(ajv)
 ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-06.json'))
 ajv.addSchema(require('./schemas/common_definitions.json'))
 const Issue = utils.issues.Issue


### PR DESCRIPTION
Pinning to old version of AJV maybe the better path here, not sure.