### PR TITLE
feat: Build help text based on console width

### DIFF
--- a/bids-validator/deno.json
+++ b/bids-validator/deno.json
@@ -29,8 +29,8 @@
   "imports": {
     "@ajv": "npm:ajv@8.16.0",
     "@bids/schema": "jsr:@bids/schema@0.11.4-dev.8+6e2874ce",
-    "@cliffy/command": "jsr:@cliffy/command@1.0.0-rc.5",
-    "@cliffy/table": "jsr:@cliffy/table@1.0.0-rc.5",
+    "@cliffy/command": "jsr:@effigies/cliffy-command@1.0.0-dev.8",
+    "@cliffy/table": "jsr:@effigies/cliffy-table@1.0.0-dev.5",
     "@hed/validator": "npm:hed-validator@3.15.5",
     "@ignore": "npm:ignore@5.3.2",
     "@libs/xml": "jsr:@libs/xml@5.4.13",


### PR DESCRIPTION
Closes bids-standard/bids-validator#11.

Just pushing to have the record here. Can merge and use a fork of cliffy or wait for https://github.com/c4spar/deno-cliffy/pull/761.


<details><summary>Before (regardless of terminal width):</summary>

```
❯ deno run -A jsr:@bids/validator --help

Usage:   bids-validator <dataset_directory>
Version: 1.14.13

Description:

  This tool checks if a dataset in a given directory is compatible with the Brain Imaging Data Structure specification. To learn more about
  Brain Imaging Data Structure visit http://bids.neuroimaging.io

Options:

  -h, --help                              - Show this help.
  -V, --version                           - Show the version number for this program.
  --json                                  - Output machine readable JSON
  -s, --schema           <URL-or-tag>     - Specify a schema version to use for validation
  -c, --config           <file>           - Path to a JSON configuration file
  -v, --verbose                           - Log more extensive information about issues
  --ignoreWarnings                        - Disregard non-critical issues
  --ignoreNiftiHeaders                    - Disregard NIfTI header content during validation
  --debug                <level>          - Enable debug output                                                             (Default: "ERROR", Values: "NOTSET", "DEBUG", "INFO",
                                                                                                                            "WARN", "ERROR", "CRITICAL")
  --filenameMode                          - Enable filename checks for newline separated filenames read from stdin
  --blacklistModalities  <modalities...>  - Array of modalities to error on if detected.                                    (Default: [], Values: "MRI", "PET", "MEG", "EEG", "iEEG",
                                                                                                                            "Microscopy", "NIRS", "MRS")
  -r, --recursive                         - Validate datasets found in derivatives directories in addition to root dataset
  -o, --outfile          <file>           - File to write validation results to.
  --color, --no-color    [color]          - Enable/disable color output (defaults to detected support)                      (Default: true)
```

</details>
<details><summary>After (88 columns)</summary>

```
❯ deno run -A ~/Projects/bids/bids-validator/bids-validator/src/bids-validator.ts --help

Usage:   bids-validator <dataset_directory>
Version: v1.14.15-dev.0-11-g8f3519b3

Description:

  This tool checks if a dataset in a given directory is compatible with the Brain
  Imaging Data Structure specification. To learn more about Brain Imaging Data
  Structure visit http://bids.neuroimaging.io

Options:

  -h, --help                              - Show this help.
  -V, --version                           - Show the version number
                                            for this program.
  --json                                  - Output machine readable
                                            JSON
  -s, --schema           <URL-or-tag>     - Specify a schema version
                                            to use for validation
  -c, --config           <file>           - Path to a JSON
                                            configuration file
  -v, --verbose                           - Log more extensive
                                            information about issues
  --ignoreWarnings                        - Disregard non-critical
                                            issues
  --ignoreNiftiHeaders                    - Disregard NIfTI header
                                            content during
                                            validation
  --debug                <level>          - Enable debug output       (Default:
                                                                      "ERROR", Values:
                                                                      "NOTSET",
                                                                      "DEBUG", "INFO",
                                                                      "WARN", "ERROR",
                                                                      "CRITICAL")
  --filenameMode                          - Enable filename checks
                                            for newline separated
                                            filenames read from
                                            stdin
  --blacklistModalities  <modalities...>  - Array of modalities to    (Default: [],
                                            error on if detected.     Values: "MRI",
                                                                      "PET", "MEG",
                                                                      "EEG", "iEEG",
                                                                      "Microscopy",
                                                                      "NIRS", "MRS")
  -r, --recursive                         - Validate datasets found
                                            in derivatives
                                            directories in addition
                                            to root dataset
  -o, --outfile          <file>           - File to write validation
                                            results to.
  --color, --no-color    [color]          - Enable/disable color      (Default: true)
                                            output (defaults to
                                            detected support)
```

</details>

<details><summary>142 columns</summary>

```
❯ deno run -A ~/Projects/bids/bids-validator/bids-validator/src/bids-validator.ts --help

Usage:   bids-validator <dataset_directory>
Version: v1.14.15-dev.0-11-g8f3519b3

Description:

  This tool checks if a dataset in a given directory is compatible with the Brain Imaging Data Structure specification. To learn more about
  Brain Imaging Data Structure visit http://bids.neuroimaging.io

Options:

  -h, --help                              - Show this help.
  -V, --version                           - Show the version number for this program.
  --json                                  - Output machine readable JSON
  -s, --schema           <URL-or-tag>     - Specify a schema version to use for validation
  -c, --config           <file>           - Path to a JSON configuration file
  -v, --verbose                           - Log more extensive information about issues
  --ignoreWarnings                        - Disregard non-critical issues
  --ignoreNiftiHeaders                    - Disregard NIfTI header content during validation
  --debug                <level>          - Enable debug output                                      (Default: "ERROR", Values: "NOTSET",
                                                                                                     "DEBUG", "INFO", "WARN", "ERROR",
                                                                                                     "CRITICAL")
  --filenameMode                          - Enable filename checks for newline separated filenames
                                            read from stdin
  --blacklistModalities  <modalities...>  - Array of modalities to error on if detected.             (Default: [], Values: "MRI", "PET",
                                                                                                     "MEG", "EEG", "iEEG", "Microscopy",
                                                                                                     "NIRS", "MRS")
  -r, --recursive                         - Validate datasets found in derivatives directories in
                                            addition to root dataset
  -o, --outfile          <file>           - File to write validation results to.
  --color, --no-color    [color]          - Enable/disable color output (defaults to detected        (Default: true)
                                            support)
```

</details>