### PR TITLE
Add banner to announce end of support for legacy validator

### DIFF
--- a/bids-validator-web/components/App.jsx
+++ b/bids-validator-web/components/App.jsx
@@ -98,6 +98,17 @@ export default class App extends React.Component {
           </div>
         </nav>
         <div className="container page-wrapper">
+          <div className="banner">
+            <strong>Notice:</strong> This version of the BIDS Validator is no
+            longer being developed. It is provided for historical reference
+            only.
+            <br />
+            Please visit{' '}
+            <a href="https://bids-standard.github.io/bids-validator/">
+              https://bids-standard.github.io/bids-validator/
+            </a>{' '}
+            for the latest version.
+          </div>
           <div className="validator">
             <Validate
               loading={this.state.status === 'validating'}

--- a/bids-validator-web/index.scss
+++ b/bids-validator-web/index.scss
@@ -27,6 +27,13 @@ form.options input {
   margin-right: 0.4rem;
 }
 
+.banner {
+  padding: 0.4rem 1rem;
+  margin-bottom: 1rem;
+  background-color: #F47174;
+  border-radius: 5px;
+}
+
 .validation-error {
   position: relative;
 }


### PR DESCRIPTION
<img width="1154" height="202" alt="image" src="https://github.com/user-attachments/assets/89798b2c-e15e-47f8-8b5e-97eb25885d0d" />

Closes #2192.