### PR TITLE
fix: avoid Maximum call stack size exceeded

### DIFF
--- a/bids-validator/validators/session.js
+++ b/bids-validator/validators/session.js
@@ -11,15 +11,12 @@ import isNode from '../utils/isNode'
  * files from the set.
  */
 const session = function missingSessionFiles(fileList) {
-  const issues = []
   const { subjects, sessions } = getDataOrganization(fileList)
-
-  issues.push(...missingSessionWarnings(subjects, sessions))
-
   const subject_files = getSubjectFiles(subjects)
-  issues.push(...missingFileWarnings(subjects, subject_files))
-
-  return issues
+  return [
+    ...missingSessionWarnings(subjects, sessions),
+    ...missingFileWarnings(subjects, subject_files),
+  ]
 }
 
 /**


### PR DESCRIPTION
Using spread syntax (`...SomeIterable`) with a long list inside a function call (in this case, `Array.prototype.push`) can result in a "Maximum call stack size exceeded" error. But this is not a problem inside array literals.

I ran into this when running `bids-validator` on the command-line, on a relatively small dataset (~350 subjects, each with ~2 sessions, all sessions labeled with unique dates because no-one understands that part of the standard).

Before the fix:
```
1: [ERR] Internal error. SOME VALIDATION STEPS MAY NOT HAVE OCCURRED (code: 0 - INTERNAL ERROR)
		Evidence: RangeError: Maximum call stack size exceeded
    at missingSessionFiles (/home/mguaypaq/.local/share/node-v20.16.0-linux-x64/lib/node_modules/bids-validator/dist/commonjs/cli.js:136164:11)
    at /home/mguaypaq/.local/share/node-v20.16.0-linux-x64/lib/node_modules/bids-validator/dist/commonjs/cli.js:137078:42
```

The error disappeared when I applied this change directly in the compiled `cli.js` around line 136164.

There are a few other cases of the `push(...SomeIterable)` pattern elsewhere in the repo, but I'm not confident enough to touch them.