### PR TITLE
fix(cli): Allow blacklisting any modality from schema.rules.modalities

### DIFF
--- a/bids-validator/src/setup/options.ts
+++ b/bids-validator/src/setup/options.ts
@@ -3,6 +3,7 @@ import type { LevelName } from '@std/log'
 import { Command, EnumType } from '@cliffy/command'
 import { getVersion } from '../version.ts'
 import type { Issue, Severity } from '../types/issues.ts'
+import { schema } from '@bids/schema'
 
 /**
  * BIDS Validator config file object definition
@@ -31,7 +32,7 @@ export type ValidatorOptions = {
 }
 
 const modalityType = new EnumType<string>(
-  ['MRI', 'PET', 'MEG', 'EEG', 'iEEG', 'Microscopy', 'NIRS', 'MRS'],
+  Object.keys(schema.rules.modalities)
 )
 
 /** Extendable Cliffy Command with built in BIDS validator options */

--- a/bids-validator/src/validators/bids.ts
+++ b/bids-validator/src/validators/bids.ts
@@ -18,6 +18,7 @@ import { type BIDSContext, BIDSContextDataset } from '../schema/context.ts'
 import type { parseOptions } from '../setup/options.ts'
 import { hedValidate } from './hed.ts'
 import { citationValidate } from './citation.ts'
+import { logger } from '../utils/logger.ts'
 
 /**
  * Ordering of checks to apply
@@ -121,8 +122,12 @@ export async function validate(
     // Map blacklisted datatypes back to the modality that generated them
     for (const modality of options.blacklistModalities) {
       const datatypes = modalitiesRule[modality.toLowerCase()]?.datatypes as string[]
-      for (const datatype of datatypes) {
-        blacklistedDatatypes.set(datatype, modality)
+      if (datatypes) {
+        for (const datatype of datatypes) {
+          blacklistedDatatypes.set(datatype, modality)
+        }
+      } else {
+        logger.warn(`Attempted to blacklist unknown modality: ${modality}`)
       }
     }
   }


### PR DESCRIPTION
Before:

```
  --blacklistModalities  <modalities...>  - Array of modalities to error on if detected.                                    (Default: [], Values: "MRI", "PET", "MEG", "EEG", "iEEG",
                                                                                                                            "Microscopy", "NIRS", "MRS")
```

After:

```
  --blacklistModalities  <modalities...>  - Array of modalities to error on if detected.                                    (Default: [], Values: "mri", "eeg", "ieeg", "meg", "beh",
                                                                                                                            "pet", "micr", "motion", "nirs", "mrs")
```

We previously used "Microscopy", but we looked up the value from `schema.rules.modalities`, so that would fail. We could map the display names, but I don't think it will hurt anybody to use `micr`. We also weren't supporting motion.

This won't help with patched schemas introducing new modalities, but blacklisting a modality introduced by a patch seems like an extremely niche use case. It would be nice if we could get the suggested values without actually limiting, as there's no harm in blacklisting something that doesn't exist. But the main use case would be OpenNeuro blacklisting a modality, and we skip over argument parsing and call `validate()` directly.

This PR adds a check so that tools calling via the API will warn, not crash, if passing an unknown modality.