### PR TITLE
chore: Bump schema

### DIFF
--- a/bids-validator/deno.json
+++ b/bids-validator/deno.json
@@ -28,7 +28,7 @@
   },
   "imports": {
     "@ajv": "npm:ajv@8.16.0",
-    "@bids/schema": "jsr:@bids/schema@0.11.4-dev.7+790c0fbf",
+    "@bids/schema": "jsr:@bids/schema@0.11.4-dev.8+6e2874ce",
     "@cliffy/command": "jsr:@cliffy/command@1.0.0-rc.5",
     "@cliffy/table": "jsr:@cliffy/table@1.0.0-rc.5",
     "@hed/validator": "npm:hed-validator@3.15.5",


### PR DESCRIPTION
Should shut up about AcquisitionDuration on non-functional scans (counting ASL as functional).