### PR TITLE
fix: Export types for typescript library users

### DIFF
--- a/bids-validator/deno.json
+++ b/bids-validator/deno.json
@@ -6,7 +6,8 @@
     "./main": "./src/main.ts",
     "./output": "./src/utils/output.ts",
     "./files": "./src/files/deno.ts",
-    "./options": "./src/setup/options.ts"
+    "./options": "./src/setup/options.ts",
+    "./issues": "./src/issues/datasetIssues.ts"
   },
   "publish": {
     "exclude": [

--- a/bids-validator/src/files/deno.ts
+++ b/bids-validator/src/files/deno.ts
@@ -7,6 +7,7 @@ import { type BIDSFile, FileTree } from '../types/filetree.ts'
 import { requestReadPermission } from '../setup/requestPermissions.ts'
 import { FileIgnoreRules, readBidsIgnore } from './ignore.ts'
 import { logger } from '../utils/logger.ts'
+export { type BIDSFile, FileTree }
 
 /**
  * Thrown when a text file is decoded as UTF-8 but contains UTF-16 characters

--- a/bids-validator/src/issues/datasetIssues.ts
+++ b/bids-validator/src/issues/datasetIssues.ts
@@ -1,5 +1,6 @@
 import { nonSchemaIssues } from './list.ts'
-import type { Issue, Severity } from '../types/issues.ts'
+import type { Issue, Severity, IssueDefinition, IssueFile } from '../types/issues.ts'
+export type { Issue, Severity, IssueDefinition, IssueFile }
 
 // Code is deprecated, return something unusual but JSON serializable
 const CODE_DEPRECATED = Number.MIN_SAFE_INTEGER

--- a/bids-validator/src/main.ts
+++ b/bids-validator/src/main.ts
@@ -8,6 +8,7 @@ import { validate } from './validators/bids.ts'
 import { consoleFormat, resultToJSONStr } from './utils/output.ts'
 import { setupLogging } from './utils/logger.ts'
 import type { ValidationResult } from './types/validation-result.ts'
+export type { ValidationResult } from './types/validation-result.ts'
 
 /**
  * Validation entrypoint intended for command line usage with Deno


### PR DESCRIPTION
Exporting these types is useful for the OpenNeuro implementation to correctly type the validation input and outputs.