### PR TITLE
fix: Use our fork of nifti-reader-js to fix console output bugs

### DIFF
--- a/bids-validator/deno.json
+++ b/bids-validator/deno.json
@@ -35,7 +35,7 @@
     "@hed/validator": "npm:hed-validator@3.15.5",
     "@ignore": "npm:ignore@5.3.2",
     "@libs/xml": "jsr:@libs/xml@5.4.13",
-    "@mango/nifti": "npm:nifti-reader-js@0.6.8",
+    "@mango/nifti": "npm:@bids/nifti-reader-js@0.6.9",
     "@std/assert": "jsr:@std/assert@1.0.2",
     "@std/fmt": "jsr:@std/fmt@1.0.0",
     "@std/fs": "jsr:@std/fs@1.0.1",

--- a/bids-validator/src/files/nifti.ts
+++ b/bids-validator/src/files/nifti.ts
@@ -27,22 +27,11 @@ async function extract(buffer: Uint8Array, nbytes: number): Promise<Uint8Array> 
   return result
 }
 
-function readHeaderQuiet(buf: ArrayBuffer) {
-  const console_error = console.error
-  const console_log = console.log
-  console.error = (msg: string) => { logger.info(msg)}
-  console.log = (msg: string) => { logger.info(msg)}
-  const header = readHeader(buf)
-  console.error = console_error
-  console.log = console_log
-  return header
-}
-
 export async function loadHeader(file: BIDSFile): Promise<NiftiHeader> {
   try {
     const buf = await file.readBytes(1024)
     const data = isCompressed(buf.buffer) ? await extract(buf, 540) : buf
-    const header = readHeaderQuiet(data.buffer)
+    const header = readHeader(data.buffer)
     if (!header) {
       throw { key: 'NIFTI_HEADER_UNREADABLE' }
     }


### PR DESCRIPTION
Fork is available at https://github.com/bids-standard/NIFTI-Reader-JS and I released 0.6.9 to include the console.log fixes that haven't landed in upstream.