### PR TITLE
Pass value of ignore test to creation of filetree object.

### DIFF
--- a/bids-validator/src/files/browser.ts
+++ b/bids-validator/src/files/browser.ts
@@ -57,7 +57,7 @@ export async function fileListToTree(files: File[]): Promise<FileTree> {
   if (bidsignore) {
     try {
       ignore.add(await readBidsIgnore(bidsignore as BIDSFile))
-    } catch(err) {
+    } catch (err) {
       console.log(`Failed to read '.bidsignore' file with the following error:\n${err}`)
     }
   }

--- a/bids-validator/src/files/browser.ts
+++ b/bids-validator/src/files/browser.ts
@@ -55,7 +55,11 @@ export async function fileListToTree(files: File[]): Promise<FileTree> {
   const tree = filesToTree(files.map((f) => new BIDSFileBrowser(f, ignore, root)))
   const bidsignore = tree.get('.bidsignore')
   if (bidsignore) {
-    ignore.add(await readBidsIgnore(bidsignore as BIDSFile))
+    try {
+      ignore.add(await readBidsIgnore(bidsignore as BIDSFile))
+    } catch(err) {
+      console.log(`Failed to read '.bidsignore' file with the following error:\n${err}`)
+    }
   }
   return tree
 }

--- a/bids-validator/src/files/deno.ts
+++ b/bids-validator/src/files/deno.ts
@@ -119,7 +119,7 @@ async function _readFileTree(
 ): Promise<FileTree> {
   await requestReadPermission()
   const name = basename(relativePath)
-  const tree = new FileTree(relativePath, name, parent)
+  const tree = new FileTree(relativePath, name, parent, ignore.test(join(rootPath, relativePath)))
 
   for await (const dirEntry of Deno.readDir(join(rootPath, relativePath))) {
     if (dirEntry.isFile || dirEntry.isSymlink) {

--- a/bids-validator/src/files/deno.ts
+++ b/bids-validator/src/files/deno.ts
@@ -2,6 +2,7 @@
  * Deno specific implementation for reading files
  */
 import { basename, join } from '@std/path'
+import { existsSync } from '@std/fs'
 import * as posix from '@std/path/posix'
 import { type BIDSFile, FileTree } from '../types/filetree.ts'
 import { requestReadPermission } from '../setup/requestPermissions.ts'
@@ -149,16 +150,13 @@ async function _readFileTree(
  */
 export async function readFileTree(rootPath: string): Promise<FileTree> {
   const ignore = new FileIgnoreRules([])
-  if (globalThis.Deno) {
-    import { existsSync } from '@std/fs'
-    if (existsSync(join(rootPath, '.bidsignore'))) {
-          const ignoreFile = new BIDSFileDeno(
-            rootPath,
-            '.bidsignore',
-            ignore,
-          )
-          ignore.add(await readBidsIgnore(ignoreFile))
-    }
+  if (existsSync(join(rootPath, '.bidsignore'))) {
+        const ignoreFile = new BIDSFileDeno(
+          rootPath,
+          '.bidsignore',
+          ignore,
+        )
+        ignore.add(await readBidsIgnore(ignoreFile))
   }
   return _readFileTree(rootPath, '/', ignore)
 }

--- a/bids-validator/src/files/deno.ts
+++ b/bids-validator/src/files/deno.ts
@@ -148,10 +148,15 @@ async function _readFileTree(
 /**
  * Read in the target directory structure and return a FileTree
  */
-export function readFileTree(rootPath: string): Promise<FileTree> {
+export async function readFileTree(rootPath: string): Promise<FileTree> {
   const ignore = new FileIgnoreRules([])
   if (existsSync(join(rootPath, '.bidsignore'))) {
-        ignore.add(readBidsIgnore(join(rootPath, '.bidsignore')))
+        const ignoreFile = new BIDSFileDeno(
+          rootPath,
+          '.bidsignore',
+          ignore,
+        )
+        ignore.add(await readBidsIgnore(ignoreFile))
   }
   return _readFileTree(rootPath, '/', ignore)
 }

--- a/bids-validator/src/files/deno.ts
+++ b/bids-validator/src/files/deno.ts
@@ -151,14 +151,14 @@ async function _readFileTree(
 export async function readFileTree(rootPath: string): Promise<FileTree> {
   const ignore = new FileIgnoreRules([])
   try {
-        const ignoreFile = new BIDSFileDeno(
-          rootPath,
-          '.bidsignore',
-          ignore,
-        )
-        ignore.add(await readBidsIgnore(ignoreFile))
+    const ignoreFile = new BIDSFileDeno(
+      rootPath,
+      '.bidsignore',
+      ignore,
+    )
+    ignore.add(await readBidsIgnore(ignoreFile))
   } catch (err) {
-    if (!Object.hasOwn(err, 'code') || err.code !== "ENOENT") {
+    if (!Object.hasOwn(err, 'code') || err.code !== 'ENOENT') {
       logger.error(`Failed to read '.bidsignore' file with the following error:\n${err}`)
     }
   }

--- a/bids-validator/src/files/deno.ts
+++ b/bids-validator/src/files/deno.ts
@@ -6,6 +6,7 @@ import * as posix from '@std/path/posix'
 import { type BIDSFile, FileTree } from '../types/filetree.ts'
 import { requestReadPermission } from '../setup/requestPermissions.ts'
 import { FileIgnoreRules, readBidsIgnore } from './ignore.ts'
+import { logger } from '../utils/logger.ts'
 
 /**
  * Thrown when a text file is decoded as UTF-8 but contains UTF-16 characters
@@ -157,8 +158,8 @@ export async function readFileTree(rootPath: string): Promise<FileTree> {
         )
         ignore.add(await readBidsIgnore(ignoreFile))
   } catch (err) {
-    if (!(Object.hasOwn(err, 'code') && err.code === "ENOENT")) {
-      throw err
+    if (!Object.hasOwn(err, 'code') || err.code !== "ENOENT") {
+      logger.error(`Failed to read '.bidsignore' file with the following error:\n${err}`)
     }
   }
   return _readFileTree(rootPath, '/', ignore)

--- a/bids-validator/src/files/deno.ts
+++ b/bids-validator/src/files/deno.ts
@@ -2,7 +2,6 @@
  * Deno specific implementation for reading files
  */
 import { basename, join } from '@std/path'
-import { existsSync } from '@std/fs'
 import * as posix from '@std/path/posix'
 import { type BIDSFile, FileTree } from '../types/filetree.ts'
 import { requestReadPermission } from '../setup/requestPermissions.ts'
@@ -150,13 +149,16 @@ async function _readFileTree(
  */
 export async function readFileTree(rootPath: string): Promise<FileTree> {
   const ignore = new FileIgnoreRules([])
-  if (existsSync(join(rootPath, '.bidsignore'))) {
-        const ignoreFile = new BIDSFileDeno(
-          rootPath,
-          '.bidsignore',
-          ignore,
-        )
-        ignore.add(await readBidsIgnore(ignoreFile))
+  if (globalThis.Deno) {
+    import { existsSync } from '@std/fs'
+    if (existsSync(join(rootPath, '.bidsignore'))) {
+          const ignoreFile = new BIDSFileDeno(
+            rootPath,
+            '.bidsignore',
+            ignore,
+          )
+          ignore.add(await readBidsIgnore(ignoreFile))
+    }
   }
   return _readFileTree(rootPath, '/', ignore)
 }

--- a/bids-validator/src/files/ignore.ts
+++ b/bids-validator/src/files/ignore.ts
@@ -2,8 +2,8 @@ import type { BIDSFile } from '../types/filetree.ts'
 import { default as ignore } from '@ignore'
 import type { Ignore } from '@ignore'
 
-export async function readBidsIgnore(file: BIDSFile) {
-  const value = await file.text()
+export function readBidsIgnore(file: string) {
+  const value = Deno.readTextFileSync(file)
   if (value) {
     const lines = value.split('\n')
     return lines

--- a/bids-validator/src/files/ignore.ts
+++ b/bids-validator/src/files/ignore.ts
@@ -2,8 +2,8 @@ import type { BIDSFile } from '../types/filetree.ts'
 import { default as ignore } from '@ignore'
 import type { Ignore } from '@ignore'
 
-export function readBidsIgnore(file: string) {
-  const value = Deno.readTextFileSync(file)
+export async function readBidsIgnore(file: BIDSFile) {
+  const value = await file.text()
   if (value) {
     const lines = value.split('\n')
     return lines

--- a/bids-validator/src/schema/applyRules.ts
+++ b/bids-validator/src/schema/applyRules.ts
@@ -221,7 +221,7 @@ function evalJsonCheck(
     }
 
     if (sidecarRule && !(keyName in context.sidecarKeyOrigin)) {
-      logger.warning(
+      logger.warn(
         `sidecarKeyOrigin map failed to initialize for ${context.path} on key ${keyName}. Validation caching not active for this key.`,
       )
     }

--- a/bids-validator/src/schema/context.ts
+++ b/bids-validator/src/schema/context.ts
@@ -225,7 +225,7 @@ export class BIDSContext implements Context {
         if (error.key) {
           this.dataset.issues.add({ code: error.key, location: this.file.path })
         }
-        logger.warning(
+        logger.warn(
           `tsv file could not be opened by loadColumns '${this.file.path}'`,
         )
         logger.debug(error)

--- a/bids-validator/src/types/filetree.ts
+++ b/bids-validator/src/types/filetree.ts
@@ -1,3 +1,5 @@
+import { FileIgnoreRules } from '../files/ignore.ts'
+
 export interface BIDSFile {
   // Filename
   name: string
@@ -29,18 +31,22 @@ export class FileTree {
   name: string
   files: BIDSFile[]
   directories: FileTree[]
-  ignored: boolean
   viewed: boolean
   parent?: FileTree
+  #ignore: FileIgnoreRules
 
-  constructor(path: string, name: string, parent?: FileTree, ignored?: boolean) {
+  constructor(path: string, name: string, parent?: FileTree, ignore?: FileIgnoreRules) {
     this.path = path
     this.files = []
     this.directories = []
     this.name = name
     this.parent = parent
     this.viewed = false
-    this.ignored = ignored || false
+    this.#ignore = ignore ?? new FileIgnoreRules([])
+  }
+
+  get ignored(): boolean {
+    return this.#ignore.test(this.path)
   }
 
   _get(parts: string[]): BIDSFile | FileTree | undefined {

--- a/bids-validator/src/validators/bids.ts
+++ b/bids-validator/src/validators/bids.ts
@@ -70,6 +70,9 @@ export async function validate(
   const bidsDerivatives: FileTree[] = []
   const nonstdDerivatives: FileTree[] = []
   fileTree.directories = fileTree.directories.filter((dir) => {
+    if (['sourcedata', 'code'].includes(dir.name)) {
+      return false
+    }
     if (dir.name !== 'derivatives') {
       return true
     }

--- a/bids-validator/src/validators/json.ts
+++ b/bids-validator/src/validators/json.ts
@@ -10,7 +10,7 @@ export const compile = memoize(metadataValidator.compile.bind(metadataValidator)
 
 export function setCustomMetadataFormats(schema: Schema): void {
   if (typeof schema.objects.formats !== 'object') {
-    logger.warning(
+    logger.warn(
       `schema.objects.formats missing from schema, format validation disabled.`,
     )
     return
@@ -19,7 +19,7 @@ export function setCustomMetadataFormats(schema: Schema): void {
   for (const key of Object.keys(schemaFormats)) {
     const pattern = schemaFormats[key]['pattern']
     if (typeof pattern !== 'string') {
-      logger.warning(
+      logger.warn(
         `schema.objects.formats.${key} pattern missing or invalid. Skipping this format for addition to context json validator`,
       )
       continue


### PR DESCRIPTION
Certain directories get contexts during calls to walk, ignore test needs to be run and set before then. Noticed certain directories in sourcedata of ds004720 triggering NOT_INCLUDED errors.

I still need to write tests for this.

Fixes https://github.com/bids-standard/bids-validator/issues/2127.